### PR TITLE
Revert "Revert "Fix general asymmetry of x1f, dx1v Coordinates terms; ensure exact float64 symmetry of PPM stencils""

### DIFF
--- a/src/athena.hpp
+++ b/src/athena.hpp
@@ -11,6 +11,7 @@
 #include "defs.hpp"
 #include "athena_arrays.hpp"
 #include <math.h>
+#include <stdint.h>  // int64_t
 
 // typedefs that allow code to run with either floats or doubles
 #if SINGLE_PRECISION_ENABLED
@@ -36,7 +37,7 @@ struct RegionSize;
 //  \brief stores logical location and level of meshblock
 
 typedef struct LogicalLocation {
-  long int lx1, lx2, lx3;
+  int64_t lx1, lx2, lx3;
   int level;
 
   LogicalLocation() : lx1(-1), lx2(-1), lx3(-1), level(-1) {}

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -308,8 +308,8 @@ BoundaryValues::BoundaryValues(MeshBlock *pmb, enum BoundaryFlag *input_bcs, Par
     x2size_ = pmy_mesh->mesh_size.x2max - pmy_mesh->mesh_size.x2min;
     x3size_ = pmy_mesh->mesh_size.x3max - pmy_mesh->mesh_size.x3min;
     int level = pmb->loc.level - pmy_mesh->root_level;
-    long int nrbx1 = pmy_mesh->nrbx1*(1L << level);
-    long int nrbx2 = pmy_mesh->nrbx2*(1L << level);
+    int64_t nrbx1 = pmy_mesh->nrbx1*(1L << level);
+    int64_t nrbx2 = pmy_mesh->nrbx2*(1L << level);
 
     shbb_.outer = false;
     shbb_.inner = false;
@@ -563,7 +563,7 @@ BoundaryValues::~BoundaryValues()
 
   if (SHEARING_BOX) {
     int level = pmb->loc.level - pmb->pmy_mesh->root_level;
-    long int nrbx1 = pmb->pmy_mesh->nrbx1*(1L << level);
+    int64_t nrbx1 = pmb->pmy_mesh->nrbx1*(1L << level);
     if (pmb->loc.lx1 == 0) { // if true for shearing inner blocks
       shboxvar_inner_hydro_.DeleteAthenaArray();
       flx_inner_hydro_.DeleteAthenaArray();
@@ -810,9 +810,9 @@ void BoundaryValues::Initialize(void)
   cng2=cng*f2d;
   cng3=cng*f3d;
   int ssize, rsize;
-  long int &lx1=pmb->loc.lx1;
-  long int &lx2=pmb->loc.lx2;
-  long int &lx3=pmb->loc.lx3;
+  int64_t &lx1=pmb->loc.lx1;
+  int64_t &lx2=pmb->loc.lx2;
+  int64_t &lx3=pmb->loc.lx3;
   int &mylevel=pmb->loc.level;
   myox1=((int)(lx1&1L));
   myox2=((int)(lx2&1L));
@@ -1125,8 +1125,8 @@ void BoundaryValues::Initialize(void)
   if (SHEARING_BOX) {
     Mesh *pmesh = pmb->pmy_mesh;
     int level = pmb->loc.level - pmesh->root_level;
-    long int nrbx1 = pmesh->nrbx1*(1L << level);
-    long int nrbx2 = pmesh->nrbx2*(1L << level);
+    int64_t nrbx1 = pmesh->nrbx1*(1L << level);
+    int64_t nrbx2 = pmesh->nrbx2*(1L << level);
     int nbtotal = pmesh->nbtotal;
     int *ranklist = pmesh->ranklist;
     int *nslist = pmesh->nslist;
@@ -1565,9 +1565,9 @@ void BoundaryValues::ProlongateBoundaries(AthenaArray<Real> &pdst,
 {
   MeshBlock *pmb=pmy_block_;
   MeshRefinement *pmr=pmb->pmr;
-  long int &lx1=pmb->loc.lx1;
-  long int &lx2=pmb->loc.lx2;
-  long int &lx3=pmb->loc.lx3;
+  int64_t &lx1=pmb->loc.lx1;
+  int64_t &lx2=pmb->loc.lx2;
+  int64_t &lx3=pmb->loc.lx3;
   int &mylevel=pmb->loc.level;
 
   for (int n=0; n<nneighbor; n++) {

--- a/src/bvals/bvals_base.cpp
+++ b/src/bvals/bvals_base.cpp
@@ -283,7 +283,7 @@ void BoundaryBase::SearchAndSetNeighbors(MeshBlockTree &tree, int *ranklist, int
   myox1=((int)(loc.lx1&1L))*2-1;
   if(block_size_.nx2>1) myox2=((int)(loc.lx2&1L))*2-1;
   if(block_size_.nx3>1) myox3=((int)(loc.lx3&1L))*2-1;
-  long int nrbx1=pmy_mesh_->nrbx1, nrbx2=pmy_mesh_->nrbx2, nrbx3=pmy_mesh_->nrbx3;
+  int64_t nrbx1=pmy_mesh_->nrbx1, nrbx2=pmy_mesh_->nrbx2, nrbx3=pmy_mesh_->nrbx3;
 
   int nf1=1, nf2=1;
   if(pmy_mesh_->multilevel==true) {

--- a/src/bvals/bvals_cc.cpp
+++ b/src/bvals/bvals_cc.cpp
@@ -228,7 +228,7 @@ void BoundaryValues::SetCellCenteredBoundarySameLevel(AthenaArray<Real> &dst,
       if(ShBoxCoord_==2){
         Mesh *pmy_mesh = pmb->pmy_mesh;
         int level = pmb->loc.level - pmy_mesh->root_level;
-        long int nrbx1 = pmy_mesh->nrbx1*(1L << level);
+        int64_t nrbx1 = pmy_mesh->nrbx1*(1L << level);
         Real qomL = qshear_*Omega_0_*x1size_;
         if ((pmb->loc.lx1==0) && (nb.ox1<0)){
           for (int k=sk;k<=ek;++k) {

--- a/src/bvals/bvals_shear.cpp
+++ b/src/bvals/bvals_shear.cpp
@@ -462,7 +462,7 @@ void BoundaryValues::FindShearBlock(const Real time)
   int ku, ii,jj;
 
   int level = pmb->loc.level-pmesh->root_level;
-  long int nrbx2 = pmesh->nrbx2*(1L<<level);
+  int64_t nrbx2 = pmesh->nrbx2*(1L<<level);
   int nx2   = pmb->block_size.nx2; // # of cells per meshblock
   int nx3   = pmb->block_size.nx3; // # of cells per meshblock
   int ncells2 = pmb->block_size.nx2 + 2*NGHOST;

--- a/src/coordinates/cartesian.cpp
+++ b/src/coordinates/cartesian.cpp
@@ -63,7 +63,13 @@ Cartesian::Cartesian(MeshBlock *pmb, ParameterInput *pin, bool flag)
     x1v(i) = 0.5*(x1f(i+1) + x1f(i));
   }
   for (int i=il-ng; i<=iu+ng-1; ++i) {
-    dx1v(i) = x1v(i+1) - x1v(i);
+    if (pmb->block_size.x1rat != 1.0) {
+      dx1v(i) = x1v(i+1) - x1v(i);
+    }
+    else {
+      // dx1v = dx1f constant for uniform mesh; may disagree with x1v(i+1) - x1v(i)
+      dx1v(i) = dx1f(i);
+    }
   }
 
   // x2-direction: x2v = dy/2
@@ -75,7 +81,13 @@ Cartesian::Cartesian(MeshBlock *pmb, ParameterInput *pin, bool flag)
       x2v(j) = 0.5*(x2f(j+1) + x2f(j));
     }
     for (int j=jl-ng; j<=ju+ng-1; ++j) {
-      dx2v(j) = x2v(j+1) - x2v(j);
+      if (pmb->block_size.x2rat != 1.0) {
+        dx2v(j) = x2v(j+1) - x2v(j);
+      }
+      else {
+        // dx2v = dx2f constant for uniform mesh; may disagree with x2v(j+1) - x2v(j)
+        dx2v(j) = dx2f(j);
+      }
     }
   }
 
@@ -88,7 +100,13 @@ Cartesian::Cartesian(MeshBlock *pmb, ParameterInput *pin, bool flag)
       x3v(k) = 0.5*(x3f(k+1) + x3f(k));
     }
     for (int k=kl-ng; k<=ku+ng-1; ++k) {
-      dx3v(k) = x3v(k+1) - x3v(k);
+      if (pmb->block_size.x3rat != 1.0) {
+        dx3v(k) = x3v(k+1) - x3v(k);
+      }
+      else {
+        // dxkv = dx3f constant for uniform mesh; may disagree with x3v(k+1) - x3v(k)
+        dx3v(k) = dx3f(k);
+      }
     }
   }
 

--- a/src/fft/athena_fft.cpp
+++ b/src/fft/athena_fft.cpp
@@ -106,26 +106,26 @@ void FFTBlock::PrintSource(int in)
   for (int k=0; k<Nx[2]; ++k) {
     for (int j=0; j<Nx[1]; ++j) {
       for (int i=0; i<Nx[0]; ++i) {
-        long int idx=GetIndex(i,j,k,f_in_);
-        if (in == 1) std::cout << in_[idx][0] << " ";
-        if (in == -1) std::cout << out_[idx][0] << " ";
+        int64_t idx=GetIndex(i,j,k,f_in_);
+        if(in == 1) std::cout << in_[idx][0] << " ";
+        if(in == -1) std::cout << out_[idx][0] << " ";
       }
       std::cout << std::endl;
     }
     std::cout << std::endl;
   }
 }
-long int FFTBlock::GetIndex(const int i, const int j, const int k)
+int64_t FFTBlock::GetIndex(const int i, const int j, const int k)
 {
   return i + nx[0] * ( j + nx[1] * k);
 }
 
-long int FFTBlock::GetGlobalIndex(const int i, const int j, const int k)
+int64_t FFTBlock::GetGlobalIndex(const int i, const int j, const int k)
 {
   return i + disp[0] + Nx[0]* ( j + disp[1] + Nx[1]* ( k + disp[2]) );
 }
 
-long int FFTBlock::GetIndex(const int i, const int j, const int k, AthenaFFTIndex *pidx)
+int64_t FFTBlock::GetIndex(const int i, const int j, const int k, AthenaFFTIndex *pidx)
 {
   int old_idx[3]={i,j,k};
   int new_idx[3];
@@ -150,12 +150,12 @@ void FFTBlock::RetrieveResult(AthenaArray<Real> &dst, int ns, int ngh, LogicalLo
   int jl=bsize.nx2>1?ngh:0;
   int kl=bsize.nx3>1?ngh:0;
 
-  for (int n=0; n<ns; n++) {
-    for (int k=kl, mk=ks; mk<=ke; k++, mk++) {
-      for (int j=jl, mj=js; mj<=je; j++, mj++) {
-        for (int i=ngh, mi=is; mi<=ie; i++, mi++) {
-          long int idx=GetIndex(mi,mj,mk,b_out_);
-          if (ns == 1) {
+  for(int n=0; n<ns; n++) {
+    for(int k=kl, mk=ks; mk<=ke; k++, mk++) {
+      for(int j=jl, mj=js; mj<=je; j++, mj++) {
+        for(int i=ngh, mi=is; mi<=ie; i++, mi++){
+          int64_t idx=GetIndex(mi,mj,mk,b_out_);
+          if(ns == 1){
             dst(k,j,i)=src[idx][0]*norm_factor_;
           } else {
             dst(n,k,j,i)=src[idx][n]*norm_factor_;
@@ -181,12 +181,12 @@ void FFTBlock::LoadSource(const AthenaArray<Real> &src, int ns, int ngh, Logical
   int jl=bsize.nx2>1?ngh:0;
   int kl=bsize.nx3>1?ngh:0;
 
-  for (int n=0; n<ns; n++) {
-    for (int k=kl, mk=ks; mk<=ke; k++, mk++) {
-      for (int j=jl, mj=js; mj<=je; j++, mj++) {
-        for (int i=ngh, mi=is; mi<=ie; i++, mi++) {
-          long int idx=GetIndex(mi,mj,mk,f_in_);
-          if (ns == 1) {
+  for(int n=0; n<ns; n++) {
+    for(int k=kl, mk=ks; mk<=ke; k++, mk++) {
+      for(int j=jl, mj=js; mj<=je; j++, mj++) {
+        for(int i=ngh, mi=is; mi<=ie; i++, mi++) {
+          int64_t idx=GetIndex(mi,mj,mk,f_in_);
+          if(ns == 1){
             dst[idx][0]=src(n,k,j,i);
             dst[idx][1]=0.0;
           } else {
@@ -204,11 +204,11 @@ void FFTBlock::LoadSource(const AthenaArray<Real> &src, int ns, int ngh, Logical
 //  \brief Apply kernel
 void FFTBlock::ApplyKernel(int mode)
 {
-  for (int k=0; k<knx[2]; k++) {
-    for (int j=0; j<knx[1]; j++) {
-      for (int i=0; i<knx[0]; i++) {
-        long int idx_in=GetIndex(i,j,k,b_in_);
-        long int idx_out=GetIndex(i,j,k,f_out_);
+  for(int k=0; k<knx[2]; k++) {
+    for(int j=0; j<knx[1]; j++) {
+      for(int i=0; i<knx[0]; i++) {
+        int64_t idx_in=GetIndex(i,j,k,b_in_);
+        int64_t idx_out=GetIndex(i,j,k,f_out_);
         in_[idx_in][0] = out_[idx_out][0];
         in_[idx_in][1] = out_[idx_out][1];
       }

--- a/src/fft/athena_fft.hpp
+++ b/src/fft/athena_fft.hpp
@@ -109,10 +109,10 @@ public:
                       LogicalLocation loc, RegionSize bsize);
   virtual void ApplyKernel(int mode);
 
-  long int GetIndex(const int i, const int j, const int k);
-  long int GetIndex(const int i, const int j, const int k, AthenaFFTIndex *pidx);
+  int64_t GetIndex(const int i, const int j, const int k);
+  int64_t GetIndex(const int i, const int j, const int k, AthenaFFTIndex *pidx);
 
-  long int GetGlobalIndex(const int i, const int j, const int k);
+  int64_t GetGlobalIndex(const int i, const int j, const int k);
 
   void DestroyPlan(AthenaFFTPlan *plan);
   void MpiInitialize();
@@ -147,7 +147,7 @@ public:
   friend class Mesh;
 
 protected:
-  long int cnt_,gcnt_;
+  int64_t cnt_,gcnt_;
   int gid_;
   FFTDriver *pmy_driver_;
   AthenaFFTComplex *in_, *out_;
@@ -186,7 +186,7 @@ public:
   friend class Mesh;
 
 protected:
-  long int gcnt_;
+  int64_t gcnt_;
   int nranks_, nblocks_;
   int *ranklist_, *nslist_, *nblist_;
   Mesh *pmy_mesh_;

--- a/src/fft/fft_driver.cpp
+++ b/src/fft/fft_driver.cpp
@@ -66,17 +66,17 @@ FFTDriver::FFTDriver(Mesh *pm, ParameterInput *pin)
   int ns = nslist_[Globals::my_rank];
   int ne = ns+nblist_[Globals::my_rank];
 
-  long int &lx1min = pm->loclist[ns].lx1;
-  long int &lx2min = pm->loclist[ns].lx2;
-  long int &lx3min = pm->loclist[ns].lx3;
-  long int lx1max = lx1min;
-  long int lx2max = lx2min;
-  long int lx3max = lx3min;
+  int64_t &lx1min = pm->loclist[ns].lx1;
+  int64_t &lx2min = pm->loclist[ns].lx2;
+  int64_t &lx3min = pm->loclist[ns].lx3;
+  int64_t lx1max = lx1min;
+  int64_t lx2max = lx2min;
+  int64_t lx3max = lx3min;
 
   for(int n=ns; n<ne; n++){
-    long int &lx1 = pm->loclist[n].lx1;
-    long int &lx2 = pm->loclist[n].lx2;
-    long int &lx3 = pm->loclist[n].lx3;
+    int64_t &lx1 = pm->loclist[n].lx1;
+    int64_t &lx2 = pm->loclist[n].lx2;
+    int64_t &lx3 = pm->loclist[n].lx3;
     lx1min = lx1min<lx1?lx1min:lx1;
     lx2min = lx2min<lx2?lx2min:lx2;
     lx3min = lx3min<lx3?lx3min:lx3;

--- a/src/fft/turbulence.cpp
+++ b/src/fft/turbulence.cpp
@@ -172,6 +172,7 @@ void TurbulenceDriver::PowerSpectrum(AthenaFFTComplex *amp){
         Real kmag = std::sqrt(kx*kx+ky*ky+kz*kz);
 
         int64_t gidx = pfb->GetGlobalIndex(i,j,k);
+
         if (gidx == 0) {
           pcoeff = 0.0;
         } else {

--- a/src/gravity/fftgravity.cpp
+++ b/src/gravity/fftgravity.cpp
@@ -110,7 +110,7 @@ void FFTGravity::ApplyKernel(int mode)
   for(int k=0; k<knx[2]; k++) {
     for(int j=0; j<knx[1]; j++) {
       for(int i=0; i<knx[0]; i++) {
-        long int gidx = GetGlobalIndex(i,j,k);
+        int64_t gidx = GetGlobalIndex(i,j,k);
         if(gidx == 0){ pcoeff = 0.0;}
         else {
           Real kx=(i+kdisp[0]);
@@ -137,8 +137,8 @@ void FFTGravity::ApplyKernel(int mode)
           pcoeff = 1.0/pcoeff;
         }
 
-        long int idx_in=GetIndex(i,j,k,b_in_);
-        long int idx_out=GetIndex(i,j,k,f_out_);
+        int64_t idx_in=GetIndex(i,j,k,b_in_);
+        int64_t idx_out=GetIndex(i,j,k,f_out_);
         in_[idx_in][0] = out_[idx_out][0]*pcoeff;
         in_[idx_in][1] = out_[idx_out][1]*pcoeff;
       }

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -316,8 +316,8 @@ Mesh::Mesh(ParameterInput *pin, int mesh_test)
         }
         // find the logical range in the ref_level
         // note: if this is too slow, this should be replaced with bi-section search.
-        long int lx1min=0, lx1max=0, lx2min=0, lx2max=0, lx3min=0, lx3max=0;
-        long int lxmax=nrbx1*(1L<<ref_lev);
+        int64_t lx1min=0, lx1max=0, lx2min=0, lx2max=0, lx3min=0, lx3max=0;
+        int64_t lxmax=nrbx1*(1L<<ref_lev);
         for(lx1min=0;lx1min<lxmax;lx1min++) {
           if(MeshGenerator_[X1DIR]((Real)(lx1min+1)/lxmax,mesh_size)>ref_size.x1min)
             break;
@@ -356,7 +356,7 @@ Mesh::Mesh(ParameterInput *pin, int mesh_test)
         }
         // create the finest level
         if(dim==1) {
-          for(long int i=lx1min; i<lx1max; i+=2) {
+          for(int64_t i=lx1min; i<lx1max; i+=2) {
             LogicalLocation nloc;
             nloc.level=lrlev, nloc.lx1=i, nloc.lx2=0, nloc.lx3=0;
             int nnew;
@@ -364,8 +364,8 @@ Mesh::Mesh(ParameterInput *pin, int mesh_test)
           }
         }
         if(dim==2) {
-          for(long int j=lx2min; j<lx2max; j+=2) {
-            for(long int i=lx1min; i<lx1max; i+=2) {
+          for(int64_t j=lx2min; j<lx2max; j+=2) {
+            for(int64_t i=lx1min; i<lx1max; i+=2) {
               LogicalLocation nloc;
               nloc.level=lrlev, nloc.lx1=i, nloc.lx2=j, nloc.lx3=0;
               int nnew;
@@ -374,9 +374,9 @@ Mesh::Mesh(ParameterInput *pin, int mesh_test)
           }
         }
         if(dim==3) {
-          for(long int k=lx3min; k<lx3max; k+=2) {
-            for(long int j=lx2min; j<lx2max; j+=2) {
-              for(long int i=lx1min; i<lx1max; i+=2) {
+          for(int64_t k=lx3min; k<lx3max; k+=2) {
+            for(int64_t j=lx2min; j<lx2max; j+=2) {
+              for(int64_t i=lx1min; i<lx1max; i+=2) {
                 LogicalLocation nloc;
                 nloc.level=lrlev, nloc.lx1=i, nloc.lx2=j, nloc.lx3=k;
                 int nnew;
@@ -909,15 +909,15 @@ void Mesh::OutputMeshStructure(int dim)
     for (int j=0; j<nbtotal; j++) {
       if(loclist[j].level==i) {
         SetBlockSizeAndBoundaries(loclist[j], block_size, block_bcs);
-        long int &lx1=loclist[j].lx1;
-        long int &lx2=loclist[j].lx2;
-        long int &lx3=loclist[j].lx3;
+        int64_t &lx1=loclist[j].lx1;
+        int64_t &lx2=loclist[j].lx2;
+        int64_t &lx3=loclist[j].lx3;
         int &ll=loclist[j].level;
         mincost=std::min(mincost,costlist[i]);
         maxcost=std::max(maxcost,costlist[i]);
         totalcost+=costlist[i];
         fprintf(fp,"#MeshBlock %d on rank=%d with cost=%g\n",j,ranklist[j],costlist[j]);
-        fprintf(fp,"#  Logical level %d, location = (%ld %ld %ld)\n",ll,lx1,lx2,lx3);
+        fprintf(fp,"#  Logical level %d, location = (%lld %lld %lld)\n",ll,lx1,lx2,lx3);
         if(dim==2) {
           fprintf(fp, "%g %g\n", block_size.x1min, block_size.x2min);
           fprintf(fp, "%g %g\n", block_size.x1max, block_size.x2min);
@@ -1453,9 +1453,9 @@ void Mesh::LoadBalance(Real *clist, int *rlist, int *slist, int *nlist, int nb)
 void Mesh::SetBlockSizeAndBoundaries(LogicalLocation loc, RegionSize &block_size,
                                      enum BoundaryFlag *block_bcs)
 {
-  long int &lx1=loc.lx1;
-  long int &lx2=loc.lx2;
-  long int &lx3=loc.lx3;
+  int64_t &lx1=loc.lx1;
+  int64_t &lx2=loc.lx2;
+  int64_t &lx3=loc.lx3;
   int &ll=loc.level;
   // calculate physical block size, x1
   if(lx1==0) {
@@ -1626,9 +1626,9 @@ void Mesh::AdaptiveMeshRefinement(ParameterInput *pin)
     for(int n=0; n<tnderef; n++) {
       if((lderef[n].lx1&1L)==0 && (lderef[n].lx2&1L)==0 && (lderef[n].lx3&1L)==0) {
         int r=n, rr=0;
-        for(long int k=0;k<=lk;k++) {
-          for(long int j=0;j<=lj;j++) {
-            for(long int i=0;i<=1;i++) {
+        for(int64_t k=0;k<=lk;k++) {
+          for(int64_t j=0;j<=lj;j++) {
+            for(int64_t i=0;i<=1;i++) {
               if((lderef[n].lx1+i)==lderef[r].lx1
               && (lderef[n].lx2+j)==lderef[r].lx2
               && (lderef[n].lx3+k)==lderef[r].lx3

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -203,7 +203,7 @@ private:
   int *nref, *nderef, *bnref, *bnderef, *rdisp, *brdisp, *ddisp, *bddisp;
   LogicalLocation *loclist;
   MeshBlockTree tree;
-  long int nrbx1, nrbx2, nrbx3;
+  int64_t nrbx1, nrbx2, nrbx3;
   bool use_meshgen_fn_[3]; // flag to use non-uniform or user meshgen function
   int nreal_user_mesh_data_, nint_user_mesh_data_;
 
@@ -240,18 +240,18 @@ private:
   void EnrollUserHistoryOutput(int i, HistoryOutputFunc_t my_func, const char *name);
   void EnrollUserMetric(MetricFunc_t my_func);
   void EnrollUserMGBoundaryFunction(enum BoundaryFace dir, MGBoundaryFunc_t my_bc);
-  void EnrollUserGravityBoundaryFunction(enum BoundaryFace dir, GravityBoundaryFunc_t my_bc);
-  void SetGravitationalConstant(Real g) { four_pi_G_=4.0*PI*g; };
-  void SetFourPiG(Real fpg) { four_pi_G_=fpg; };
-  void SetGravityThreshold(Real eps) { grav_eps_=eps; };
+  void EnrollUserGravityBoundaryFunction(enum BoundaryFace dir,
+                                         GravityBoundaryFunc_t my_bc);
+  void SetGravitationalConstant(Real g) { four_pi_G_=4.0*PI*g; }
+  void SetFourPiG(Real fpg) { four_pi_G_=fpg; }
+  void SetGravityThreshold(Real eps) { grav_eps_=eps; }
 };
 
 //----------------------------------------------------------------------------------------
 // \!fn Real DefaultMeshGeneratorX1(Real x, RegionSize rs)
 // \brief x1 mesh generator function, x is the logical location; x=i/nx1
 
-inline Real DefaultMeshGeneratorX1(Real x, RegionSize rs)
-{
+inline Real DefaultMeshGeneratorX1(Real x, RegionSize rs) {
   Real lw, rw;
   if(rs.x1rat==1.0) {
     rw=x, lw=1.0-x;
@@ -268,8 +268,7 @@ inline Real DefaultMeshGeneratorX1(Real x, RegionSize rs)
 // \!fn Real DefaultMeshGeneratorX2(Real x, RegionSize rs)
 // \brief x2 mesh generator function, x is the logical location; x=j/nx2
 
-inline Real DefaultMeshGeneratorX2(Real x, RegionSize rs)
-{
+inline Real DefaultMeshGeneratorX2(Real x, RegionSize rs) {
   Real lw, rw;
   if(rs.x2rat==1.0) {
     rw=x, lw=1.0-x;
@@ -286,8 +285,7 @@ inline Real DefaultMeshGeneratorX2(Real x, RegionSize rs)
 // \!fn Real DefaultMeshGeneratorX3(Real x, RegionSize rs)
 // \brief x3 mesh generator function, x is the logical location; x=k/nx3
 
-inline Real DefaultMeshGeneratorX3(Real x, RegionSize rs)
-{
+inline Real DefaultMeshGeneratorX3(Real x, RegionSize rs) {
   Real lw, rw;
   if(rs.x3rat==1.0) {
     rw=x, lw=1.0-x;
@@ -298,6 +296,30 @@ inline Real DefaultMeshGeneratorX3(Real x, RegionSize rs)
     rw=1.0-lw;
   }
   return rs.x3min*lw+rs.x3max*rw;
+}
+
+//----------------------------------------------------------------------------------------
+// \!fn Real UniformMeshGeneratorX1(Real x, RegionSize rs)
+// \brief x1 mesh generator function, x is the logical location; real cells in [-0.5, 0.5]
+
+inline Real UniformMeshGeneratorX1(Real x, RegionSize rs) {
+  return ((Real) 0.5-x)*rs.x1min + ((Real) 0.5+x)*rs.x1max;
+}
+
+//----------------------------------------------------------------------------------------
+// \!fn Real UniformMeshGeneratorX2(Real x, RegionSize rs)
+// \brief x2 mesh generator function, x is the logical location; real cells in [-0.5, 0.5]
+
+inline Real UniformMeshGeneratorX2(Real x, RegionSize rs) {
+  return ((Real) 0.5-x)*rs.x2min + ((Real) 0.5+x)*rs.x2max;
+}
+
+//----------------------------------------------------------------------------------------
+// \!fn Real UniformMeshGeneratorX3(Real x, RegionSize rs)
+// \brief x3 mesh generator function, x is the logical location; real cells in [-0.5, 0.5]
+
+inline Real UniformMeshGeneratorX3(Real x, RegionSize rs) {
+  return ((Real) 0.5-x)*rs.x3min + ((Real) 0.5+x)*rs.x3max;
 }
 
 #endif  // MESH_HPP

--- a/src/mesh/meshblock_tree.cpp
+++ b/src/mesh/meshblock_tree.cpp
@@ -81,10 +81,10 @@ MeshBlockTree::~MeshBlockTree()
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn void MeshBlockTree::CreateRootGrid(long int nx,long int ny, long int nz, int nl)
+//! \fn void MeshBlockTree::CreateRootGrid(int64_t nx,int64_t ny, int64_t nz, int nl)
 //  \brief create the root grid; the root grid can be incomplete (less than 8 leaves)
 
-void MeshBlockTree::CreateRootGrid(long int nx, long int ny, long int nz, int nl)
+void MeshBlockTree::CreateRootGrid(int64_t nx, int64_t ny, int64_t nz, int nl)
 {
   if (loc.level == nl) return;
 
@@ -109,12 +109,12 @@ void MeshBlockTree::CreateRootGrid(long int nx, long int ny, long int nz, int nl
 
 //----------------------------------------------------------------------------------------
 //! \fn void MeshBlockTree::AddMeshBlock(MeshBlockTree& root, LogicalLocation rloc,
-//   int dim, enum BoundaryFlag* mesh_bcs, long int rbx, long int rby, long int rbz,
+//   int dim, enum BoundaryFlag* mesh_bcs, int64_t rbx, int64_t rby, int64_t rbz,
 //   int rl, int &nnew)
 //  \brief add a MeshBlock to the tree, also creates neighboring blocks
 
 void MeshBlockTree::AddMeshBlock(MeshBlockTree& root, LogicalLocation rloc, int dim,
-   enum BoundaryFlag* mesh_bcs, long int rbx, long int rby, long int rbz,
+   enum BoundaryFlag* mesh_bcs, int64_t rbx, int64_t rby, int64_t rbz,
    int rl, int &nnew)
 {
   int mx, my, mz;
@@ -134,11 +134,11 @@ void MeshBlockTree::AddMeshBlock(MeshBlockTree& root, LogicalLocation rloc, int 
 
 //----------------------------------------------------------------------------------------
 //! \fn void MeshBlockTree::AddMeshBlockWithoutRefine(LogicalLocation rloc,
-//                          long int rbx, long int rby, long int rbz, int rl)
+//                          int64_t rbx, int64_t rby, int64_t rbz, int rl)
 //  \brief add a MeshBlock to the tree without refinement, used in restarting
 
 void MeshBlockTree::AddMeshBlockWithoutRefine(LogicalLocation rloc,
-                    long int rbx, long int rby, long int rbz, int rl)
+                    int64_t rbx, int64_t rby, int64_t rbz, int rl)
 {
   int mx, my, mz;
   if(loc.level==rloc.level) // done
@@ -158,16 +158,16 @@ void MeshBlockTree::AddMeshBlockWithoutRefine(LogicalLocation rloc,
 
 //----------------------------------------------------------------------------------------
 //! \fn void MeshBlockTree::Refine(MeshBlockTree& root, int dim,
-//           enum BoundaryFlag* mesh_bcs, long int rbx, long int rby, long int rbz,
+//           enum BoundaryFlag* mesh_bcs, int64_t rbx, int64_t rby, int64_t rbz,
 //           int rl, int &nnew)
 //  \brief make finer leaves
 
 void MeshBlockTree::Refine(MeshBlockTree& root, int dim, enum BoundaryFlag* mesh_bcs,
-                    long int rbx, long int rby, long int rbz, int rl, int &nnew)
+                    int64_t rbx, int64_t rby, int64_t rbz, int rl, int &nnew)
 {
   if(flag==false) return;
-  long int nxmax,nymax,nzmax;
-  long int ox, oy, oz, oxmin, oxmax, oymin, oymax, ozmin, ozmax;
+  int64_t nxmax,nymax,nzmax;
+  int64_t ox, oy, oz, oxmin, oxmax, oymin, oymax, ozmin, ozmax;
   int xmax,ymax,zmax;
   LogicalLocation nloc;
   nloc.level=loc.level;
@@ -242,12 +242,12 @@ void MeshBlockTree::Refine(MeshBlockTree& root, int dim, enum BoundaryFlag* mesh
 
 //----------------------------------------------------------------------------------------
 //! \fn void MeshBlockTree::Derefine(MeshBlockTree& root, int dim,
-//                                   enum BoundaryFlag* mesh_bcs, long int rbx,
-//                                   long int rby, long int rbz, int rl, int &ndel)
+//                                   enum BoundaryFlag* mesh_bcs, int64_t rbx,
+//                                   int64_t rby, int64_t rbz, int rl, int &ndel)
 //  \brief destroy leaves and make this block a leaf
 
 void MeshBlockTree::Derefine(MeshBlockTree& root, int dim, enum BoundaryFlag* mesh_bcs,
-                    long int rbx, long int rby, long int rbz, int rl, int &ndel)
+                    int64_t rbx, int64_t rby, int64_t rbz, int rl, int &ndel)
 {
   int s2=0, e2=0, s3=0, e3=0;
   if(dim>=2) s2=-1, e2=1;
@@ -356,18 +356,18 @@ void MeshBlockTree::GetMeshBlockList(LogicalLocation *list, int *pglist, int& co
 //----------------------------------------------------------------------------------------
 //! \fn MeshBlockTree* MeshBlockTree::FindNeighbor(LogicalLocation myloc, int ox1,
 //                                    int ox2, int ox3, enum BoundaryFlag* bcs,
-//                                    long int rbx, long int rby, long int rbz, int rl)
+//                                    int64_t rbx, int64_t rby, int64_t rbz, int rl)
 //  \brief find a neighboring block, called from the root of the tree
 //         If it is coarser or same level, return the pointer to that block.
 //         If it is a finer block, return the pointer to its parent.
 //         Note that this function must be called on a completed tree only
 
 MeshBlockTree* MeshBlockTree::FindNeighbor(LogicalLocation myloc, int ox1, int ox2,
-  int ox3, enum BoundaryFlag* bcs, long int rbx, long int rby, long int rbz,
+  int ox3, enum BoundaryFlag* bcs, int64_t rbx, int64_t rby, int64_t rbz,
   int rl, bool amrflag)
 {
   std::stringstream msg;
-  long int lx, ly, lz;
+  int64_t lx, ly, lz;
   int ll;
   int ox, oy, oz;
   MeshBlockTree *bt = this;
@@ -402,7 +402,7 @@ MeshBlockTree* MeshBlockTree::FindNeighbor(LogicalLocation myloc, int ox1, int o
     }
     else return NULL;
   }
-  long int num_x3 = rbz<<(ll-rl);
+  int64_t num_x3 = rbz<<(ll-rl);
   if(lz<0) {
     if(bcs[INNER_X3]==PERIODIC_BNDRY) lz=num_x3-1;
     else return NULL;

--- a/src/mesh/meshblock_tree.hpp
+++ b/src/mesh/meshblock_tree.hpp
@@ -33,21 +33,21 @@ public:
   MeshBlockTree* GetLeaf(int ox, int oy, int oz) {return pleaf[oz][oy][ox];}
 
   // functions
-  void CreateRootGrid(long int nx, long int ny, long int nz, int nl);
+  void CreateRootGrid(int64_t nx, int64_t ny, int64_t nz, int nl);
   void AddMeshBlock(MeshBlockTree& root, LogicalLocation rloc, int dim,
-       enum BoundaryFlag* mesh_bcs, long int rbx, long int rby, long int rbz,
+       enum BoundaryFlag* mesh_bcs, int64_t rbx, int64_t rby, int64_t rbz,
        int rl, int &nnew);
   void AddMeshBlockWithoutRefine(LogicalLocation rloc, 
-                                 long int rbx, long int rby, long int rbz, int rl);
+                                 int64_t rbx, int64_t rby, int64_t rbz, int rl);
   void Refine(MeshBlockTree& root, int dim, enum BoundaryFlag* mesh_bcs,
-              long int rbx, long int rby, long int rbz, int rl, int &nnew);
+              int64_t rbx, int64_t rby, int64_t rbz, int rl, int &nnew);
   void Derefine(MeshBlockTree& root, int dim, enum BoundaryFlag* mesh_bcs,
-              long int rbx, long int rby, long int rbz, int rl, int &ndel);
+              int64_t rbx, int64_t rby, int64_t rbz, int rl, int &ndel);
   MeshBlockTree* FindMeshBlock(LogicalLocation tloc);
   void CountMeshBlock(int& count);
   void GetMeshBlockList(LogicalLocation *list, int *pglist, int& count);
   MeshBlockTree* FindNeighbor(LogicalLocation myloc, int ox1, int ox2, int ox3,
-                 enum BoundaryFlag* bcs, long int rbx, long int rby, long int rbz,
+                 enum BoundaryFlag* bcs, int64_t rbx, int64_t rby, int64_t rbz,
                  int rl, bool amrflag=false);
 
 private:

--- a/src/outputs/athena_hdf5.cpp
+++ b/src/outputs/athena_hdf5.cpp
@@ -71,7 +71,7 @@ void ATHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
 
   int num_blocks_local;                       // number of MeshBlocks on this Mesh
   int *levels_mesh;                           // array of refinement levels on Mesh
-  long int *locations_mesh;                   // array of logical locations on Mesh
+  int64_t *locations_mesh;                   // array of logical locations on Mesh
   float *x1f_mesh;                            // array of x1 values on Mesh
   float *x2f_mesh;                            // array of x2 values on Mesh
   float *x3f_mesh;                            // array of x3 values on Mesh
@@ -238,7 +238,7 @@ void ATHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
 
   // Allocate contiguous buffers for data in memory
   levels_mesh = new int[num_blocks_local];
-  locations_mesh = new long int[num_blocks_local * 3];
+  locations_mesh = new int64_t[num_blocks_local * 3];
   x1f_mesh = new float[num_blocks_local * (nx1+1)];
   x2f_mesh = new float[num_blocks_local * (nx2+1)];
   x3f_mesh = new float[num_blocks_local * (nx3+1)];

--- a/src/outputs/io_wrapper.hpp
+++ b/src/outputs/io_wrapper.hpp
@@ -18,7 +18,7 @@ typedef MPI_File IOWrapperFile;
 typedef FILE * IOWrapperFile;
 #endif
 
-typedef long int IOWrapperSize_t;
+typedef int64_t IOWrapperSize_t;
 enum rwmode {IO_WRAPPER_READ_MODE, IO_WRAPPER_WRITE_MODE};
 
 class IOWrapper

--- a/src/pgen/hb3.cpp
+++ b/src/pgen/hb3.cpp
@@ -138,7 +138,7 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin)
   Real kz = (2.0*PI/x2size)*((double)nwy);
 
   Real x1,x2,x3,rd,rp,rval, rvx, rvy, rvz;
-  long int iseed = -1-gid; // Initialize on the first call to ran2
+  int64_t iseed = -1-gid; // Initialize on the first call to ran2
 // Initialize perturbations
 //   ipert = 1 - isentropic perturbations to P & d [default]
 //   ipert = 2 - uniform Vx=amp, sinusoidal density

--- a/src/pgen/hgb.cpp
+++ b/src/pgen/hgb.cpp
@@ -127,7 +127,7 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin)
     B0 = sqrt((double)(2.0*pres/beta));
 
 // Ensure a different initial random seed for each meshblock.
-  long int iseed = -1 - gid;
+  int64_t iseed = -1 - gid;
 
 // Initialize boxsize
   Lx = pmy_mesh->mesh_size.x1max - pmy_mesh->mesh_size.x1min;

--- a/src/pgen/kh.cpp
+++ b/src/pgen/kh.cpp
@@ -53,7 +53,7 @@ void Mesh::InitUserMeshData(ParameterInput *pin)
 
 void MeshBlock::ProblemGenerator(ParameterInput *pin)
 {
-  long int iseed = -1 - gid;
+  int64_t iseed = -1 - gid;
   Real gm1 = peos->GetGamma() - 1.0;
 
   // Read problem parameters

--- a/src/pgen/rt.cpp
+++ b/src/pgen/rt.cpp
@@ -84,7 +84,7 @@ void Mesh::InitUserMeshData(ParameterInput *pin)
 
 void MeshBlock::ProblemGenerator(ParameterInput *pin)
 {
-  long int iseed = -1;
+  int64_t iseed = -1;
   Real gamma = peos->GetGamma();
   Real gm1 = gamma - 1.0;
   

--- a/src/pgen/strat.cpp
+++ b/src/pgen/strat.cpp
@@ -132,7 +132,7 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin)
   Real kz = (2.0*PI/Lz)*((double)nwz);
 
   // Ensure a different initial random seed for each meshblock.
-  long int iseed = -1 - gid;
+  int64_t iseed = -1 - gid;
 
   // adiabatic gamma
   Real gam = peos->GetGamma();

--- a/src/pgen/turb.cpp
+++ b/src/pgen/turb.cpp
@@ -31,7 +31,7 @@
 #endif
 
 
-long int rseed; // seed for turbulence power spectrum
+int64_t rseed; // seed for turbulence power spectrum
 
 //========================================================================================
 //! \fn void Mesh::InitUserMeshData(ParameterInput *pin)

--- a/src/reconstruct/ppm.cpp
+++ b/src/reconstruct/ppm.cpp
@@ -142,10 +142,11 @@ void Reconstruction::PiecewiseParabolicX1(MeshBlock *pmb,
       }
       // Approximate interface average at i-1/2 and i+1/2 using PPM (CW eq 1.6)
       for (int i=il-1; i<=iu; ++i) {
-        dph(i)= prec->c3i(i)*q_im1(n,i) + prec->c4i(i)*q(n,i) +
-                prec->c5i(i)*dd_im1(i) + prec->c6i(i)*dd(i);
-        dph_ip1(i)= prec->c3i(i+1)*q(n,i) + prec->c4i(i+1)*q_ip1(n,i) +
-                    prec->c5i(i+1)*dd(i) + prec->c6i(i+1)*dd_ip1(i);
+        // KGF: group the biased stencil quantities to preserve FP symmetry
+        dph(i)= (prec->c3i(i)*q_im1(n,i) + prec->c4i(i)*q(n,i)) +
+            (prec->c5i(i)*dd_im1(i) + prec->c6i(i)*dd(i));
+        dph_ip1(i)= (prec->c3i(i+1)*q(n,i) + prec->c4i(i+1)*q_ip1(n,i)) +
+            (prec->c5i(i+1)*dd(i) + prec->c6i(i+1)*dd_ip1(i) );
       }
 
 //--- Step 2a. ---------------------------------------------------------------------------
@@ -154,9 +155,10 @@ void Reconstruction::PiecewiseParabolicX1(MeshBlock *pmb,
         // approximate second derivative at interfaces for smooth extrema preservation
 #pragma omp simd
         for (int i=il-1; i<=iu+1; ++i) {
-          d2qc_im1(i) = q_im2(n,i) - 2.0*q_im1(n,i) + q    (n,i);
-          d2qc    (i) = q_im1(n,i) - 2.0*q    (n,i) + q_ip1(n,i); //(CD eq 85a) (no 1/2)
-          d2qc_ip1(i) = q    (n,i) - 2.0*q_ip1(n,i) + q_ip2(n,i);
+          // KGF: add the off-centered quantities first to preserve FP symmetry
+          d2qc_im1(i) = q_im2(n,i) + q    (n,i) - 2.0*q_im1(n,i);
+          d2qc    (i) = q_im1(n,i) + q_ip1(n,i) - 2.0*q    (n,i); //(CD eq 85a) (no 1/2)
+          d2qc_ip1(i) = q    (n,i) + q_ip2(n,i) - 2.0*q_ip1(n,i);
         }
 
         // i-1/2
@@ -165,7 +167,8 @@ void Reconstruction::PiecewiseParabolicX1(MeshBlock *pmb,
           Real qa = dph(i) - q_im1(n,i); // (CD eq 84a)
           Real qb = q(n,i) - dph(i);     // (CD eq 84b)
           if (qa*qb < 0.0) { // Local extrema detected at i-1/2 face
-            qa = 3.0*(q_im1(n,i) - 2.0*dph(i) + q(n,i));  // (CD eq 85b)
+            // KGF: add the off-centered quantities first to preserve FP symmetry
+            qa = 3.0*(q_im1(n,i) + q(n,i)  - 2.0*dph(i));  // (CD eq 85b)
             qb = d2qc_im1(i);    // (CD eq 85a) (no 1/2)
             Real qc = d2qc(i);   // (CD eq 85c) (no 1/2)
             Real qd = 0.0;
@@ -181,7 +184,8 @@ void Reconstruction::PiecewiseParabolicX1(MeshBlock *pmb,
           Real qa = dph_ip1(i) - q(n,i);       // (CD eq 84a)
           Real qb = q_ip1(n,i) - dph_ip1(i);   // (CD eq 84b)
           if (qa*qb < 0.0) { // Local extrema detected at i+1/2 face
-            qa = 3.0*(q(n,i) - 2.0*dph_ip1(i) + q_ip1(n,i));  // (CD eq 85b)
+            // KGF: add the off-centered quantities first to preserve FP symmetry
+            qa = 3.0*(q(n,i) + q_ip1(n,i) - 2.0*dph_ip1(i));  // (CD eq 85b)
             qb = d2qc(i);            // (CD eq 85a) (no 1/2)
             Real qc = d2qc_ip1(i);   // (CD eq 85c) (no 1/2)
             Real qd = 0.0;
@@ -194,7 +198,8 @@ void Reconstruction::PiecewiseParabolicX1(MeshBlock *pmb,
 
 #pragma omp simd
         for (int i=il-1; i<=iu; ++i) {
-          d2qf(i) = 6.0*(dph(i) - 2.0*q(n,i) + dph_ip1(i)); // a6 coefficient * -2
+          // KGF: add the off-centered quantities first to preserve FP symmetry
+          d2qf(i) = 6.0*(dph(i) + dph_ip1(i) - 2.0*q(n,i)); // a6 coefficient * -2
         }
 
 //--- Step 2b. ---------------------------------------------------------------------------
@@ -439,10 +444,11 @@ void Reconstruction::PiecewiseParabolicX2(MeshBlock *pmb,
       }
       // Approximate interface average at j-1/2 and j+1/2 using PPM (CW eq 1.6)
       for (int i=il; i<=iu; ++i) {
-        dph(i)= prec->c3j(j)*q_jm1(n,i) + prec->c4j(j)*q(n,i) +
-                prec->c5j(j)*dd_jm1(i) + prec->c6j(j)*dd(i);
-        dph_jp1(i)= prec->c3j(j+1)*q(n,i) + prec->c4j(j+1)*q_jp1(n,i) +
-                    prec->c5j(j+1)*dd(i) + prec->c6j(j+1)*dd_jp1(i);
+        // KGF: group the biased stencil quantities to preserve FP symmetry
+        dph(i)= (prec->c3j(j)*q_jm1(n,i) + prec->c4j(j)*q(n,i)) +
+            (prec->c5j(j)*dd_jm1(i) + prec->c6j(j)*dd(i));
+        dph_jp1(i)= (prec->c3j(j+1)*q(n,i) + prec->c4j(j+1)*q_jp1(n,i)) +
+            (prec->c5j(j+1)*dd(i) + prec->c6j(j+1)*dd_jp1(i));
       }
 
 //--- Step 2a. ---------------------------------------------------------------------------
@@ -451,9 +457,10 @@ void Reconstruction::PiecewiseParabolicX2(MeshBlock *pmb,
         // approximate second derivative at interfaces for smooth extrema preservation
 #pragma omp simd
         for (int i=il; i<=iu; ++i) {
-          d2qc_jm1(i) = q_jm2(n,i) - 2.0*q_jm1(n,i) + q    (n,i);
-          d2qc    (i) = q_jm1(n,i) - 2.0*q    (n,i) + q_jp1(n,i); //(CD eq 85a) (no 1/2)
-          d2qc_jp1(i) = q    (n,i) - 2.0*q_jp1(n,i) + q_jp2(n,i);
+          // KGF: add the off-centered quantities first to preserve FP symmetry
+          d2qc_jm1(i) = q_jm2(n,i) + q    (n,i) - 2.0*q_jm1(n,i);
+          d2qc    (i) = q_jm1(n,i) + q_jp1(n,i) - 2.0*q    (n,i); //(CD eq 85a) (no 1/2)
+          d2qc_jp1(i) = q    (n,i) + q_jp2(n,i) - 2.0*q_jp1(n,i);
         }
 
         // j-1/2
@@ -462,7 +469,8 @@ void Reconstruction::PiecewiseParabolicX2(MeshBlock *pmb,
           Real qa = dph(i) - q_jm1(n,i); // (CD eq 84a)
           Real qb = q(n,i) - dph(i);     // (CD eq 84b)
           if (qa*qb < 0.0) { // Local extrema detected at j-1/2 face
-            qa = 3.0*(q_jm1(n,i) - 2.0*dph(i) + q(n,i));  // (CD eq 85b)
+            // KGF: add the off-centered quantities first to preserve FP symmetry
+            qa = 3.0*(q_jm1(n,i) + q(n,i) - 2.0*dph(i));  // (CD eq 85b)
             qb = d2qc_jm1(i);    // (CD eq 85a) (no 1/2)
             Real qc = d2qc(i);   // (CD eq 85c) (no 1/2)
             Real qd = 0.0;
@@ -478,7 +486,8 @@ void Reconstruction::PiecewiseParabolicX2(MeshBlock *pmb,
           Real qa = dph_jp1(i) - q(n,i);       // (CD eq 84a)
           Real qb = q_jp1(n,i) - dph_jp1(i);   // (CD eq 84b)
           if (qa*qb < 0.0) { // Local extrema detected at j+1/2 face
-            qa = 3.0*(q(n,i) - 2.0*dph_jp1(i) + q_jp1(n,i));  // (CD eq 85b)
+            // KGF: add the off-centered quantities first to preserve FP symmetry
+            qa = 3.0*(q(n,i) + q_jp1(n,i)  - 2.0*dph_jp1(i));  // (CD eq 85b)
             qb = d2qc(i);            // (CD eq 85a) (no 1/2)
             Real qc = d2qc_jp1(i);   // (CD eq 85c) (no 1/2)
             Real qd = 0.0;
@@ -491,7 +500,8 @@ void Reconstruction::PiecewiseParabolicX2(MeshBlock *pmb,
 
 #pragma omp simd
         for (int i=il; i<=iu; ++i) {
-          d2qf(i) = 6.0*(dph(i) - 2.0*q(n,i) + dph_jp1(i)); // a6 coefficient * -2
+          // KGF: add the off-centered quantities first to preserve FP symmetry
+          d2qf(i) = 6.0*(dph(i) + dph_jp1(i) - 2.0*q(n,i)); // a6 coefficient * -2
         }
 
 //--- Step 2b. ---------------------------------------------------------------------------
@@ -736,10 +746,11 @@ void Reconstruction::PiecewiseParabolicX3(MeshBlock *pmb,
       }
       // Approximate interface average at k-1/2 and k+1/2 using PPM (CW eq 1.6)
       for (int i=il; i<=iu; ++i) {
-        dph(i)= prec->c3k(k)*q_km1(n,i) + prec->c4k(k)*q(n,i) +
-                prec->c5k(k)*dd_km1(i) + prec->c6k(k)*dd(i);
-        dph_kp1(i)= prec->c3k(k+1)*q(n,i) + prec->c4k(k+1)*q_kp1(n,i) +
-                    prec->c5k(k+1)*dd(i) + prec->c6k(k+1)*dd_kp1(i);
+        // KGF: group the biased stencil quantities to preserve FP symmetry
+        dph(i)= (prec->c3k(k)*q_km1(n,i) + prec->c4k(k)*q(n,i)) +
+            (prec->c5k(k)*dd_km1(i) + prec->c6k(k)*dd(i));
+        dph_kp1(i)= (prec->c3k(k+1)*q(n,i) + prec->c4k(k+1)*q_kp1(n,i)) +
+            (prec->c5k(k+1)*dd(i) + prec->c6k(k+1)*dd_kp1(i));
       }
 
 //--- Step 2a. ---------------------------------------------------------------------------
@@ -748,9 +759,10 @@ void Reconstruction::PiecewiseParabolicX3(MeshBlock *pmb,
         // approximate second derivative at interfaces for smooth extrema preservation
 #pragma omp simd
         for (int i=il; i<=iu; ++i) {
-          d2qc_km1(i) = q_km2(n,i) - 2.0*q_km1(n,i) + q    (n,i);
-          d2qc    (i) = q_km1(n,i) - 2.0*q    (n,i) + q_kp1(n,i); //(CD eq 85a) (no 1/2)
-          d2qc_kp1(i) = q    (n,i) - 2.0*q_kp1(n,i) + q_kp2(n,i);
+          // KGF: add the off-centered quantities first to preserve FP symmetry
+          d2qc_km1(i) = q_km2(n,i) + q    (n,i) - 2.0*q_km1(n,i) ;
+          d2qc    (i) = q_km1(n,i) + q_kp1(n,i) - 2.0*q    (n,i) ; //(CD eq 85a) (no 1/2)
+          d2qc_kp1(i) = q    (n,i) + q_kp2(n,i) - 2.0*q_kp1(n,i) ;
         }
 
         // k-1/2
@@ -759,7 +771,8 @@ void Reconstruction::PiecewiseParabolicX3(MeshBlock *pmb,
           Real qa = dph(i) - q_km1(n,i); // (CD eq 84a)
           Real qb = q(n,i) - dph(i);     // (CD eq 84b)
           if (qa*qb < 0.0) { // Local extrema detected at k-1/2 face
-            qa = 3.0*(q_km1(n,i) - 2.0*dph(i) + q(n,i));  // (CD eq 85b)
+            // KGF: add the off-centered quantities first to preserve FP symmetry
+            qa = 3.0*(q_km1(n,i) + q(n,i) - 2.0*dph(i));  // (CD eq 85b)
             qb = d2qc_km1(i);    // (CD eq 85a) (no 1/2)
             Real qc = d2qc(i);   // (CD eq 85c) (no 1/2)
             Real qd = 0.0;
@@ -775,7 +788,8 @@ void Reconstruction::PiecewiseParabolicX3(MeshBlock *pmb,
           Real qa = dph_kp1(i) - q(n,i);       // (CD eq 84a)
           Real qb = q_kp1(n,i) - dph_kp1(i);   // (CD eq 84b)
           if (qa*qb < 0.0) { // Local extrema detected at k+1/2 face
-            qa = 3.0*(q(n,i) - 2.0*dph_kp1(i) + q_kp1(n,i));  // (CD eq 85b)
+            // KGF: add the off-centered quantities first to preserve FP symmetry
+            qa = 3.0*(q(n,i) + q_kp1(n,i) - 2.0*dph_kp1(i));  // (CD eq 85b)
             qb = d2qc(i);            // (CD eq 85a) (no 1/2)
             Real qc = d2qc_kp1(i);   // (CD eq 85c) (no 1/2)
             Real qd = 0.0;
@@ -788,7 +802,8 @@ void Reconstruction::PiecewiseParabolicX3(MeshBlock *pmb,
 
 #pragma omp simd
         for (int i=il; i<=iu; ++i) {
-          d2qf(i) = 6.0*(dph(i) - 2.0*q(n,i) + dph_kp1(i)); // a6 coefficient * -2
+          // KGF: add the off-centered quantities first to preserve FP symmetry
+          d2qf(i) = 6.0*(dph(i) + dph_kp1(i) - 2.0*q(n,i)); // a6 coefficient * -2
         }
 
 //--- Step 2b. ---------------------------------------------------------------------------


### PR DESCRIPTION
Found the bug in `mesh_symmetry` branch. Reverts PrincetonUniversity/athena#99