### PR TITLE
Use C++ compiler front ends for main/documented "configure.py --cxx" options but support C front ends; add built-in support for Apple+LLVM with OpenMP workaround

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -220,14 +220,17 @@ cxx_choices = [
     'clang++-simd',
     'clang++-apple',
 ]
+
+
 def c_to_cpp(arg):
-  arg = arg.replace('gcc', 'g++', 1)
-  arg = arg.replace('icc', 'icpc', 1)
-  if arg == 'clang':
-    arg = 'clang++'
-  else:
-    arg = arg.replace('clang-', 'clang++-', 1)
-  return arg
+    arg = arg.replace('gcc', 'g++', 1)
+    arg = arg.replace('icc', 'icpc', 1)
+    if arg == 'clang':
+        arg = 'clang++'
+    else:
+        arg = arg.replace('clang-', 'clang++-', 1)
+    return arg
+
 
 # --cxx=[name] argument
 parser.add_argument(


### PR DESCRIPTION
Closes #182. 

Added new `--cxx=clang++-apple` option for handling different `-omp` compiler and library flags for Apple LLVM. 

Also, added basic `description` and `epilog` strings to `argparse.ArgumentParser()` object for when `./configure.py --help` is invoked. 