### PR TITLE
Fix edge-case bug in typecast function.

### DIFF
--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -1015,7 +1015,7 @@ def athinput(filename):
     # Function for interpreting strings numerically
     def typecast(x):
         if '_' in x:
-          return x
+            return x
         try:
             return int(x)
         except ValueError:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In `athena_read.py` the `typecast` function would cast underscore delimited integers as an integer instead of a string. E.g. `typecast('256_64_0')` returns `256640`; expected output: `'256_64_0'`. This PR fixes this.