### PR TITLE
Use simple average when computing cell-centered B 

### DIFF
--- a/src/field/field.cpp
+++ b/src/field/field.cpp
@@ -121,6 +121,12 @@ Field::~Field() {
 
 void Field::CalculateCellCenteredField(const FaceField &bf, AthenaArray<Real> &bc,
             Coordinates *pco, int is, int ie, int js, int je, int ks, int ke) {
+  // Defer to Reconstruction class to check if uniform Cartesian formula can be used
+  // (unweighted average)
+  const bool uniform_ave_x1 = pmy_block->precon->uniform_limiter[0];
+  const bool uniform_ave_x2 = pmy_block->precon->uniform_limiter[1];
+  const bool uniform_ave_x3 = pmy_block->precon->uniform_limiter[2];
+
   for (int k=ks; k<=ke; ++k) {
     for (int j=js; j<=je; ++j) {
     // calc cell centered fields first
@@ -139,8 +145,7 @@ void Field::CalculateCellCenteredField(const FaceField &bf, AthenaArray<Real> &b
         Real lw, rw; // linear interpolation coefficients from lower and upper cell faces
 
         // cell center B-fields are defined as spatial interpolation at the volume center
-        // Defer to Reconstruction class to check if uniform Cartesian formula can be used
-        if (pmy_block->precon->uniform_limiter[0] == true) {
+        if (uniform_ave_x1 == true) {
           lw = 0.5;
           rw = 0.5;
         } else {
@@ -153,7 +158,7 @@ void Field::CalculateCellCenteredField(const FaceField &bf, AthenaArray<Real> &b
         }
         bcc1 = lw*b1_i + rw*b1_ip1;
 
-        if (pmy_block->precon->uniform_limiter[1] == true) {
+        if (uniform_ave_x2 == true) {
           lw = 0.5;
           rw = 0.5;
         } else {
@@ -165,7 +170,7 @@ void Field::CalculateCellCenteredField(const FaceField &bf, AthenaArray<Real> &b
           rw = (x2v_j  - x2f_j)/dx2_j;
         }
         bcc2 = lw*b2_j + rw*b2_jp1;
-        if (pmy_block->precon->uniform_limiter[2] == true) {
+        if (uniform_ave_x3 == true) {
           lw = 0.5;
           rw = 0.5;
         } else {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The current second-order accurate conversion from face-averaged to cell-centered B field 
```c++
 void Field::CalculateCellCenteredField(const FaceField &bf, AthenaArray<Real> &bc,
             Coordinates *pco, int is, int ie, int js, int je, int ks, int ke)
```
references the volume centered and cell face and volume center positions to compute the weighted average coefficients, for example:
```c++
lw = (x2f_jp - x2v_j)/dx2_j;
rw = (x2v_j  - x2f_j)/dx2_j;
```
which should reduce to 0.5 for uniform Cartesian coordinates. However, due to floating point round-off error, `x2f(j+1) - x2v(j) != dx2f(j)/2.0` e.g., so the coefficients `lw, rw` wont add up to 1.0 exactly. Note for uniform meshes, `dx2f = dx2v` exactly, but the positions are inexact. 

This PR simply uses the existing `uniform_limiter[3]` switches in the Reconstruction class to determine if the simple averaging formula can be used to compute the cell-centered magnetic field from the face-averaged magnetic fields in each direction. 

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

[mhd-rotor-2D-nx1-32-ic-Bcc1-master.pdf](https://github.com/PrincetonUniversity/athena/files/1972235/mhd-rotor-2D-nx1-32-ic-Bcc1-master.pdf) plots the current `nx1=nx2=20` with `NGHOST=2` initial condition `Bcc1` for the 2D MHD rotor problem. The ghost zones are also shown. The initial condition is supposed to have uniform B1 corresponding to `bx0=1.410474` requested in the `athinput.rotor` file, but banding of deviations appear in x1 ranging from min/max:
```
1.410473999999998
1.4104740000000013
```
Since the fixes in #98, the deviations are symmetric about the midplane. 

[mhd-rotor-2D-nx1-32-ic-Bcc1-fix.pdf](https://github.com/PrincetonUniversity/athena/files/1972177/mhd-rotor-2D-nx1-32-ic-Bcc1-fix.pdf) shows the uniform Bcc1 after the adding the switch in this PR, where all zones real and ghost have
```
1.4104740000000000
```
equivalent to 0552802248421E0 in binary. 

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->

- [ ] Fix remaining reflective symmetry violations for double precision MHD in Athena++
