### PR TITLE
Do not access de-allocated memory in SliceOutputData

### DIFF
--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -785,7 +785,7 @@ bool OutputType::SliceOutputData(MeshBlock *pmb, int dim)
     }
 
     ReplaceOutputDataNode(pdata,pnew);
-    pdata = pdata->pnext;
+    pdata = pnew->pnext;
   }
  
   // modify array indices


### PR DESCRIPTION
SliceOutputData is accessing a de-allocated object, which might result in an undefined behavior. This simple patch fixes this issue.