### PR TITLE
Redefine and initialize grav_mean_rho directly in Mesh class

### DIFF
--- a/src/gravity/gravity.cpp
+++ b/src/gravity/gravity.cpp
@@ -34,6 +34,15 @@ Gravity::Gravity(MeshBlock *pmb, ParameterInput *pin) {
     throw std::runtime_error(msg.str().c_str());
     return;
   }
+  grav_mean_rho=pmb->pmy_mesh->grav_mean_rho_;
+  if (grav_mean_rho==-1.0) {
+   std::stringstream msg;
+   msg << "### FATAL ERROR in Gravity::Gravity" << std::endl
+        << "Background Mean Density must be set in the Mesh::InitUserMeshData "
+        << "using the SetMeanDensity function." << std::endl;
+    throw std::runtime_error(msg.str().c_str());
+    return;
+  }
 
   // Allocate memory for gravitational potential, but only when needed.
   int ncells1 = pmb->block_size.nx1 + 2*(NGHOST);

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -76,7 +76,7 @@ Mesh::Mesh(ParameterInput *pin, int mesh_test) {
   dt   = (FLT_MAX*0.4);
   nbnew=0; nbdel=0;
 
-  four_pi_G_=0.0, grav_eps_=-1.0;
+  four_pi_G_=0.0, grav_eps_=-1.0, grav_mean_rho_=-1.0;
 
   turb_flag = 0;
 
@@ -523,7 +523,7 @@ Mesh::Mesh(ParameterInput *pin, IOWrapper& resfile, int mesh_test) {
   nreal_user_mesh_data_=0;
   nuser_history_output_=0;
 
-  four_pi_G_=0.0, grav_eps_=-1.0;
+  four_pi_G_=0.0, grav_eps_=-1.0, grav_mean_rho_=-1.0;
 
   turb_flag = 0;
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -213,7 +213,7 @@ private:
   std::string *user_history_output_names_;
 
   // global constants
-  Real four_pi_G_, grav_eps_;
+  Real four_pi_G_, grav_eps_, grav_mean_rho_;
 
   // functions
   MeshGenFunc_t MeshGenerator_[3];
@@ -253,6 +253,7 @@ private:
   void SetGravitationalConstant(Real g) { four_pi_G_=4.0*PI*g; }
   void SetFourPiG(Real fpg) { four_pi_G_=fpg; }
   void SetGravityThreshold(Real eps) { grav_eps_=eps; }
+  void SetMeanDensity(Real d0) { grav_mean_rho_=d0; }
 };
 
 

--- a/src/pgen/jeans.cpp
+++ b/src/pgen/jeans.cpp
@@ -47,7 +47,7 @@
 static Real ang_2, ang_3; // Rotation angles about the y and z' axis
 static Real sin_a2, cos_a2, sin_a3, cos_a3;
 static Real amp, njeans, lambda, kwave; // amplitude, Wavelength, 2*PI/wavelength
-static Real cs2,gam,gm1,omega,omega2, grav_mean_rho, gconst;
+static Real cs2,gam,gm1,omega,omega2, gconst;
 static Real ev[NWAVE], rem[NWAVE][NWAVE], lem[NWAVE][NWAVE];
 static Real d0,p0,v0,u0,w0,va,b0;
 
@@ -90,7 +90,6 @@ void Mesh::InitUserMeshData(ParameterInput *pin) {
     cs2 = SQR(iso_cs);
   }
   gconst = cs2*PI*njeans*njeans/(d0*lambda*lambda);
-  grav_mean_rho = d0;
 
   kwave = 2.0*PI/lambda;
   omega2 = SQR(kwave)*cs2*(1.0 - SQR(njeans));
@@ -100,6 +99,7 @@ void Mesh::InitUserMeshData(ParameterInput *pin) {
     SetGravitationalConstant(gconst);
     Real eps = pin->GetOrAddReal("problem","grav_eps", 0.0);
     SetGravityThreshold(eps);
+    SetMeanDensity(d0);
   }
 
   if (Globals::my_rank==0) {
@@ -155,9 +155,6 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
 
 //  pmy_mesh->tlim=pin->SetReal("time","tlim",2.0*PI/omega*2.0);
 
-  if (SELF_GRAVITY_ENABLED) {
-    pgrav->grav_mean_rho = grav_mean_rho;
-  } // self-gravity
 }
 
 void Mesh::UserWorkAfterLoop(ParameterInput *pin) {

--- a/src/pgen/poisson.cpp
+++ b/src/pgen/poisson.cpp
@@ -49,6 +49,7 @@ void Mesh::InitUserMeshData(ParameterInput *pin) {
   Real eps = pin->GetOrAddReal("problem","grav_eps", 0.0);
   SetFourPiG(four_pi_G);
   SetGravityThreshold(eps);
+  SetMeanDensity(0.0);
 }
 
 //========================================================================================
@@ -69,7 +70,6 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
 
   Real four_pi_G = pin->GetReal("problem","four_pi_G");
   Real gconst = four_pi_G / (4.0*PI);
-  Real grav_mean_rho = 0.0;
 
   int iprob = pin->GetOrAddInteger("problem","iprob",1);
   int nlim = pin->GetInteger("time","nlim");


### PR DESCRIPTION
## Description
1. set grav_mean_rho using SetMeanDensity function from Mesh::InitMeshData similarly with four_pi_G.
2. modify problems accordingly

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It passes regression/grav tests

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->
