### PR TITLE
Fixed spherical coordinates for non-ideal MHD

### DIFF
--- a/src/coordinates/spherical_polar.cpp
+++ b/src/coordinates/spherical_polar.cpp
@@ -210,7 +210,7 @@ SphericalPolar::SphericalPolar(MeshBlock *pmb, ParameterInput *pin, bool flag)
       // Rf_{i+1}^2/R_{i}^2/Rf_{i+1}^2
       phy_src2_i_(i) = phy_src1_i_(i);
       // R^2 at the volume center for non-ideal MHD
-      coord_area1vc_i_(i) = SQR(x1v(i))
+      coord_area1vc_i_(i) = SQR(x1v(i));
     }
     coord_area1_i_(iu+ng+1) = x1f(iu+ng+1)*x1f(iu+ng+1);
 #pragma omp simd


### PR DESCRIPTION
coord_area1vc_i_(i) was defined but not calculated, and all the radial face areas used in the non-ideal MHD part were zero. Also, the sign of coord_area1vc_j_(ju) at the outer pole was wrong.

This part was committed by @jmshi, but written by some one else. I would like to request the original author of this part to review it. I just put @zhuzh1983  and @xueningbai as temporary reviewers as I guess you guys know this part.

Also, if possible, it would be nice if we have a test set for non-ideal MHD problems, at least for this kind of trivial mistakes.

## Prerequisite checklist
- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


By the way, we have reached 2000 commits - wow.
