### PR TITLE
Adiabatic sound speed robustness improvement 

### DIFF
--- a/src/eos/adiabatic_hydro.cpp
+++ b/src/eos/adiabatic_hydro.cpp
@@ -140,5 +140,5 @@ void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
 
 Real EquationOfState::SoundSpeed(const Real prim[NHYDRO])
 {
-  return sqrt(gamma_*prim[IEN]/prim[IDN]);
+  return prim[IPR] > 0.0 ? sqrt(gamma_*prim[IPR]/prim[IDN]) : 0.0;
 }

--- a/src/eos/adiabatic_mhd.cpp
+++ b/src/eos/adiabatic_mhd.cpp
@@ -155,17 +155,12 @@ void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
 
 Real EquationOfState::SoundSpeed(const Real prim[NHYDRO])
 {
-  return sqrt(GetGamma()*prim[IEN]/prim[IDN]);
+  return prim[IPR] > 0.0 ? sqrt(gamma_*prim[IPR]/prim[IDN]) : 0.0;
 }
-
-//----------------------------------------------------------------------------------------
-// \!fn Real EquationOfState::FastMagnetosonicSpeed(const Real prim[], const Real bx)
-// \brief returns fast magnetosonic speed given vector of primitive variables
-// Note the formula for (C_f)^2 is positive definite, so this func never returns a NaN 
 
 Real EquationOfState::FastMagnetosonicSpeed(const Real prim[(NWAVE)], const Real bx)
 {
-  Real asq = GetGamma()*prim[IEN]/prim[IDN];
+  Real asq = prim[IPR] > 0.0 ? GetGamma()*prim[IPR]/prim[IDN] : 0.0;
   Real vaxsq = bx*bx/prim[IDN];
   Real ct2 = (prim[IBY]*prim[IBY] + prim[IBZ]*prim[IBZ])/prim[IDN];
   Real qsq = vaxsq + ct2 + asq;

--- a/src/hydro/rsolvers/hydro/hllc.cpp
+++ b/src/hydro/rsolvers/hydro/hllc.cpp
@@ -99,7 +99,7 @@ void Hydro::RiemannSolver(const int k,const int j, const int il, const int iu,
     Real mr = -(wri[IDN]*vxr);
 
     // Determine the contact wave speed...
-    Real am = (tl - tr)/(ml + mr);
+    Real am = (ml + mr) != 0.0 ? (tl - tr)/(ml + mr) : 0.0;
     // ...and the pressure at the contact surface
     Real cp = (ml*tr + mr*tl)/(ml + mr);
     cp = cp > 0.0 ? cp : 0.0;


### PR DESCRIPTION
The pull request is intended to ameliorate complications arising from the use of low-dissipation PPM limiters + the HLLC Riemann solver in strong shock tests. Unlike the current PLM implementation, non-negativity may not be guaranteed with higher order reconstructions, and the primitive variable floors will not prevent nonphysical negative pressures from being introduced in the flux calculation.

This PR ensures that: 
1. Nonrelativistic adiabatic Hydro and MHD `Real EquationOfState::SoundSpeed(const Real prim[NHYDRO])` will no longer return`NaN`. Also changed primitive variable array argument indexing of pressure from `IEN` to `IPR`
2. HLLC contact wave mode speed calculation will no longer divide by zero