### PR TITLE
Global initialization of turbulence realization

### DIFF
--- a/src/fft/turbulence.cpp
+++ b/src/fft/turbulence.cpp
@@ -152,18 +152,33 @@ void TurbulenceDriver::PowerSpectrum(AthenaFFTComplex *amp) {
   Real pcoeff;
   FFTBlock *pfb = pmy_fb;
   AthenaFFTIndex *idx = pfb->b_in_;
-  int knx1=pfb->knx[0],knx2=pfb->knx[1],knx3=pfb->knx[2];
+  int kNx1 = pfb->kNx[0], kNx2 = pfb->kNx[1], kNx3 = pfb->kNx[2];
+  int knx1 = pfb->knx[0], knx2 = pfb->knx[1], knx3 = pfb->knx[2];
+  int kdisp1 = pfb->kdisp[0], kdisp2 = pfb->kdisp[1], kdisp3 = pfb->kdisp[2];
+
   // set random amplitudes with gaussian deviation
-  for (int k=0; k<knx3; k++) {
-    for (int j=0; j<knx2; j++) {
-      for (int i=0; i<knx1; i++) {
-        Real q1=ran2(&rseed);
-        Real q2=ran2(&rseed);
-        Real q3=std::sqrt(-2.0*std::log(q1+1.e-20))*std::cos(TWO_PI*q2);
-        q1=ran2(&rseed);
-        std::int64_t kidx=pfb->GetIndex(i,j,k,idx);
-        amp[kidx][0] = q3*std::cos(TWO_PI*q1);
-        amp[kidx][1] = q3*std::sin(TWO_PI*q1);
+  // loop over entire Mesh
+  for (int gk=0; gk<kNx3; gk++) {
+    for (int gj=0; gj<kNx2; gj++) {
+      for (int gi=0; gi<kNx1; gi++) {
+        int k = gk - kdisp3;
+        int j = gj - kdisp2;
+        int i = gi - kdisp1;
+        if ((k >= 0) && (k < knx3) &&
+            (j >= 0) && (j < knx2) &&
+            (i >= 0) && (i < knx3)) {
+          Real q1=ran2(&rseed);
+          Real q2=ran2(&rseed);
+          Real q3=std::sqrt(-2.0*std::log(q1+1.e-20))*std::cos(TWO_PI*q2);
+          q1=ran2(&rseed);
+          std::int64_t kidx=pfb->GetIndex(i,j,k,idx);
+          amp[kidx][0] = q3*std::cos(TWO_PI*q1);
+          amp[kidx][1] = q3*std::sin(TWO_PI*q1);
+        } else { // if it is not in FFTBlock, just burn three random numbers
+          ran2(&rseed);
+          ran2(&rseed);
+          ran2(&rseed);
+        }
       }
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

For MPI jobs, turbulence realizations were different for different number of processors (more precisely, different number of `FFTBlock`; in the current implementation, it doesn't depend on the number of `MeshBlock` since all the `MeshBlocks` in one processor are already collected to set `FFTBlock`). To get an identical realization, the loop for k-space (in `PowerSpectrum()`) is revised to loop over the entire k-space, but take only local k-indices. 

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Confirmed that the realizations are identical for different number of processors.
