### PR TITLE
Fix to self-gravity FFT and MG Solve

### DIFF
--- a/src/gravity/fftgravity.cpp
+++ b/src/gravity/fftgravity.cpp
@@ -71,8 +71,7 @@ void FFTGravityDriver::Solve(int step, int mode)
   for(int igid=nbs;igid<=nbe;igid++){
     MeshBlock *pmb=pmy_mesh_->FindMeshBlock(igid);
     if(pmb!=NULL) {
-      if(step == 1) in.InitWithShallowSlice(pmb->phydro->u,4,IDN,1);
-      else if(step == 2) in.InitWithShallowSlice(pmb->phydro->u1,4,IDN,1);
+      in.InitWithShallowSlice(pmb->phydro->u,4,IDN,1);
       pfb->LoadSource(in, 1, NGHOST, pmb->loc, pmb->block_size);
     }
 //    else { // on another process

--- a/src/gravity/mggravity.cpp
+++ b/src/gravity/mggravity.cpp
@@ -97,8 +97,7 @@ void MGGravityDriver::Solve(int step)
   while(pmggrav!=NULL) {
     MeshBlock *pmb=pmy_mesh_->FindMeshBlock(pmggrav->gid_);
     if(pmb!=NULL) {
-      if(step==1) in.InitWithShallowCopy(pmb->phydro->u);
-      else if(step==2) in.InitWithShallowCopy(pmb->phydro->u1);
+      in.InitWithShallowCopy(pmb->phydro->u);
       pmggrav->LoadSource(in, IDN, NGHOST, four_pi_G_);
       if(mode_>=2) // iterative mode - load initial guess
         pmggrav->LoadFinestData(pmb->pgrav->phi, 0, NGHOST);


### PR DESCRIPTION
I have been running convergence tests for advected 1D self-gravitating sheets (Spitzer sheets) and noticed that they unexpectedly converged as N^-1.  I am not confident in the time-stepping algorithm yet, however, I believe that when working inside `FFTGravityDriver::Solve` and `MGGravityDriver::Solve` we should always pass the conserved quantity array `u` no matter which step we are on (i.e., we should never pass `u1`, c.f. `AddHydroSourceTerms` in the time integrator task list, we only pass `u` no matter which step).  Can anybody with more experience with the time-stepping routine confirm this? 

After making the suggested edits, the advected 1D self-gravitating sheets converge to second-order with rk2 and vl2 (see attached).  Further, this edit allows for us to use higher-order integrators without segmentation faults.  

Finally, the Jeans3D test still passes, and the reported output errors are now 30% of their prior values.  
[convergenceFinal.pdf](https://github.com/PrincetonUniversity/athena/files/1799123/convergenceFinal.pdf)


