### PR TITLE
Small configure script enhancements

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -23,6 +23,7 @@
 #   -mpi              enable parallelization with MPI
 #   -omp              enable parallelization with OpenMP
 #   -hdf5             enable HDF5 output (requires the HDF5 library)
+#   --hdf5_path=path  path to HDF5 libraries (requires the HDF5 library)
 #   --ifov=N          enable N internal hydro output variables
 #---------------------------------------------------------------------------------------
 
@@ -141,6 +142,12 @@ parser.add_argument('-hdf5',
     action='store_true',
     default=False,
     help='enable HDF5 Output')
+
+# --hdf5_path argument
+parser.add_argument('--hdf5_path',
+    type=str,
+    default='',
+    help='path to HDF5 libraries')
 
 # -ifov=N argument
 parser.add_argument('--ifov',
@@ -346,6 +353,9 @@ else:
 # -hdf5 argument
 if args['hdf5']:
   definitions['HDF5_OPTION'] = 'HDF5OUTPUT'
+  if args['hdf5_path'] != '':
+    makefile_options['PREPROCESSOR_FLAGS'] += '-I%s/include' % args['hdf5_path']
+    makefile_options['LINKER_FLAGS'] += '-L%s/lib' % args['hdf5_path']
   if args['cxx'] == 'g++' or args['cxx'] == 'icc' or args['cxx'] == 'cray':
     makefile_options['LIBRARY_FLAGS'] += ' -lhdf5'
   if args['cxx'] == 'bgxl':
@@ -384,9 +394,9 @@ with open(makefile_input, 'r') as current_file:
   makefile_template = current_file.read()
 
 # Make substitutions
-for key,val in definitions.iteritems():
+for key,val in definitions.items():
   defsfile_template = re.sub(r'@{0}@'.format(key), val, defsfile_template)
-for key,val in makefile_options.iteritems():
+for key,val in makefile_options.items():
   makefile_template = re.sub(r'@{0}@'.format(key), val, makefile_template)
 
 # Write output files


### PR DESCRIPTION
This PR makes two small changes to the configure script:
1. Changes `.iteritems()` to `.items()` so that the script can be run with both Python 2 and Python 3. 
2. Allows the user to specify a path to the HDF5 library in case their system isn't one of the predefined ones that the script already knows about. If the new option is not specified, there is no change to the original behavior of the script. 

Example:

`python configure.py --prob cluster3d -mpi -hdf5 --hdf5_path /Users/jzuhone/miniconda`

where in this case `/Users/jzuhone/miniconda` is the path to the HDF5 library. 
