### PR TITLE
Fix typo in 1D prolongation of magnetic field

### DIFF
--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -622,7 +622,7 @@ void MeshRefinement::ProlongateSharedFieldX1(
     }
   } else { // 1D
     for (int i=si; i<=ei; i++) {
-      int fi=(si-pmb->cis)*2+pmb->is;
+      int fi=(i-pmb->cis)*2+pmb->is;
       fine(0,0,fi)=coarse(0,0,i);
     }
   }


### PR DESCRIPTION
Pretty self-explanatory. I didn't see any other issues in the other 1D clauses of `mesh_refinement.cpp`. For comparison, here is Bx before the fix, where prolongation happens in cycle 53 for some particular shock tube:

![before](https://user-images.githubusercontent.com/2496675/52171943-bae95e80-271a-11e9-9bbe-7f27d404fec2.png)

And here it is after this fix:

![after](https://user-images.githubusercontent.com/2496675/52171947-c2106c80-271a-11e9-86d5-a470380a6d1e.png)