### PR TITLE
Fix fail criterion for diffusion/*_diffusion* tests

### DIFF
--- a/tst/regression/scripts/tests/diffusion/resistive_diffusion.py
+++ b/tst/regression/scripts/tests/diffusion/resistive_diffusion.py
@@ -61,7 +61,10 @@ def analyze():
     print('[Resistive Diffusion Explicit]: Convergence order = {}'.format(conv))
 
     flag = True
-    if conv > -1.99:
+    if not np.isfinite(conv):
+        print('[Resistive Diffusion Explicit]: NaN encountered.')
+        flag = False
+    elif conv > -1.99:
         print('[Resistive Diffusion Explicit]: Scheme NOT Converging at ~2nd order.')
         flag = False
     else:

--- a/tst/regression/scripts/tests/diffusion/resistive_diffusion_sts.py
+++ b/tst/regression/scripts/tests/diffusion/resistive_diffusion_sts.py
@@ -61,7 +61,10 @@ def analyze():
     print('[Resistive Diffusion STS]: Convergence order = {}'.format(conv))
 
     flag = True
-    if conv > -0.99:
+    if not np.isfinite(conv):
+        print('[Resistive Diffusion STS]: NaN encountered.')
+        flag = False
+    elif conv > -0.99:
         print('[Resistive Diffusion STS]: Scheme NOT Converging at ~1st order.')
         flag = False
     else:

--- a/tst/regression/scripts/tests/diffusion/viscous_diffusion.py
+++ b/tst/regression/scripts/tests/diffusion/viscous_diffusion.py
@@ -60,7 +60,10 @@ def analyze():
     print('[Viscous Diffusion Explicit]: Convergence order = {}'.format(conv))
 
     flag = True
-    if conv > -1.99:
+    if not np.isfinite(conv):
+        print('[Viscous Diffusion Explicit]: NaN encountered.')
+        flag = False
+    elif conv > -1.99:
         print('[Viscous Diffusion Explicit]: Scheme NOT Converging at ~2nd order.')
         flag = False
     else:

--- a/tst/regression/scripts/tests/diffusion/viscous_diffusion_sts.py
+++ b/tst/regression/scripts/tests/diffusion/viscous_diffusion_sts.py
@@ -61,7 +61,10 @@ def analyze():
     print('[Viscous Diffusion STS]: Convergence order = {}'.format(conv))
 
     flag = True
-    if conv > -0.99:
+    if not np.isfinite(conv):
+        print('[Viscous Diffusion STS]: NaN encountered.')
+        flag = False
+    elif conv > -0.99:
         print('[Viscous Diffusion STS]: Scheme NOT Converging at ~1st order.')
         flag = False
     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Pleas review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
`diffusion/*_diffusion*` tests were not failing when `NaN`'s were encountered.   This PR checks for finiteness of outputs during convergence analysis.     
<!--- Why is this change required? What problem does it solve? -->
In @felker 's development of the STS tasklist in the `bvals_pscalars` branch, some changes have produced `NaN`'s during convergence analysis in the  `diffusion/*_diffusion*` test problems.  However, the logic in the regression tests (in present `master`) led to PASSES.  After this PR, `NaN`'ing will be caught if encountered in these regression tests.  

## Minor Changes
1. Add `if` clause to `diffusion/*_diffusion*` tests to check for finiteness in convergence analysis.  

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
All tests still pass in master; `NaN`'ing calculations in `bvals_pscalars` branch now fail.  

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->
See Issue #223 .  Are other existing regression problems subject to this problem?
