### PR TITLE
Added interactive spherical plotting:

### DIFF
--- a/vis/python/plot_spherical.py
+++ b/vis/python/plot_spherical.py
@@ -31,9 +31,9 @@ import numpy as np
 # Athena++ modules
 import athena_read
 
+
 # Main function
 def main(**kwargs):
-
     # Load function for transforming coordinates
     if kwargs['stream'] is not None:
         from scipy.ndimage import map_coordinates


### PR DESCRIPTION
Fixed fatal bug in spherical plotting script and added interactivity

## Prerequisite checklist

- [ x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

## Description

Recent reformatting broke the spherical plotting script (no bug report filed) by trying to change the matplotlib backend after loading pyplot. This is now fixed in the same way the other plotting scripts are written.

At the same time, `plot_spherical.py` was the only script to not allow interactive plotting (`plt.show()`), and this has been changed.

## Testing and validation

There are no regression tests for plotting scripts.