### PR TITLE
Eliminate redundant calls to ApplyPrimitiveFloors()

### DIFF
--- a/src/reconstruct/plm.cpp
+++ b/src/reconstruct/plm.cpp
@@ -107,6 +107,7 @@ void Reconstruction::PiecewiseLinearX1(MeshBlock *pmb,
       }
     }
     if (pmb->precon->characteristic_reconstruction) {
+#pragma omp simd
       for (int i=il-1; i<=iu; ++i) {
         // Reapply EOS floors to both L/R reconstructed primitive states
         pmb->peos->ApplyPrimitiveFloors(wl, k, j, i+1);
@@ -209,6 +210,7 @@ void Reconstruction::PiecewiseLinearX2(MeshBlock *pmb,
       }
     }
     if (pmb->precon->characteristic_reconstruction) {
+#pragma omp simd
       for (int i=il; i<=iu; ++i) {
         // Reapply EOS floors to both L/R reconstructed primitive states
         pmb->peos->ApplyPrimitiveFloors(wl, k, j+1, i);
@@ -311,6 +313,7 @@ void Reconstruction::PiecewiseLinearX3(MeshBlock *pmb,
       }
     }
     if (pmb->precon->characteristic_reconstruction) {
+#pragma omp simd
       for (int i=il; i<=iu; ++i) {
         // Reapply EOS floors to both L/R reconstructed primitive states
         pmb->peos->ApplyPrimitiveFloors(wl, k+1, j, i);

--- a/src/reconstruct/ppm.cpp
+++ b/src/reconstruct/ppm.cpp
@@ -332,6 +332,7 @@ void Reconstruction::PiecewiseParabolicX1(MeshBlock *pmb,
         wr(n,k,j,i  ) = qr_imh(n,i);
       }
     }
+#pragma omp simd
     for (int i=il-1; i<=iu; ++i) {
       // Reapply EOS floors to both L/R reconstructed primitive states
       pmb->peos->ApplyPrimitiveFloors(wl, k, j, i+1);
@@ -636,6 +637,7 @@ void Reconstruction::PiecewiseParabolicX2(MeshBlock *pmb,
         wr(n,k,j  ,i) = qr_jmh(n,i);
       }
     }
+#pragma omp simd
     for (int i=il; i<=iu; ++i) {
       // Reapply EOS floors to both L/R reconstructed primitive states
       pmb->peos->ApplyPrimitiveFloors(wl, k, j+1, i);
@@ -943,6 +945,7 @@ void Reconstruction::PiecewiseParabolicX3(MeshBlock *pmb,
         wr(n,k  ,j,i) = qr_kmh(n,i);
       }
     }
+#pragma omp simd
     for (int i=il; i<=iu; ++i) {
       // Reapply EOS floors to both L/R reconstructed primitive states
       pmb->peos->ApplyPrimitiveFloors(wl, k+1, j, i);


### PR DESCRIPTION
## Description
Closes #153. 

Unfortunately, this loop fission will reduce the arithmetic intensity of these final loops in the `plm.cpp` and `ppm.cpp` reconstruction functions. But, it is probably better than having redundant function calls. 

