### PR TITLE
Correct energy bug in PrimitiveToConserved in general_hydro.cpp

### DIFF
--- a/src/eos/general/general_hydro.cpp
+++ b/src/eos/general/general_hydro.cpp
@@ -154,7 +154,8 @@ void EquationOfState::PrimitiveToConserved(
         u_m1 = w_vx*w_d;
         u_m2 = w_vy*w_d;
         u_m3 = w_vz*w_d;
-        u_e = SimpleEgas(u_d, w_p); // cellwise conversion
+        // cellwise conversion
+        u_e = SimpleEgas(u_d, w_p) + 0.5*w_d*(SQR(w_vx) + SQR(w_vy) + SQR(w_vz));
       }
     }
   }


### PR DESCRIPTION
This PR fixes a single line of code. There was a bug on line 157 of `general_hydro.cpp`. The kinetic energy contribution was missing.