### PR TITLE
Fix directional symmetry violation by nonuniform PLM reconstruction

### DIFF
--- a/src/reconstruct/plm.cpp
+++ b/src/reconstruct/plm.cpp
@@ -125,23 +125,25 @@ void Reconstruction::PiecewiseLinearX3(Coordinates *pco, const int kl, const int
   Real dql,dqr,dqc,q_km1,q_k;
 
   for (int k=kl; k<=ku; ++k){
-    Real dx3km2i = 1.0/pco->dx3v(k-2);
-    Real dx3km1i = 1.0/pco->dx3v(k-1);
-    Real dx3ki   = 1.0/pco->dx3v(k);
+    Real dx3_km2 = pco->dx3v(k-2);
+    Real dx3_km1 = pco->dx3v(k-1);
+    Real dx3_k   = pco->dx3v(k);
     Real dxfr=pco->x3f(k)-pco->x3v(k-1);
     Real dxfl=pco->x3v(k)-pco->x3f(k);
-    Real cfm=pco->dx3v(k-1)/dxfr;
-    Real cbm=pco->dx3v(k-2)/(pco->x3v(k-1)-pco->x3f(k-1));
-    Real cfp=pco->dx3v(k)/(pco->x3f(k+1)-pco->x3v(k));
-    Real cbp=pco->dx3v(k-1)/dxfl;
+    Real dxfrp=pco->x3f(k+1)-pco->x3v(k);
+    Real dxflm=pco->x3v(k-1)-pco->x3f(k-1);
+    Real cfm=dx3_km1/dxfr;
+    Real cbm=dx3_km2/dxflm;
+    Real cfp=dx3_k/dxfrp;
+    Real cbp=dx3_km1/dxfl;
     for (int j=jl; j<=ju; ++j){
 #pragma simd
     for (int i=il; i<=iu; ++i){
       q_km1 = q(nin,k-1,j,i);
       q_k   = q(nin,k  ,j,i);
-      dql = (q(nin,k-1,j,i) - q(nin,k-2,j,i))*dx3km2i;
-      dqc = (q(nin,k  ,j,i) - q(nin,k-1,j,i))*dx3km1i;
-      dqr = (q(nin,k+1,j,i) - q(nin,k  ,j,i))*dx3ki;
+      dql = (q(nin,k-1,j,i) - q(nin,k-2,j,i))/dx3_km2;
+      dqc = (q(nin,k  ,j,i) - q(nin,k-1,j,i))/dx3_km1;
+      dqr = (q(nin,k+1,j,i) - q(nin,k  ,j,i))/dx3_k;
 
       // compute ql_(k-1/2) using Mignone 2014's modified van-Leer limiter
       Real dq2 = dql*dqc;


### PR DESCRIPTION
**Summary**

The order of floating point operations for the nonuniform version of the `Reconstruction::PiecewiseLinearX1()` limiter is slightly different from the order used in `Reconstruction::PiecewiseLinearX2(), Reconstruction::PiecewiseLinearX3()`. This is responsible for a small directional asymmetry that can be observed in the 2D Liska-Wendroff implosion test with a uniform Cartesian mesh that grows immediately from `cycle=0`.

**Detailed explanation**

The underlying issue can be partially explained by the way that the volumetric cell spacings `dx1v, dx2v, dx3v` are derived from the exact face spacings `dx1f, dx2f, dx3f`. The `dx*v` quantities contain errors larger than double precision machine epsilon, even for a uniform Cartesian mesh. For example, the spacings and their inverses in `plm.cpp` for a nx1=nx2=32 mesh are (to 17 digits):
```
dx_im2 =9.37500000000002220e-03
dx_im1 =9.37499999999996669e-03
dx_i   =9.37500000000002220e-03

dx2jm2i =1.0666666666666641e+02
dx2jm1i =1.0666666666666704e+02
dx2ji   =1.0666666666666641e+02
```

Normally for a square mesh with equal domain limits, these errors would propagate identically in each grid direction and symmetry would be maintained in the implosion problem. However, the small errors are sensitive to the differences in the `PLMx*()` orders of operation. In `PLMx1()`, the mesh spacings directly divide the stencil differences of primitives, e.g.:
```c++
Real& dx_im2 = pco->dx1v(i-2);
dql = (q(nin,k,j,i-1) - q(nin,k,j,i-2))/dx_im2;
```
However, for the `x2, x3` versions, the inverses of the mesh spacings are precomputed and stored, e.g.:
```c++
Real dx2jm2i = 1.0/pco->dx2v(j-2);
dql = (q(nin,k,j-1,i) - q(nin,k,j-2,i))*dx2jm2i;
```
Storing the inverse incurs additional error due to the rounding step, and it amplifies the error in the volumetric spacings. In this case, the difference in the resulting velocity reconstructions is about `2e-15`:
```
v_x = -3.2376325564866005e-02
v_y = -3.2376325564866026e-02
```
(The asymmetry might have appeared for some problems/mesh sizes even if `dx1v=dx2v=dx1f=dx2f` were all exactly equal everywhere on the mesh, due to the inherent greater loss of precision in a reciprocal calculation and multiplication vs. a division.)

**Fix**

This PR simply duplicates the `Reconstruction::PiecewiseLinearX1()` sequence of operations for the `x2, x3` versions. 

More substantial changes to ameliorate the round-off error in the volumetric spacings are being considered for the future.
