### PR TITLE
1D MHD AMR fix

### DIFF
--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -2243,6 +2243,7 @@ void Mesh::AdaptiveMeshRefinement(ParameterInput *pin) {
             }
             if (pmb->block_size.nx3==1) {
               int ie=is+block_size.nx1/2-1, je=js+block_size.nx2/2-1;
+              if (pmb->block_size.nx2==1) je=js;
               for (int j=js; j<=je; j++) {
                 for (int i=is; i<=ie; i++)
                   dst_b.x3f(pmb->ks+1, j, i)=dst_b.x3f(pmb->ks, j, i);

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -805,10 +805,10 @@ void MeshRefinement::ProlongateSharedFieldX3(
   } else {
     for (int i=si; i<=ei; i++) {
       int fi=(i-pmb->cis)*2+pmb->is;
-      Real gxm = (coarse(0,0,i)   - coarse(0,0,i-1)) / (pcoarsec->x1s3(i) -
-                                                        pcoarsec->x1s3(i-1));
-      Real gxp = (coarse(0,0,i+1) - coarse(0,0,i)) / (pcoarsec->x1s3(i+1) -
-                                                      pcoarsec->x1s3(i));
+      Real gxm = (coarse(0,0,i)   - coarse(0,0,i-1))
+               / (pcoarsec->x1s3(i) - pcoarsec->x1s3(i-1));
+      Real gxp = (coarse(0,0,i+1) - coarse(0,0,i))
+               / (pcoarsec->x1s3(i+1) - pcoarsec->x1s3(i));
       Real gxc = 0.5*(SIGN(gxm)+SIGN(gxp))*std::min(std::abs(gxm),std::abs(gxp));
       fine(0,0,fi  )=fine(1,0,fi  )
                     =coarse(0,0,i)-gxc*(pcoarsec->x1s3(i)-pco->x1s3(fi));


### PR DESCRIPTION
### Summary

A couple recent bug fixes (f61ef03 and 819ffd8) improved the treatment of By and Bz in 1D MHD AMR, perfectly addressing the test cases in #209 and #212. However a couple changes made to `ProlongateSharedFieldX2()` are missing from `ProlongateSharedFieldX3()`. This applies them.

**However** there may still be a small related bug.

### Test case

I haven't yet tried reducing this to Newtonian, so this is an SR shock tube I'm running. I'm using problem generator [sr_amr_shock.txt](https://github.com/PrincetonUniversity/athena/files/2820536/sr_amr_shock.txt) and input file [sr_amr_shock_athinput.txt](https://github.com/PrincetonUniversity/athena/files/2820548/sr_amr_shock_athinput.txt).

There is perfect symmetry between By and Bz physically. However, time slice 400 shows artifacts in Bz in the rarefaction region. Before the commit in this pull request, we have

![before](https://user-images.githubusercontent.com/2496675/52109396-29f77380-25b2-11e9-8d59-59cb20d763e8.png)

With this pull request, the situation certainly improves:

![after](https://user-images.githubusercontent.com/2496675/52109418-3bd91680-25b2-11e9-8bb1-ab260a810ae0.png)

### To do

- [x] Determine if the remaining hiccups in Bz are still a problem, and what could be breaking symmetry.