### PR TITLE
Fix bug in spherical plotting script

### DIFF
--- a/vis/python/plot_spherical.py
+++ b/vis/python/plot_spherical.py
@@ -182,7 +182,7 @@ def main(**kwargs):
 
     # Join scalar data through boundaries
     if not kwargs['midplane']:
-        vals = np.vstack((vals_right, vals_left[::-1,:]))
+        vals = np.vstack((vals_right, vals_left[::-1, :]))
 
     # Perform slicing/averaging of vector data
     if kwargs['stream'] is not None:


### PR DESCRIPTION
When plotting vertical slices, the colormapped values were upside down on the left side of the image. For example,

```bash
./configure.py -g -b --prob gr_torus --coord kerr-schild -hdf5
make clean
make -j
bin/athena -i inputs/mhd_gr/athinput.fm_torus -d temp/ time/nlim=0 problem/r_edge=8.0 problem/r_peak=15.0 problem/tilt_angle=30.0
vis/python/plot_spherical.py temp/fm_torus.prim.00000.athdf rho temp/rho.png --logc -s Bcc
```

used to produce this

![rho_bug](https://user-images.githubusercontent.com/2496675/56771134-b4431400-676a-11e9-9890-1f6215e8a0e0.png)

but now produces this

![rho_fix](https://user-images.githubusercontent.com/2496675/56771140-b86f3180-676a-11e9-9eb1-441fb8b3ba94.png)