### PR TITLE
Remove unused GravityBoundaryFunction_[] array from Mesh class

### DIFF
--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1201,7 +1201,6 @@ void Mesh::AllocateIntUserMeshDataField(int n) {
   return;
 }
 
-
 //----------------------------------------------------------------------------------------
 //! \fn void Mesh::EnrollUserMGBoundaryFunction(enum BoundaryFace dir
 //                                              MGBoundaryFunc_t my_bc)
@@ -1218,28 +1217,10 @@ void Mesh::EnrollUserMGBoundaryFunction(enum BoundaryFace dir, MGBoundaryFunc_t 
   return;
 }
 
-
-//----------------------------------------------------------------------------------------
-//! \fn void Mesh::EnrollUserGravityBoundaryFunction(enum BoundaryFace dir,
-//                                                   GravityBoundaryFunc_t my_bc)
-//  \brief Enroll a user-defined boundary function
-
-void Mesh::EnrollUserGravityBoundaryFunction(enum BoundaryFace dir,
-                                             GravityBoundaryFunc_t my_bc) {
-  std::stringstream msg;
-  if (dir<0 || dir>5) {
-    msg << "### FATAL ERROR in EnrollBoundaryCondition function" << std::endl
-        << "dirName = " << dir << " not valid" << std::endl;
-    throw std::runtime_error(msg.str().c_str());
-  }
-  GravityBoundaryFunction_[dir]=my_bc;
-  return;
-}
-
-
 //----------------------------------------------------------------------------------------
 // \!fn void Mesh::ApplyUserWorkBeforeOutput(ParameterInput *pin)
 // \brief Apply MeshBlock::UserWorkBeforeOutput
+
 void Mesh::ApplyUserWorkBeforeOutput(ParameterInput *pin) {
   MeshBlock *pmb = pblock;
   while (pmb != NULL)  {

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -230,7 +230,6 @@ private:
   ConductionCoeff_t ConductionCoeff_;
   FieldDiffusionCoeff_t FieldDiffusivity_;
   MGBoundaryFunc_t MGBoundaryFunction_[6];
-  GravityBoundaryFunc_t GravityBoundaryFunction_[6];
 
   void AllocateRealUserMeshDataField(int n);
   void AllocateIntUserMeshDataField(int n);
@@ -248,8 +247,6 @@ private:
   void EnrollUserHistoryOutput(int i, HistoryOutputFunc_t my_func, const char *name);
   void EnrollUserMetric(MetricFunc_t my_func);
   void EnrollUserMGBoundaryFunction(enum BoundaryFace dir, MGBoundaryFunc_t my_bc);
-  void EnrollUserGravityBoundaryFunction(enum BoundaryFace dir,
-                                         GravityBoundaryFunc_t my_bc);
   void EnrollViscosityCoefficient(ViscosityCoeff_t my_func);
   void EnrollConductionCoefficient(ConductionCoeff_t my_func);
   void EnrollFieldDiffusivity(FieldDiffusionCoeff_t my_func);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #148. Trying to sneak this PR in before finally tagging and releasing v1.1.1 today. 

@tomidakn , should I delete ` Mesh::EnrollUserMGBoundaryFunction()`? Should I rename `MGBoundaryFunction_` to `MGGravityBoundaryFunction_`? --- **Leaving Multigrid completely alone until Kengo generalizes it.**