### PR TITLE
Fix self-gravity energy source term

### DIFF
--- a/src/hydro/srcterms/self_gravity.cpp
+++ b/src/hydro/srcterms/self_gravity.cpp
@@ -40,7 +40,7 @@ void HydroSourceTerms::SelfGravity(const Real dt,const AthenaArray<Real> *flux,
           phil = 0.5*(pgrav->phi(k,j,i-1)+pgrav->phi(k,j,i  ));
           phir = 0.5*(pgrav->phi(k,j,i  )+pgrav->phi(k,j,i+1));
           // Update momenta and energy with d/dx1 terms
-          cons(IEN,k,j,i) -= 0.5*dtodx1*(flux[X1DIR](IDN,k,j,i  )*(phic - phil) + 
+          cons(IEN,k,j,i) -= dtodx1*(flux[X1DIR](IDN,k,j,i  )*(phic - phil) + 
                                          flux[X1DIR](IDN,k,j,i+1)*(phir - phic));
         }
       }
@@ -59,7 +59,7 @@ void HydroSourceTerms::SelfGravity(const Real dt,const AthenaArray<Real> *flux,
             phic = pgrav->phi(k,j,i);
             phil = 0.5*(pgrav->phi(k,j-1,i)+pgrav->phi(k,j  ,i));
             phir = 0.5*(pgrav->phi(k,j  ,i)+pgrav->phi(k,j+1,i));
-            cons(IEN,k,j,i) -= 0.5*dtodx2*(flux[X2DIR](IDN,k,j  ,i)*(phic - phil) + 
+            cons(IEN,k,j,i) -= dtodx2*(flux[X2DIR](IDN,k,j  ,i)*(phic - phil) + 
                                            flux[X2DIR](IDN,k,j+1,i)*(phir - phic));
           }
         }
@@ -79,7 +79,7 @@ void HydroSourceTerms::SelfGravity(const Real dt,const AthenaArray<Real> *flux,
             phic = pgrav->phi(k,j,i);
             phil = 0.5*(pgrav->phi(k-1,j,i)+pgrav->phi(k  ,j,i));
             phir = 0.5*(pgrav->phi(k  ,j,i)+pgrav->phi(k+1,j,i));
-            cons(IEN,k,j,i) -= 0.5*dtodx3*(flux[X3DIR](IDN,k  ,j,i)*(phic - phil) + 
+            cons(IEN,k,j,i) -= dtodx3*(flux[X3DIR](IDN,k  ,j,i)*(phic - phil) + 
                                            flux[X3DIR](IDN,k+1,j,i)*(phir - phic));
           }
         }


### PR DESCRIPTION
Correction to energy source term for self-gravity.  An extra factor of 0.5 led to errors in maintaining equilibrium of 1D Spitzer sheets and 3D polytropic equilibrium.  

Note: This bug did not affect isothermal hydrodynamics with self-gravity.  After this fix, the jeans_3D test still passes.  

More details on the bug and equilibrium/advection tests are given in attached pdf.  

Patrick Mullen
University of Illinois
[athena_selfgravity_bug.pdf](https://github.com/PrincetonUniversity/athena/files/1753280/athena_selfgravity_bug.pdf)
