### PR TITLE
Remove inverse h_coeff from Coordinates class

### DIFF
--- a/src/coordinates/cartesian.cpp
+++ b/src/coordinates/cartesian.cpp
@@ -59,13 +59,6 @@ Cartesian::Cartesian(MeshBlock *pmb, ParameterInput *pin, bool flag)
   h32v.NewAthenaArray(ncells2);
   dh32vd2.NewAthenaArray(ncells2);
 
-  h2fi.NewAthenaArray(ncells1);
-  h2vi.NewAthenaArray(ncells1);
-  h31fi.NewAthenaArray(ncells1);
-  h31vi.NewAthenaArray(ncells1);
-  h32fi.NewAthenaArray(ncells2);
-  h32vi.NewAthenaArray(ncells2);
-
   // allocate arrays for area weighted positions for AMR/SMR MHD
   if ((pm->multilevel==true) && MAGNETIC_FIELDS_ENABLED) {
     x1s2.NewAthenaArray(ncells1);
@@ -129,9 +122,7 @@ Cartesian::Cartesian(MeshBlock *pmb, ParameterInput *pin, bool flag)
   // x1-direction
   for (int i=il-ng; i<=iu+ng; ++i) {
     h2v(i) = 1.0;
-    h2vi(i) = 1.0;
     h2f(i) = 1.0;
-    h2fi(i) = 1.0;
     h31v(i) = 1.0;
     h31f(i) = 1.0;
     dh2vd1(i) = 0.0;
@@ -144,16 +135,12 @@ Cartesian::Cartesian(MeshBlock *pmb, ParameterInput *pin, bool flag)
   if (pmb->block_size.nx2 == 1) {
     h32v(jl) = 1.0;
     h32f(jl) = 1.0;
-    h32vi(jl) = 1.0;
-    h32fi(jl) = 1.0;
     dh32vd2(jl) = 0.0;
     dh32fd2(jl) = 0.0;
   } else {
     for (int j=jl-ng; j<=ju+ng; ++j) {
       h32v(j) = 1.0;
       h32f(j) = 1.0;
-      h32vi(j) = 1.0;
-      h32fi(j) = 1.0;
       dh32vd2(j) = 0.0;
       dh32fd2(j) = 0.0;
     }

--- a/src/coordinates/coordinates.hpp
+++ b/src/coordinates/coordinates.hpp
@@ -42,8 +42,6 @@ public:
   // geometry coefficient
   AthenaArray<Real> h2f,dh2fd1,h31f,h32f,dh31fd1,dh32fd2;
   AthenaArray<Real> h2v,dh2vd1,h31v,h32v,dh31vd1,dh32vd2;
-  AthenaArray<Real> h2fi,h31fi,h32fi;
-  AthenaArray<Real> h2vi,h31vi,h32vi;
 
   // functions...
   // ...to compute length of edges

--- a/src/coordinates/cylindrical.cpp
+++ b/src/coordinates/cylindrical.cpp
@@ -65,13 +65,6 @@ Cylindrical::Cylindrical(MeshBlock *pmb, ParameterInput *pin, bool flag)
   h32v.NewAthenaArray(ncells2);
   dh32vd2.NewAthenaArray(ncells2);
 
-  h2fi.NewAthenaArray(ncells1);
-  h2vi.NewAthenaArray(ncells1);
-  h31fi.NewAthenaArray(ncells1);
-  h31vi.NewAthenaArray(ncells1);
-  h32fi.NewAthenaArray(ncells2);
-  h32vi.NewAthenaArray(ncells2);
-
   // allocate arrays for area weighted positions for AMR/SMR MHD
   if ((pm->multilevel==true) && MAGNETIC_FIELDS_ENABLED) {
     x1s2.NewAthenaArray(ncells1);
@@ -121,9 +114,7 @@ Cylindrical::Cylindrical(MeshBlock *pmb, ParameterInput *pin, bool flag)
   // x1-direction
   for (int i=il-ng; i<=iu+ng; ++i) {
     h2v(i) = x1v(i);
-    h2vi(i) = 1.0/x1v(i);
     h2f(i) = x1f(i);
-    h2fi(i) = 1.0/x1f(i);
     h31v(i) = 1.0;
     h31f(i) = 1.0;
     dh2vd1(i) = 1.0;
@@ -136,16 +127,12 @@ Cylindrical::Cylindrical(MeshBlock *pmb, ParameterInput *pin, bool flag)
   if (pmb->block_size.nx2 == 1) {
     h32v(jl) = 1.0;
     h32f(jl) = 1.0;
-    h32vi(jl) = 1.0;
-    h32fi(jl) = 1.0;
     dh32vd2(jl) = 0.0;
     dh32fd2(jl) = 0.0;
   } else {
     for (int j=jl-ng; j<=ju+ng; ++j) {
       h32v(j) = 1.0;
       h32f(j) = 1.0;
-      h32vi(j) = 1.0;
-      h32fi(j) = 1.0;
       dh32vd2(j) = 0.0;
       dh32fd2(j) = 0.0;
     }

--- a/src/coordinates/spherical_polar.cpp
+++ b/src/coordinates/spherical_polar.cpp
@@ -65,13 +65,6 @@ SphericalPolar::SphericalPolar(MeshBlock *pmb, ParameterInput *pin, bool flag)
   h32v.NewAthenaArray(ncells2);
   dh32vd2.NewAthenaArray(ncells2);
 
-  h2fi.NewAthenaArray(ncells1);
-  h2vi.NewAthenaArray(ncells1);
-  h31fi.NewAthenaArray(ncells1);
-  h31vi.NewAthenaArray(ncells1);
-  h32fi.NewAthenaArray(ncells2);
-  h32vi.NewAthenaArray(ncells2);
-
   // allocate arrays for area weighted positions for AMR/SMR MHD
   if ((pm->multilevel==true) && MAGNETIC_FIELDS_ENABLED) {
     x1s2.NewAthenaArray(ncells1);
@@ -127,10 +120,6 @@ SphericalPolar::SphericalPolar(MeshBlock *pmb, ParameterInput *pin, bool flag)
     h2f(i) = x1f(i);
     h31v(i) = x1v(i);
     h31f(i) = x1f(i);
-    h2vi(i) = 1.0/x1v(i);
-    h2fi(i) = 1.0/x1f(i);
-    h31vi(i) = 1.0/x1v(i);
-    h31fi(i) = 1.0/x1f(i);
     dh2vd1(i) = 1.0;
     dh2fd1(i) = 1.0;
     dh31vd1(i) = 1.0;
@@ -141,16 +130,12 @@ SphericalPolar::SphericalPolar(MeshBlock *pmb, ParameterInput *pin, bool flag)
   if (pmb->block_size.nx2 == 1) {
     h32v(jl) = sin(x2v(jl));
     h32f(jl) = sin(x2f(jl));
-    h32vi(jl) = 1.0/sin(x2v(jl));
-    h32fi(jl) = 1.0/sin(x2f(jl));
     dh32vd2(jl) = cos(x2v(jl));
     dh32fd2(jl) = cos(x2f(jl));
   } else {
     for (int j=jl-ng; j<=ju+ng; ++j) {
       h32v(j) = sin(x2v(j));
       h32f(j) = sin(x2f(j));
-      h32vi(j) = 1.0/sin(x2v(j));
-      h32fi(j) = 1.0/sin(x2f(j));
       dh32vd2(j) = cos(x2v(j));
       dh32fd2(j) = cos(x2f(j));
     }


### PR DESCRIPTION
remove the unnecessary inverse of geometric coeff defined and calculated in coordinate class. 