### PR TITLE
Revert GR optimizations

### DIFF
--- a/src/eos/adiabatic_hydro_gr.cpp
+++ b/src/eos/adiabatic_hydro_gr.cpp
@@ -87,53 +87,62 @@ void EquationOfState::ConservedToPrimitive(
   const int initial_guess_multiplications = 10;
 
   // Extract ratio of specific heats
-  const Real gamma_adi = gamma_;
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
-  const Real gamma_tmp = SQR(gamma_max_)-1.0;
+  const Real &gamma_adi = gamma_;
 
   // Go through cells
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
       pco->CellMetric(k, j, il, iu, g_, g_inv_);
-
-#pragma omp simd simdlen(SIMD_WIDTH) early_exit
+#pragma omp simd
       for (int i=il; i<=iu; ++i) {
         // Extract metric
-        Real g_11 = g_(I11,i), g_12 = g_(I12,i), g_13 = g_(I13,i),
-             g_22 = g_(I22,i), g_23 = g_(I23,i), g_33 = g_(I33,i);
-        Real g00 = g_inv_(I00,i), g01 = g_inv_(I01,i), g02 = g_inv_(I02,i),
-             g03 = g_inv_(I03,i), g10 = g_inv_(I01,i), g11 = g_inv_(I11,i),
-             g12 = g_inv_(I12,i), g13 = g_inv_(I13,i), g20 = g_inv_(I02,i),
-             g21 = g_inv_(I12,i), g22 = g_inv_(I22,i), g23 = g_inv_(I23,i),
-             g30 = g_inv_(I03,i), g31 = g_inv_(I13,i), g32 = g_inv_(I23,i),
-             g33 = g_inv_(I33,i);
+        const Real
+            // unused:
+            //&g_00 = g_(I00,i), &g_01 = g_(I01,i), &g_02 = g_(I02,i), &g_03 = g_(I03,i),
+            // &g_10 = g_(I01,i);
+            // &g_20 = g_(I02,i), &g_21 = g_(I12,i);
+            // &g_30 = g_(I03,i), &g_31 = g_(I13,i), &g_32 = g_(I23,i);
+            &g_11 = g_(I11,i), &g_12 = g_(I12,i), &g_13 = g_(I13,i),
+            &g_22 = g_(I22,i), &g_23 = g_(I23,i),
+            &g_33 = g_(I33,i);
+        const Real &g00 = g_inv_(I00,i), &g01 = g_inv_(I01,i), &g02 = g_inv_(I02,i),
+                   &g03 = g_inv_(I03,i), &g10 = g_inv_(I01,i), &g11 = g_inv_(I11,i),
+                   &g12 = g_inv_(I12,i), &g13 = g_inv_(I13,i), &g20 = g_inv_(I02,i),
+                   &g21 = g_inv_(I12,i), &g22 = g_inv_(I22,i), &g23 = g_inv_(I23,i),
+                   &g30 = g_inv_(I03,i), &g31 = g_inv_(I13,i), &g32 = g_inv_(I23,i),
+                   &g33 = g_inv_(I33,i);
         Real alpha = 1.0/std::sqrt(-g00);
-        Real alpha_2 = alpha * alpha;
 
         // Extract conserved quantities
-        Real rho_u0 = cons(IDN,k,j,i);
-        Real t0_0 = cons(IEN,k,j,i);
-        Real t0_1 = cons(IVX,k,j,i);
-        Real t0_2 = cons(IVY,k,j,i);
-        Real t0_3 = cons(IVZ,k,j,i);
+        const Real &rho_u0 = cons(IDN,k,j,i);
+        const Real &t0_0 = cons(IEN,k,j,i);
+        const Real &t0_1 = cons(IVX,k,j,i);
+        const Real &t0_2 = cons(IVY,k,j,i);
+        const Real &t0_3 = cons(IVZ,k,j,i);
 
         // Calculate variations on conserved quantities
-        Real d = alpha * rho_u0;  // (N 21)
-        Real q_n = - alpha_2 * (g00*t0_0 + g01*t0_1 + g02*t0_2 + g03*t0_3);
-        Real qq1 = alpha * (g10*t0_0 + g11*t0_1 + g12*t0_2 + g13*t0_3 - g01*q_n);
-        Real qq2 = alpha * (g20*t0_0 + g21*t0_1 + g22*t0_2 + g23*t0_3 - g02*q_n);
-        Real qq3 = alpha * (g30*t0_0 + g31*t0_1 + g32*t0_2 + g33*t0_3 - g03*q_n);
-        Real qq_sq = alpha_2 * (g00*t0_0*t0_0 + 2.0*g01*t0_0*t0_1 + 2.0*g02*t0_0*t0_2
-                                + 2.0*g03*t0_0*t0_3 + g11*t0_1*t0_1 + 2.0*g12*t0_1*t0_2
-                                + 2.0*g13*t0_1*t0_3 + g22*t0_2*t0_2 + 2.0*g23*t0_2*t0_3
-                                + g33*t0_3*t0_3) + SQR(q_n);
+        Real d = alpha * rho_u0;                                               // (N 21)
+        Real q_0 = alpha * t0_0;                                               // (N 17)
+        Real q_1 = alpha * t0_1;                                               // (N 17)
+        Real q_2 = alpha * t0_2;                                               // (N 17)
+        Real q_3 = alpha * t0_3;                                               // (N 17)
+        Real q_n = -alpha * (g00*q_0 + g01*q_1 + g02*q_2 + g03*q_3);
+        Real qq1 = g10*q_0 + g11*q_1 + g12*q_2 + g13*q_3 - alpha * g01 * q_n;
+        Real qq2 = g20*q_0 + g21*q_1 + g22*q_2 + g23*q_3 - alpha * g02 * q_n;
+        Real qq3 = g30*q_0 + g31*q_1 + g32*q_2 + g33*q_3 - alpha * g03 * q_n;
+        Real tmp1 = g00*q_0*q_0 + 2.0*g01*q_0*q_1 + 2.0*g02*q_0*q_2 + 2.0*g03*q_0*q_3
+                    + g11*q_1*q_1 + 2.0*g12*q_1*q_2 + 2.0*g13*q_1*q_3
+                    + g22*q_2*q_2 + 2.0*g23*q_2*q_3
+                    + g33*q_3*q_3;
+        Real tmp2 = alpha * (g00*q_0 + g01*q_1 + g02*q_2 + g03*q_3);
+        Real qq_sq = tmp1 + SQR(tmp2);
 
         // Extract old primitives
-        Real rho_old = prim_old(IDN,k,j,i);
-        Real pgas_old = prim_old(IPR,k,j,i);
-        Real uu1_old = prim_old(IVX,k,j,i);
-        Real uu2_old = prim_old(IVY,k,j,i);
-        Real uu3_old = prim_old(IVZ,k,j,i);
+        const Real &rho_old = prim_old(IDN,k,j,i);
+        const Real &pgas_old = prim_old(IPR,k,j,i);
+        const Real &uu1_old = prim_old(IVX,k,j,i);
+        const Real &uu2_old = prim_old(IVY,k,j,i);
+        const Real &uu3_old = prim_old(IVZ,k,j,i);
 
         // Construct initial guess for relativistic gas enthalpy W
         Real tmp = g_11*SQR(uu1_old) + 2.0*g_12*uu1_old*uu2_old + 2.0*g_13*uu1_old*uu3_old
@@ -141,7 +150,7 @@ void EquationOfState::ConservedToPrimitive(
                    + g_33*SQR(uu3_old);
         Real gamma_sq = 1.0 + tmp;
         Real wgas_rel_init =
-            gamma_sq * (rho_old + gamma_prime * pgas_old);
+            gamma_sq * (rho_old + gamma_adi/(gamma_adi-1.0) * pgas_old);
         for (int count = 0; count < initial_guess_multiplications; ++count) {
           if (SQR(wgas_rel_init) <= qq_sq) {  // v^2 >= 1 according to (N 28)
             wgas_rel_init *= initial_guess_multiplier;
@@ -178,14 +187,21 @@ void EquationOfState::ConservedToPrimitive(
         // unused:
         // Real u0 = gamma_rel/alpha;  // (N 21)
 
+        // Extract primitives
+        Real &rho = prim(IDN,k,j,i);
+        Real &pgas = prim(IPR,k,j,i);
+        Real &uu1 = prim(IVX,k,j,i);
+        Real &uu2 = prim(IVY,k,j,i);
+        Real &uu3 = prim(IVZ,k,j,i);
+
         // Set density and pressure
-        Real rho = d/gamma_rel;  // (N 21)
-        Real pgas = 1.0 / gamma_prime * (wgas_rel_true/gamma_sq - rho);  // (N 21,32)
+        rho = d/gamma_rel;                                                  // (N 21)
+        pgas = (gamma_adi-1.0)/gamma_adi * (wgas_rel_true/gamma_sq - rho);  // (N 21,32)
 
         // Set velocity
-        Real uu1 = gamma_rel * qq1 / wgas_rel_true;  // (N 31)
-        Real uu2 = gamma_rel * qq2 / wgas_rel_true;  // (N 31)
-        Real uu3 = gamma_rel * qq3 / wgas_rel_true;  // (N 31)
+        uu1 = gamma_rel * qq1 / wgas_rel_true;  // (N 31)
+        uu2 = gamma_rel * qq2 / wgas_rel_true;  // (N 31)
+        uu3 = gamma_rel * qq3 / wgas_rel_true;  // (N 31)
 
         // Apply floors to density and pressure
         Real density_floor_local = density_floor_;
@@ -209,19 +225,12 @@ void EquationOfState::ConservedToPrimitive(
 
         // Apply ceiling to velocity
         if (gamma_rel > gamma_max_) {
-          Real factor = std::sqrt(gamma_tmp / (SQR(gamma_rel)-1.0));
+          Real factor = std::sqrt((SQR(gamma_max_)-1.0) / (SQR(gamma_rel)-1.0));
           uu1 *= factor;
           uu2 *= factor;
           uu3 *= factor;
           fixed_(k,j,i) = true;
         }
-
-        // Set primitives quantities
-        prim(IDN,k,j,i) = rho;
-        prim(IPR,k,j,i) = pgas;
-        prim(IVX,k,j,i) = uu1;
-        prim(IVY,k,j,i) = uu2;
-        prim(IVZ,k,j,i) = uu3;
       }
     }
   }
@@ -232,7 +241,7 @@ void EquationOfState::ConservedToPrimitive(
       pco->CellMetric(k, j, il, iu, g_, g_inv_);
       for (int i=il; i<=iu; ++i) {
         if (fixed_(k,j,i)) {
-          PrimitiveToConservedSingle(prim, gamma_prime, g_, g_inv_, k, j, i, cons, pco);
+          PrimitiveToConservedSingle(prim, gamma_adi, g_, g_inv_, k, j, i, cons, pco);
           fixed_(k,j,i) = false;
         }
       }
@@ -253,25 +262,22 @@ void EquationOfState::ConservedToPrimitive(
 // Notes:
 //   single-cell function exists for other purposes; call made to that function rather
 //       than having duplicate code
-void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
-                                           const AthenaArray<Real> &bb_cc,
-                                           AthenaArray<Real> &cons, Coordinates *pco,
-                                           int il, int iu, int jl,
-                                           int ju, int kl, int ku) {
-  const Real gamma_adi = gamma_;
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
 
+void EquationOfState::PrimitiveToConserved(
+    const AthenaArray<Real> &prim,
+    const AthenaArray<Real> &bb_cc, AthenaArray<Real> &cons, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
       pco->CellMetric(k, j, il, iu, g_, g_inv_);
+      //#pragma omp simd // fn is too long to inline
       for (int i=il; i<=iu; ++i) {
-        PrimitiveToConservedSingle(prim, gamma_prime, g_, g_inv_, k, j, i, cons, pco);
+        PrimitiveToConservedSingle(prim, gamma_, g_, g_inv_, k, j, i, cons, pco);
       }
     }
   }
   return;
 }
-
 
 //----------------------------------------------------------------------------------------
 // Function for calculating relativistic sound speeds
@@ -290,12 +296,12 @@ void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
 
 void EquationOfState::SoundSpeedsSR(Real rho_h, Real pgas, Real vx, Real gamma_lorentz_sq,
                                     Real *plambda_plus, Real *plambda_minus) {
-  Real cs_sq = gamma_ * pgas / rho_h;                                 // (MB 4)
+  const Real gamma_adi = gamma_;
+  Real cs_sq = gamma_adi * pgas / rho_h;                                 // (MB 4)
   Real sigma_s = cs_sq / (gamma_lorentz_sq * (1.0-cs_sq));
   Real relative_speed = std::sqrt(sigma_s * (1.0 + sigma_s - SQR(vx)));
-  Real sigma_s_tmp = 1.0 / (1.0+sigma_s);
-  *plambda_plus = sigma_s_tmp * (vx + relative_speed);             // (MB 23)
-  *plambda_minus = sigma_s_tmp * (vx - relative_speed);            // (MB 23)
+  *plambda_plus = 1.0/(1.0+sigma_s) * (vx + relative_speed);             // (MB 23)
+  *plambda_minus = 1.0/(1.0+sigma_s) * (vx - relative_speed);            // (MB 23)
   return;
 }
 
@@ -318,9 +324,10 @@ void EquationOfState::SoundSpeedsGR(Real rho_h, Real pgas, Real u0, Real u1, Rea
                                     Real *plambda_plus, Real *plambda_minus) {
   // Parameters and constants
   const Real discriminant_tol = -1.0e-10;  // values between this and 0 are considered 0
+  const Real gamma_adi = gamma_;
 
   // Calculate comoving sound speed
-  Real cs_sq = gamma_ * pgas / rho_h;
+  Real cs_sq = gamma_adi * pgas / rho_h;
 
   // Set sound speeds in appropriate coordinates
   Real a = SQR(u0) - (g00 + SQR(u0)) * cs_sq;
@@ -344,25 +351,29 @@ void EquationOfState::SoundSpeedsGR(Real rho_h, Real pgas, Real u0, Real u1, Rea
 }
 
 namespace {
+
+//----------------------------------------------------------------------------------------
 // Function for converting primitives to conserved variables in a single cell
 // Inputs:
 //   prim: 3D array of primitives
 //   gamma_adi: ratio of specific heats
 //   g,gi: 1D arrays of metric covariant and contravariant coefficients
 //   k,j,i: indices of cell
-//   pco: pointer to Coordinate
+//   pco: pointer to Coordinates
 // Outputs:
 //   cons: conserved variables set in desired cell
-void PrimitiveToConservedSingle(const AthenaArray<Real> &prim, Real gamma_prime,
-                                const AthenaArray<Real> &g,
-                                const AthenaArray<Real> &gi, int k, int j, int i,
-                                AthenaArray<Real> &cons, Coordinates *pco) {
+
+void PrimitiveToConservedSingle(
+    const AthenaArray<Real> &prim, Real gamma_adi,
+    const AthenaArray<Real> &g, const AthenaArray<Real> &gi,
+    int k, int j, int i,
+    AthenaArray<Real> &cons, Coordinates *pco) {
   // Extract primitives
-  Real rho = prim(IDN,k,j,i);
-  Real pgas = prim(IPR,k,j,i);
-  Real uu1 = prim(IVX,k,j,i);
-  Real uu2 = prim(IVY,k,j,i);
-  Real uu3 = prim(IVZ,k,j,i);
+  const Real &rho = prim(IDN,k,j,i);
+  const Real &pgas = prim(IPR,k,j,i);
+  const Real &uu1 = prim(IVX,k,j,i);
+  const Real &uu2 = prim(IVY,k,j,i);
+  const Real &uu3 = prim(IVZ,k,j,i);
 
   // Calculate 4-velocity
   Real alpha = std::sqrt(-1.0/gi(I00,i));
@@ -377,14 +388,20 @@ void PrimitiveToConservedSingle(const AthenaArray<Real> &prim, Real gamma_prime,
   Real u_0, u_1, u_2, u_3;
   pco->LowerVectorCell(u0, u1, u2, u3, k, j, i, &u_0, &u_1, &u_2, &u_3);
 
-  // Set conserved quantities
-  Real wgas_u0 = (rho + gamma_prime * pgas) * u0;
-  cons(IDN,k,j,i) = rho * u0;
-  cons(IEN,k,j,i) = wgas_u0 * u_0 + pgas;
-  cons(IM1,k,j,i) = wgas_u0 * u_1;
-  cons(IM2,k,j,i) = wgas_u0 * u_2;
-  cons(IM3,k,j,i) = wgas_u0 * u_3;
+  // Extract conserved quantities
+  Real &rho_u0 = cons(IDN,k,j,i);
+  Real &t0_0 = cons(IEN,k,j,i);
+  Real &t0_1 = cons(IM1,k,j,i);
+  Real &t0_2 = cons(IM2,k,j,i);
+  Real &t0_3 = cons(IM3,k,j,i);
 
+  // Set conserved quantities
+  Real wgas = rho + gamma_adi/(gamma_adi-1.0) * pgas;
+  rho_u0 = rho * u0;
+  t0_0 = wgas * u0 * u_0 + pgas;
+  t0_1 = wgas * u0 * u_1;
+  t0_2 = wgas * u0 * u_2;
+  t0_3 = wgas * u0 * u_3;
   return;
 }
 

--- a/src/eos/adiabatic_mhd_gr.cpp
+++ b/src/eos/adiabatic_mhd_gr.cpp
@@ -16,7 +16,6 @@
 // Athena++ headers
 #include "../athena.hpp"                   // enums, macros
 #include "../athena_arrays.hpp"            // AthenaArray
-
 #include "../coordinates/coordinates.hpp"  // Coordinates
 #include "../field/field.hpp"              // FaceField
 #include "../mesh/mesh.hpp"                // MeshBlock
@@ -26,35 +25,20 @@
 namespace {
 // Declarations
 void CalculateNormalConserved(
-    const AthenaArray<Real> &cons,
-    const AthenaArray<Real> &bb,
+    const AthenaArray<Real> &cons, const AthenaArray<Real> &bb,
     const AthenaArray<Real> &g, const AthenaArray<Real> &gi,
-    int k, int j, int il, int iu,
-    AthenaArray<Real> &dd, AthenaArray<Real> &ee,
-    AthenaArray<Real> &mm, AthenaArray<Real> &bbb,
-    AthenaArray<Real> &tt);
-#pragma omp declare simd simdlen(SIMD_WIDTH)                            \
-  uniform(num_iterations,dd_vals,ee_vals,mm_vals,                       \
-          bb_vals,tt_vals,gamma_adi,k,j,prim,gamma_vals,pmag_vals) linear(i)
+    int k, int j, int il, int iu, AthenaArray<Real> &dd, AthenaArray<Real> &ee,
+    AthenaArray<Real> &mm, AthenaArray<Real> &bbb, AthenaArray<Real> &tt);
 bool ConservedToPrimitiveNormal(
-    const int num_iterations,
-    const AthenaArray<Real> &dd_vals,
-    const AthenaArray<Real> &ee_vals,
-    const AthenaArray<Real> &mm_vals,
-    const AthenaArray<Real> &bb_vals,
+    const AthenaArray<Real> &dd_vals, const AthenaArray<Real> &ee_vals,
+    const AthenaArray<Real> &mm_vals, const AthenaArray<Real> &bb_vals,
     const AthenaArray<Real> &tt_vals,
     Real gamma_adi, Real pgas_old,
-    int k, int j, int i, AthenaArray<Real> &prim,
-    AthenaArray<Real> &gamma_vals,
-    AthenaArray<Real> &pmag_vals);
-#pragma omp declare simd simdlen(SIMD_WIDTH)                    \
-  uniform(prim,gamma_adi,bb_cc,g, gi,k,j,cons,pco) linear(i)
+    int k, int j, int i, AthenaArray<Real> &prim, Real *p_gamma_lor, Real *p_pmag);
 void PrimitiveToConservedSingle(
-    const AthenaArray<Real> &prim, Real gamma_adi,
-    const AthenaArray<Real> &bb_cc,
+    const AthenaArray<Real> &prim, Real gamma_adi, const AthenaArray<Real> &bb_cc,
     const AthenaArray<Real> &g, const AthenaArray<Real> &gi,
-    int k, int j, int i,
-    AthenaArray<Real> &cons, Coordinates *pco);
+    int k, int j, int i, AthenaArray<Real> &cons, Coordinates *pco);
 } // namespace
 
 //----------------------------------------------------------------------------------------
@@ -78,18 +62,13 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
   int nc1 = pmb->ncells1;
   g_.NewAthenaArray(NMETRIC, nc1);
   g_inv_.NewAthenaArray(NMETRIC, nc1);
-  fixed_.NewAthenaArray(nc1);
-  success_.NewAthenaArray(nc1);
   normal_dd_.NewAthenaArray(nc1);
   normal_ee_.NewAthenaArray(nc1);
-  normal_mm_.NewAthenaArray(4, nc1);
-  normal_bb_.NewAthenaArray(4, nc1);
+  normal_mm_.NewAthenaArray(4,nc1);
+  normal_bb_.NewAthenaArray(4,nc1);
   normal_tt_.NewAthenaArray(nc1);
-  dens_floor_local_.NewAthenaArray(nc1);
-  press_floor_local_.NewAthenaArray(nc1);
-  normal_gamma_.NewAthenaArray(nc1);
-  pmag_.NewAthenaArray(nc1);
 }
+
 
 //----------------------------------------------------------------------------------------
 // Variable inverter
@@ -107,13 +86,11 @@ void EquationOfState::ConservedToPrimitive(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
     AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, Coordinates *pco,
     int il, int iu, int jl, int ju, int kl, int ku) {
-
   // Parameters
   const Real mm_sq_ee_sq_max = 1.0 - 1.0e-12;  // max. of squared momentum over energy
 
   // Extract ratio of specific heats
-  const Real gamma_adi = gamma_;
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
+  const Real &gamma_adi = gamma_;
 
   // Interpolate magnetic field from faces to cell centers
   pmy_block_->pfield->CalculateCellCenteredField(bb, bb_cc, pco, il, iu, jl, ju, kl, ku);
@@ -128,194 +105,167 @@ void EquationOfState::ConservedToPrimitive(
       CalculateNormalConserved(cons, bb_cc, g_, g_inv_, k, j, il, iu, normal_dd_,
                                normal_ee_, normal_mm_, normal_bb_, normal_tt_);
 
-      // Pass 1: Initial attempt at inversion
-#pragma omp simd simdlen(SIMD_WIDTH)
+      // Go through cells
       for (int i=il; i<=iu; ++i) {
         // Set flag indicating conserved values need adjusting at end
-        fixed_(i) = false;
+        bool fixed = false;
 
         // Calculate floors for density and pressure
-        dens_floor_local_(i) = density_floor_;
+        Real density_floor_local = density_floor_;
         if (rho_pow_ != 0.0) {
-          dens_floor_local_(i) =
-              std::max(dens_floor_local_(i), rho_min_ * std::pow(pco->x1v(i), rho_pow_));
+          density_floor_local =
+              std::max(density_floor_local, rho_min_ * std::pow(pco->x1v(i), rho_pow_));
         }
-        press_floor_local_(i) = pressure_floor_;
+        Real pressure_floor_local = pressure_floor_;
         if (pgas_pow_ != 0.0) {
-          press_floor_local_(i) = std::max(press_floor_local_(i),
-                                           pgas_min_ * std::pow(pco->x1v(i), pgas_pow_));
+          pressure_floor_local = std::max(pressure_floor_local,
+                                          pgas_min_ * std::pow(pco->x1v(i), pgas_pow_));
         }
 
         // Ensure conserved density is large enough
-        Real dd_min = dens_floor_local_(i);
+        Real dd_min = density_floor_local;
         if (normal_dd_(i) < dd_min) {
           normal_dd_(i) = dd_min;
-          fixed_(i) = true;
+          fixed = true;
         }
 
         // Ensure conserved energy is large enough
-        Real ee_min = dens_floor_local_(i) + press_floor_local_(i)/(gamma_adi-1.0)
+        Real ee_min = density_floor_local + pressure_floor_local/(gamma_adi-1.0)
                       + 0.5*normal_bb_(0,i);
         if (normal_ee_(i) < ee_min) {
           normal_ee_(i) = ee_min;
-          fixed_(i) = true;
+          fixed = true;
         }
 
         // Ensure conserved momentum is not too large given energy
         Real mm_sq_max = mm_sq_ee_sq_max * SQR(normal_ee_(i));
-        Real factor = std::sqrt(mm_sq_max/normal_mm_(0,i));
         if (normal_mm_(0,i) > mm_sq_max) {
+          Real factor = std::sqrt(mm_sq_max/normal_mm_(0,i));
           normal_mm_(0,i) = mm_sq_max;
           normal_mm_(1,i) *= factor;
           normal_mm_(2,i) *= factor;
           normal_mm_(3,i) *= factor;
           normal_tt_(i) *= factor;
-          fixed_(i) = true;
+          fixed = true;
         }
 
         // Set primitives
-        success_(i) = ConservedToPrimitiveNormal(3, normal_dd_, normal_ee_, normal_mm_,
-                                                 normal_bb_, normal_tt_, gamma_adi,
-                                                 prim_old(IPR,k,j,i),
-                                                 k, j, i, prim, normal_gamma_, pmag_);
-      }
+        Real gamma, pmag;
+        bool success = ConservedToPrimitiveNormal(normal_dd_, normal_ee_, normal_mm_,
+                                                  normal_bb_, normal_tt_, gamma_adi,
+                                                  prim_old(IPR,k,j,i), k, j, i, prim,
+                                                  &gamma, &pmag);
 
-      // Pass 2: Cleanup (most cells should be skipped)
-#pragma omp simd simdlen(SIMD_WIDTH)
-      for (int i=il; i<=iu; ++i) {
-        // Reapply iteration procedure in case convergence not attained (possibly slow)
-        if (!success_(i)) {
-          success_(i) = ConservedToPrimitiveNormal(7, normal_dd_, normal_ee_, normal_mm_,
-                                                   normal_bb_, normal_tt_, gamma_adi,
-                                                   prim(IPR,k,j,i),
-                                                   k, j, i, prim, normal_gamma_, pmag_);
-        }
-      }
-
-      // Pass 3: Density and pressure floors, and possible re-inversion
-//#pragma omp simd simdlen(SIMD_WIDTH) // this leads to memory corruption
-      for (int i=il; i<=iu; ++i) {
         // Handle failures
-        if (!success_(i)) {
+        if (!success) {
           for (int n = 0; n < NHYDRO; ++n) {
             prim(n,k,j,i) = prim_old(n,k,j,i);
           }
-          fixed_(i) = true;
+          fixed = true;
         }
 
-        // Apply primitive density and gas pressure floors
+        // Apply density and gas pressure floors in normal frame
         if (sigma_max_ > 0.0) {
-          dens_floor_local_(i) = std::max(dens_floor_local_(i), 2.0*pmag_(i)/sigma_max_);
+          density_floor_local = std::max(density_floor_local, 2.0*pmag/sigma_max_);
         }
         if (beta_min_ > 0.0) {
-          press_floor_local_(i) = std::max(press_floor_local_(i), beta_min_*pmag_(i));
+          pressure_floor_local = std::max(pressure_floor_local, beta_min_*pmag);
         }
-        Real rho_add = std::max(dens_floor_local_(i) - prim(IDN,k,j,i), 0.0);
-        Real pgas_add = std::max(press_floor_local_(i) - prim(IPR,k,j,i), 0.0);
-        Real wgas_add = rho_add + gamma_prime * pgas_add;
-
-        // Adjust normal frame conserved quantities, and recalculate primitives
-        if (success_(i) && (rho_add > 0.0 || pgas_add > 0.0)) {
+        Real rho_add = std::max(density_floor_local-prim(IDN,k,j,i), 0.0);
+        Real pgas_add = std::max(pressure_floor_local-prim(IPR,k,j,i), 0.0);
+        if (success && (rho_add > 0.0 || pgas_add > 0.0)) {
           // Adjust conserved density and energy
-          normal_dd_(i) += rho_add * normal_gamma_(i);
-          normal_ee_(i) += wgas_add * SQR(normal_gamma_(i)) + pgas_add;
+          Real wgas_add = rho_add + gamma_adi/(gamma_adi-1.0) * pgas_add;
+          normal_dd_(i) += rho_add * gamma;
+          normal_ee_(i) += wgas_add * SQR(gamma) + pgas_add;
 
           // Recalculate primitives
-          success_(i) = ConservedToPrimitiveNormal(10, normal_dd_, normal_ee_, normal_mm_,
-                                                   normal_bb_, normal_tt_, gamma_adi,
-                                                   prim_old(IPR,k,j,i), k, j, i, prim,
-                                                   normal_gamma_, pmag_);
+          success = ConservedToPrimitiveNormal(normal_dd_, normal_ee_, normal_mm_,
+                                               normal_bb_, normal_tt_, gamma_adi,
+                                               prim_old(IPR,k,j,i), k, j, i, prim,
+                                               &gamma, &pmag);
 
           // Handle failures
-          if (!success_(i)) {
+          if (!success) {
             for (int n = 0; n < NHYDRO; ++n) {
               prim(n,k,j,i) = prim_old(n,k,j,i);
             }
           }
-          fixed_(i) = true;
+          fixed = true;
         }
-      }
 
-      // Pass 4: Velocity ceiling
-#pragma omp simd simdlen(SIMD_WIDTH)
-      for (int i=il; i<=iu; ++i) {
         // Apply velocity ceiling
         Real &uu1 = prim(IVX,k,j,i);
         Real &uu2 = prim(IVY,k,j,i);
         Real &uu3 = prim(IVZ,k,j,i);
-        Real tmp = g_(I11,i)*SQR(uu1) + 2.0*g_(I12,i)*uu1*uu2 + 2.0*g_(I13,i)*uu1*uu3
-                   + g_(I22,i)*SQR(uu2) + 2.0*g_(I23,i)*uu2*uu3
-                   + g_(I33,i)*SQR(uu3);
-        if (!success_(i)) {
-          normal_gamma_(i) = std::sqrt(1.0 + tmp);
+        if (!success) {
+          Real tmp = g_(I11,i)*SQR(uu1) + 2.0*g_(I12,i)*uu1*uu2 + 2.0*g_(I13,i)*uu1*uu3
+                     + g_(I22,i)*SQR(uu2) + 2.0*g_(I23,i)*uu2*uu3
+                     + g_(I33,i)*SQR(uu3);
+          gamma = std::sqrt(1.0 + tmp);
         }
         bool velocity_ceiling = false;
-        Real factor = std::sqrt((SQR(gamma_max_)-1.0) / (SQR(normal_gamma_(i))-1.0));
-        if (normal_gamma_(i) > gamma_max_) {
+        if (gamma > gamma_max_) {
+          Real factor = std::sqrt((SQR(gamma_max_)-1.0) / (SQR(gamma)-1.0));
           uu1 *= factor;
           uu2 *= factor;
           uu3 *= factor;
-          fixed_(i) = true;
+          fixed = true;
           velocity_ceiling = true;
         }
 
-        // Calculate b^0 (only needed if velocity_ceiling == true)
-        Real alpha = std::sqrt(-1.0/g_inv_(I00,i));
-        Real u0 = normal_gamma_(i)/alpha;
-        Real u1 = uu1 - alpha * normal_gamma_(i) * g_inv_(I01,i);
-        Real u2 = uu2 - alpha * normal_gamma_(i) * g_inv_(I02,i);
-        Real u3 = uu3 - alpha * normal_gamma_(i) * g_inv_(I03,i);
-        const Real &bb1 = bb_cc(IB1,k,j,i);
-        const Real &bb2 = bb_cc(IB2,k,j,i);
-        const Real &bb3 = bb_cc(IB3,k,j,i);
-        Real b0 = g_(I01,i)*u0*bb1 + g_(I02,i)*u0*bb2 + g_(I03,i)*u0*bb3
-                  + g_(I11,i)*u1*bb1 + g_(I12,i)*u1*bb2 + g_(I13,i)*u1*bb3
-                  + g_(I12,i)*u2*bb1 + g_(I22,i)*u2*bb2 + g_(I23,i)*u2*bb3
-                  + g_(I13,i)*u3*bb1 + g_(I23,i)*u3*bb2 + g_(I33,i)*u3*bb3;
-
         // Recalculate density and pressure floors given new velocity
         if (velocity_ceiling) {
-          pmag_(i) = 0.5 * (normal_bb_(0,i)/SQR(normal_gamma_(i)) + SQR(b0/u0));
+          Real alpha = std::sqrt(-1.0/g_inv_(I00,i));
+          Real u0 = gamma/alpha;
+          Real u1 = uu1 - alpha * gamma * g_inv_(I01,i);
+          Real u2 = uu2 - alpha * gamma * g_inv_(I02,i);
+          Real u3 = uu3 - alpha * gamma * g_inv_(I03,i);
+          const Real &bb1 = bb_cc(IB1,k,j,i);
+          const Real &bb2 = bb_cc(IB2,k,j,i);
+          const Real &bb3 = bb_cc(IB3,k,j,i);
+          Real b0 = g_(I01,i)*u0*bb1 + g_(I02,i)*u0*bb2 + g_(I03,i)*u0*bb3
+                    + g_(I11,i)*u1*bb1 + g_(I12,i)*u1*bb2 + g_(I13,i)*u1*bb3
+                    + g_(I12,i)*u2*bb1 + g_(I22,i)*u2*bb2 + g_(I23,i)*u2*bb3
+                    + g_(I13,i)*u3*bb1 + g_(I23,i)*u3*bb2 + g_(I33,i)*u3*bb3;
+          pmag = 0.5 * (normal_bb_(0,i)/SQR(gamma) + SQR(b0/u0));
         }
-        dens_floor_local_(i) = density_floor_;
+        density_floor_local = density_floor_;
         if (rho_pow_ != 0.0) {
-          dens_floor_local_(i) =
-              std::max(dens_floor_local_(i), rho_min_ * std::pow(pco->x1v(i), rho_pow_));
+          density_floor_local =
+              std::max(density_floor_local, rho_min_ * std::pow(pco->x1v(i), rho_pow_));
         }
         if (sigma_max_ > 0.0) {
-          dens_floor_local_(i) = std::max(dens_floor_local_(i), 2.0*pmag_(i)/sigma_max_);
+          density_floor_local = std::max(density_floor_local, 2.0*pmag/sigma_max_);
         }
-        press_floor_local_(i) = pressure_floor_;
+        pressure_floor_local = pressure_floor_;
         if (pgas_pow_ != 0.0) {
-          press_floor_local_(i) = std::max(press_floor_local_(i),
-                                           pgas_min_ * std::pow(pco->x1v(i), pgas_pow_));
+          pressure_floor_local = std::max(pressure_floor_local,
+                                          pgas_min_ * std::pow(pco->x1v(i), pgas_pow_));
         }
         if (beta_min_ > 0.0) {
-          press_floor_local_(i) = std::max(press_floor_local_(i), beta_min_*pmag_(i));
+          pressure_floor_local = std::max(pressure_floor_local, beta_min_*pmag);
         }
 
         // Apply density and gas pressure floors in fluid frame
         Real &rho = prim(IDN,k,j,i);
         Real &pgas = prim(IPR,k,j,i);
-        if (rho < dens_floor_local_(i)) {
-          rho = dens_floor_local_(i);
-          fixed_(i) = true;
+        if (rho < density_floor_local) {
+          rho = density_floor_local;
+          fixed = true;
         }
-        if (pgas < press_floor_local_(i)) {
-          pgas = press_floor_local_(i);
-          fixed_(i) = true;
+        if (pgas < pressure_floor_local) {
+          pgas = pressure_floor_local;
+          fixed = true;
         }
-        if (!success_(i)) {
-          rho = dens_floor_local_(i);
-          pgas = press_floor_local_(i);
+        if (!success) {
+          rho = density_floor_local;
+          pgas = pressure_floor_local;
           uu1 = uu2 = uu3 = 0.0;
         }
-      }
 
-      // Pass 5: Consistency check
-#pragma omp simd simdlen(SIMD_WIDTH)
-      for (int i=il; i<=iu; ++i) {
-        if (fixed_(i)) {
+        // Ensure conserved variables match primitives
+        if (fixed) {
           PrimitiveToConservedSingle(prim, gamma_adi, bb_cc, g_, g_inv_, k, j, i, cons,
                                      pco);
         }
@@ -324,7 +274,6 @@ void EquationOfState::ConservedToPrimitive(
   }
   return;
 }
-
 
 //----------------------------------------------------------------------------------------
 // Function for converting all primitives to conserved variables
@@ -341,14 +290,12 @@ void EquationOfState::ConservedToPrimitive(
 
 void EquationOfState::PrimitiveToConserved(
     const AthenaArray<Real> &prim,
-    const AthenaArray<Real> &bb_cc,
-    AthenaArray<Real> &cons, Coordinates *pco,
-    int il, int iu, int jl,
-    int ju, int kl, int ku) {
+    const AthenaArray<Real> &bb_cc, AthenaArray<Real> &cons, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
       pco->CellMetric(k, j, il, iu, g_, g_inv_);
-#pragma omp simd simdlen(SIMD_WIDTH)
+      //#pragma omp simd // fn is too long to inline
       for (int i=il; i<=iu; ++i) {
         PrimitiveToConservedSingle(prim, gamma_, bb_cc, g_, g_inv_, k, j, i, cons, pco);
       }
@@ -356,7 +303,6 @@ void EquationOfState::PrimitiveToConserved(
   }
   return;
 }
-
 
 namespace {
 
@@ -385,49 +331,54 @@ namespace {
 void CalculateNormalConserved(
     const AthenaArray<Real> &cons, const AthenaArray<Real> &bb,
     const AthenaArray<Real> &g, const AthenaArray<Real> &gi,
-    int k, int j, int il, int iu, AthenaArray<Real> &dd, AthenaArray<Real> &ee,
+    int k, int j, int il, int iu,
+    AthenaArray<Real> &dd, AthenaArray<Real> &ee,
     AthenaArray<Real> &mm, AthenaArray<Real> &bbb, AthenaArray<Real> &tt) {
   // Go through row
-#pragma omp simd simdlen(SIMD_WIDTH)
   for (int i=il; i<=iu; ++i) {
     // Extract metric
-    Real g_11 = g(I11,i), g_12 = g(I12,i), g_13 = g(I13,i),
-         g_21 = g(I12,i), g_22 = g(I22,i), g_23 = g(I23,i),
-         g_31 = g(I13,i), g_32 = g(I23,i), g_33 = g(I33,i);
-    Real g00 = gi(I00,i), g01 = gi(I01,i), g02 = gi(I02,i), g03 = gi(I03,i),
-         g10 = gi(I01,i), g11 = gi(I11,i), g12 = gi(I12,i), g13 = gi(I13,i),
-         g20 = gi(I02,i), g21 = gi(I12,i), g22 = gi(I22,i), g23 = gi(I23,i),
-         g30 = gi(I03,i), g31 = gi(I13,i), g32 = gi(I23,i), g33 = gi(I33,i);
+    const Real &g_11 = g(I11,i), &g_12 = g(I12,i), &g_13 = g(I13,i),
+               &g_21 = g(I12,i), &g_22 = g(I22,i), &g_23 = g(I23,i),
+               &g_31 = g(I13,i), &g_32 = g(I23,i), &g_33 = g(I33,i);
+    const Real &g00 = gi(I00,i), &g01 = gi(I01,i), &g02 = gi(I02,i), &g03 = gi(I03,i),
+               &g10 = gi(I01,i), &g11 = gi(I11,i), &g12 = gi(I12,i), &g13 = gi(I13,i),
+               &g20 = gi(I02,i), &g21 = gi(I12,i), &g22 = gi(I22,i), &g23 = gi(I23,i),
+               &g30 = gi(I03,i), &g31 = gi(I13,i), &g32 = gi(I23,i), &g33 = gi(I33,i);
 
     // Calculate unit timelike normal
     const Real alpha = std::sqrt(-1.0/g00);
-    const Real alpha_2 = alpha * alpha;
+    const Real n0 = -alpha * g00;
+    const Real n1 = -alpha * g01;
+    const Real n2 = -alpha * g02;
+    const Real n3 = -alpha * g03;
 
     // Calculate projection operator
-    const Real j10 = g10 + alpha_2*g01*g00, j20 = g20 + alpha_2*g02*g00,
-               j30 = g30 + alpha_2*g03*g00, j11 = g11 + alpha_2*g01*g01,
-               j21 = g21 + alpha_2*g02*g01, j31 = g31 + alpha_2*g03*g01,
-               j12 = g12 + alpha_2*g01*g02, j22 = g22 + alpha_2*g02*g02,
-               j32 = g32 + alpha_2*g03*g02, j13 = g13 + alpha_2*g01*g03,
-               j23 = g23 + alpha_2*g02*g03, j33 = g33 + alpha_2*g03*g03;
+    const Real j10 = g10 + n1*n0, j20 = g20 + n2*n0, j30 = g30 + n3*n0;
+    const Real j11 = g11 + n1*n1, j21 = g21 + n2*n1, j31 = g31 + n3*n1;
+    const Real j12 = g12 + n1*n2, j22 = g22 + n2*n2, j32 = g32 + n3*n2;
+    const Real j13 = g13 + n1*n3, j23 = g23 + n2*n3, j33 = g33 + n3*n3;
 
     // Extract conserved quantities
-    Real rho_u0 = cons(IDN,k,j,i);
-    Real t0_0 = cons(IEN,k,j,i);
-    Real t0_1 = cons(IVX,k,j,i);
-    Real t0_2 = cons(IVY,k,j,i);
-    Real t0_3 = cons(IVZ,k,j,i);
-    Real bb1 = bb(IB1,k,j,i);
-    Real bb2 = bb(IB2,k,j,i);
-    Real bb3 = bb(IB3,k,j,i);
+    const Real &rho_u0 = cons(IDN,k,j,i);
+    const Real &t0_0 = cons(IEN,k,j,i);
+    const Real &t0_1 = cons(IVX,k,j,i);
+    const Real &t0_2 = cons(IVY,k,j,i);
+    const Real &t0_3 = cons(IVZ,k,j,i);
+    const Real &bb1 = bb(IB1,k,j,i);
+    const Real &bb2 = bb(IB2,k,j,i);
+    const Real &bb3 = bb(IB3,k,j,i);
 
     // Calculate projected momentum densities Q_\mu = -n_\nu T^\nu_\mu (N 17)
-    const Real qq_n = -alpha_2*(t0_0*g00 + t0_1*g01 + t0_2*g02 + t0_3*g03);
+    const Real qq_0 = alpha * t0_0;
+    const Real qq_1 = alpha * t0_1;
+    const Real qq_2 = alpha * t0_2;
+    const Real qq_3 = alpha * t0_3;
+    const Real qq_n = qq_0*n0 + qq_1*n1 + qq_2*n2 + qq_3*n3;
 
     // Calculate projected momentum M^i = j^{i\mu} Q_\mu
-    const Real mm1 = alpha*(j10*t0_0 + j11*t0_1 + j12*t0_2 + j13*t0_3);
-    const Real mm2 = alpha*(j20*t0_0 + j21*t0_1 + j22*t0_2 + j23*t0_3);
-    const Real mm3 = alpha*(j30*t0_0 + j31*t0_1 + j32*t0_2 + j33*t0_3);
+    const Real mm1 = j10*qq_0 + j11*qq_1 + j12*qq_2 + j13*qq_3;
+    const Real mm2 = j20*qq_0 + j21*qq_1 + j22*qq_2 + j23*qq_3;
+    const Real mm3 = j30*qq_0 + j31*qq_1 + j32*qq_2 + j33*qq_3;
 
     // Calculate projected field \mathcal{B}^i = alpha B^i (N 5)
     const Real bbb1 = alpha * bb1;
@@ -457,12 +408,12 @@ void CalculateNormalConserved(
 }
 
 //----------------------------------------------------------------------------------------
-// Function for calculating primitives in normal observer frame: cleanup passes
+// Function for calculating primitives in normal observer frame
 // Inputs:
 //   dd_vals: array of conserved densities
 //   ee_vals: array of conserved energies
 //   mm_vals: array of conserved momenta \mathcal{M}^2, M^i
-//   bb_vals: array of magnetic fields \mathcal{B}^2, B^i
+//   bb_vals: array of magnetic fields \mathcal{B{^2, B^i
 //   tt_vals: array of M_i B^i values
 //   gamma_adi: ratio of specific heats
 //   pgas_old: previous value of p_{gas} used to initialize iteration
@@ -470,8 +421,8 @@ void CalculateNormalConserved(
 // Outputs:
 //   returned value: true for successful convergence, false otherwise
 //   prim: all values set in given cell
-//   gamma_vals: normal-frame Lorentz factor set in given cell
-//   pmag_vals: magnetic pressure set in given cell
+//   p_gamma_lor: normal-frame Lorentz factor
+//   p_pmag: magnetic pressure
 // Notes:
 //   generalizes Newman & Hamlin 2014, SIAM J. Sci. Comput. 36(4) B661 (NH)
 //     like SR, but all 3-vector operations done with respect to g_{ij} rather than
@@ -486,20 +437,15 @@ void CalculateNormalConserved(
 //     ll: \mathcal{L}
 //     wgas: w_{gas} (NH: w)
 //     rr: \mathcal{R}
-//   same exact function as ConservedToPrimitiveNormalInitial(), except this does 7
-//       iterations
 
 bool ConservedToPrimitiveNormal(
-    const int num_iterations,
-    const AthenaArray<Real> &dd_vals,
-    const AthenaArray<Real> &ee_vals,
-    const AthenaArray<Real> &mm_vals,
-    const AthenaArray<Real> &bb_vals,
-    const AthenaArray<Real> &tt_vals,
-    Real gamma_adi, Real pgas_old, int k, int j, int i,
-    AthenaArray<Real> &prim, AthenaArray<Real> &gamma_vals,
-    AthenaArray<Real> &pmag_vals) {
+    const AthenaArray<Real> &dd_vals, const AthenaArray<Real> &ee_vals,
+    const AthenaArray<Real> &mm_vals, const AthenaArray<Real> &bb_vals,
+    const AthenaArray<Real> &tt_vals, Real gamma_adi, Real pgas_old,
+    int k, int j, int i,
+    AthenaArray<Real> &prim, Real *p_gamma_lor, Real *p_pmag) {
   // Parameters
+  const int max_iterations = 10;
   const Real tol = 1.0e-12;
   const Real pgas_uniform_min = 1.0e-12;
   const Real a_min = 1.0e-12;
@@ -519,11 +465,8 @@ bool ConservedToPrimitiveNormal(
   const Real &bb3 = bb_vals(3,i);
   const Real &tt = tt_vals(i);
 
-  // Precompute function of adiabatic index
-  Real gamma_prime_inv = (gamma_adi-1.0) / gamma_adi;
-
   // Calculate functions of conserved quantities
-  Real d = 0.5 * (mm_sq * bb_sq - SQR(tt));                  // (NH 5.7)
+  Real d = 0.5 * (mm_sq * bb_sq - SQR(tt));             // (NH 5.7)
   d = std::max(d, 0.0);
   Real pgas_min = std::cbrt(27.0/4.0 * d) - ee - 0.5*bb_sq;
   pgas_min = std::max(pgas_min, pgas_uniform_min);
@@ -531,80 +474,96 @@ bool ConservedToPrimitiveNormal(
   // Iterate until convergence
   Real pgas[3];
   pgas[0] = std::max(pgas_old, pgas_min);
-  for (int n = 0; n < num_iterations; ++n) {
-    // Iterate normally for 2 out of every 3 times
+  int n;
+  for (n = 0; n < max_iterations; ++n) {
+    // Step 1: Calculate cubic coefficients
+    Real a;
     if (n%3 != 2) {
-      // Step 1: Calculate cubic coefficients
-      Real a = ee + pgas[n%3] + 0.5*bb_sq;  // (NH 5.7)
+      a = ee + pgas[n%3] + 0.5*bb_sq;  // (NH 5.7)
       a = std::max(a, a_min);
+    }
 
-      // Step 2: Calculate correct root of cubic equation
-      Real phi = std::acos(1.0/a * std::sqrt(27.0*d/(4.0*a)));        // (NH 5.10)
-      Real eee = a/3.0 - 2.0/3.0 * a * std::cos(2.0/3.0 * (phi+PI));  // (NH 5.11)
-      Real ll = eee - bb_sq;                                          // (NH 5.5)
-      Real v_sq = (mm_sq*SQR(ll) + SQR(tt)*(bb_sq+2.0*ll))
-                  / SQR(ll * (bb_sq+ll));                             // (NH 5.2)
+    // Step 2: Calculate correct root of cubic equation
+    Real phi, eee, ll, v_sq;
+    if (n%3 != 2) {
+      phi = std::acos(1.0/a * std::sqrt(27.0*d/(4.0*a)));                     // (NH 5.10)
+      eee = a/3.0 - 2.0/3.0 * a * std::cos(2.0/3.0 * (phi+PI));               // (NH 5.11)
+      ll = eee - bb_sq;                                                       // (NH 5.5)
+      v_sq = (mm_sq*SQR(ll) + SQR(tt)*(bb_sq+2.0*ll)) / SQR(ll * (bb_sq+ll)); // (NH 5.2)
       v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
-      Real gamma_sq = 1.0/(1.0-v_sq);                                 // (NH 3.1)
-      Real gamma = std::sqrt(gamma_sq);                               // (NH 3.1)
-      pgas[(n+1)%3] = gamma_prime_inv * (ll/gamma_sq - dd/gamma);     // (NH 4.1)
+      Real gamma_sq = 1.0/(1.0-v_sq);                                         // (NH 3.1)
+      Real gamma = std::sqrt(gamma_sq);                                       // (NH 3.1)
+      Real wgas = ll/gamma_sq;                                                // (NH 5.1)
+      Real rho = dd/gamma;                                                    // (NH 4.5)
+      pgas[(n+1)%3] = (gamma_adi-1.0)/gamma_adi * (wgas - rho);               // (NH 4.1)
       pgas[(n+1)%3] = std::max(pgas[(n+1)%3], pgas_min);
+    }
 
-      // Every third iteration, apply Aitken acceleration instead
-    } else {
-      // Step 4: Calculate Aitken accelerant and check for convergence
+    // Step 3: Check for convergence
+    if (n%3 != 2) {
+      if (pgas[(n+1)%3] > pgas_min && std::abs(pgas[(n+1)%3]-pgas[n%3]) < tol) {
+        break;
+      }
+    }
+
+    // Step 4: Calculate Aitken accelerant and check for convergence
+    if (n%3 == 2) {
       Real rr = (pgas[2] - pgas[1]) / (pgas[1] - pgas[0]);  // (NH 7.1)
-      if (std::abs(rr) < rr_max + tol) {
-        pgas[0] = pgas[1] + (pgas[2] - pgas[1]) / (1.0 - rr);  // (NH 7.2)
-        pgas[0] = std::max(pgas[0], pgas_min);
+      if (!std::isfinite(rr) || std::abs(rr) > rr_max) {
+        continue;
+      }
+      pgas[0] = pgas[1] + (pgas[2] - pgas[1]) / (1.0 - rr);  // (NH 7.2)
+      pgas[0] = std::max(pgas[0], pgas_min);
+      if (pgas[0] > pgas_min && std::abs(pgas[0]-pgas[2]) < tol) {
+        break;
       }
     }
   }
 
-  // Step 3: Check for convergence
-  bool success=true;
-  if (pgas[num_iterations%3] < pgas_min ||
-      std::abs(pgas[num_iterations%3]-pgas[(num_iterations-1)%3]) > tol) {
-    success = false;
-  }
-
   // Step 5: Set primitives
-  prim(IPR,k,j,i) = pgas[num_iterations%3];
+  if (n == max_iterations) {
+    return false;
+  }
+  prim(IPR,k,j,i) = pgas[(n+1)%3];
+  if (!std::isfinite(prim(IPR,k,j,i))) {
+    return false;
+  }
   Real a = ee + prim(IPR,k,j,i) + 0.5*bb_sq;                      // (NH 5.7)
   a = std::max(a, a_min);
   Real phi = std::acos(1.0/a * std::sqrt(27.0*d/(4.0*a)));        // (NH 5.10)
   Real eee = a/3.0 - 2.0/3.0 * a * std::cos(2.0/3.0 * (phi+PI));  // (NH 5.11)
   Real ll = eee - bb_sq;                                          // (NH 5.5)
   Real v_sq = (mm_sq*SQR(ll) + SQR(tt)*(bb_sq+2.0*ll))
-              / SQR(ll * (bb_sq+ll));                                     // (NH 5.2)
+              / SQR(ll * (bb_sq+ll));                             // (NH 5.2)
   v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
   Real gamma_sq = 1.0/(1.0-v_sq);                                 // (NH 3.1)
   Real gamma = std::sqrt(gamma_sq);                               // (NH 3.1)
-  prim(IDN,k,j,i) = dd/gamma;
-  Real ss = tt/ll;                                                // (NH 4.8)
-  Real eee_inv = 1.0/eee;
-  Real gamma_v1 = gamma * (mm1 + ss*bb1) * eee_inv;               // (NH 4.6, 5.5)
-  Real gamma_v2 = gamma * (mm2 + ss*bb2) * eee_inv;               // (NH 4.6, 5.5)
-  Real gamma_v3 = gamma * (mm3 + ss*bb3) * eee_inv;               // (NH 4.6, 5.5)
-  prim(IVX,k,j,i) = gamma_v1;                                     // (NH 3.3)
-  prim(IVY,k,j,i) = gamma_v2;                                     // (NH 3.3)
-  prim(IVZ,k,j,i) = gamma_v3;                                     // (NH 3.3)
-  if (!std::isfinite(prim(IPR,k,j,i))
-      || !std::isfinite(prim(IDN,k,j,i))
-      || !std::isfinite(prim(IVX,k,j,i))
+  //Real wgas = ll/gamma_sq;                                      // (NH 5.1); unused var
+  prim(IDN,k,j,i) = dd/gamma;                                     // (NH 4.5)
+  if (!std::isfinite(prim(IDN,k,j,i))) {
+    return false;
+  }
+  Real ss = tt/ll;                          // (NH 4.8)
+  Real v1 = (mm1 + ss*bb1) / (ll + bb_sq);  // (NH 4.6)
+  Real v2 = (mm2 + ss*bb2) / (ll + bb_sq);  // (NH 4.6)
+  Real v3 = (mm3 + ss*bb3) / (ll + bb_sq);  // (NH 4.6)
+  prim(IVX,k,j,i) = gamma*v1;               // (NH 3.3)
+  prim(IVY,k,j,i) = gamma*v2;               // (NH 3.3)
+  prim(IVZ,k,j,i) = gamma*v3;               // (NH 3.3)
+  if (!std::isfinite(prim(IVX,k,j,i))
       || !std::isfinite(prim(IVY,k,j,i))
       || !std::isfinite(prim(IVZ,k,j,i))) {
-    success = false;
+    return false;
   }
-  gamma_vals(i) = gamma;
-  pmag_vals(i) = 0.5 * (bb_sq/gamma_sq + SQR(ss));                // (NH 3.7, 3.11)
-  return success;
+  *p_gamma_lor = gamma;
+  *p_pmag = 0.5 * (bb_sq/gamma_sq + SQR(ss));  // (NH 3.7, 3.11)
+  return true;
 }
 
 //----------------------------------------------------------------------------------------
 // Function for converting primitives to conserved variables in a single cell
 // Inputs:
-//   prim: 1D array of primitives
+//   prim: 3D array of primitives
 //   gamma_adi: ratio of specific heats
 //   bb_cc: 3D array of cell-centered magnetic field
 //   g,gi: 1D arrays of metric covariant and contravariant coefficients
@@ -614,9 +573,10 @@ bool ConservedToPrimitiveNormal(
 //   cons: conserved variables set in desired cell
 
 void PrimitiveToConservedSingle(
-    const AthenaArray<Real> &prim, Real gamma_adi, const AthenaArray<Real> &bb_cc,
-    const AthenaArray<Real> &g, const AthenaArray<Real> &gi,
-    int k, int j, int i, AthenaArray<Real> &cons, Coordinates *pco) {
+    const AthenaArray<Real> &prim, Real gamma_adi,
+    const AthenaArray<Real> &bb_cc, const AthenaArray<Real> &g,
+    const AthenaArray<Real> &gi, int k, int j, int i, AthenaArray<Real> &cons,
+    Coordinates *pco) {
   // Extract primitives and magnetic fields
   const Real &rho = prim(IDN,k,j,i);
   const Real &pgas = prim(IPR,k,j,i);
@@ -627,7 +587,6 @@ void PrimitiveToConservedSingle(
   const Real &bb2 = bb_cc(IB2,k,j,i);
   const Real &bb3 = bb_cc(IB3,k,j,i);
 
-  Real gamma_prime =  gamma_adi/(gamma_adi-1.0);
   // Calculate 4-velocity
   Real alpha = std::sqrt(-1.0/gi(I00,i));
   Real tmp = g(I11,i)*uu1*uu1 + 2.0*g(I12,i)*uu1*uu2 + 2.0*g(I13,i)*uu1*uu3
@@ -661,13 +620,13 @@ void PrimitiveToConservedSingle(
   Real &t0_3 = cons(IM3,k,j,i);
 
   // Set conserved quantities
-  Real wtot_u0 = (rho + gamma_prime * pgas + b_sq) * u0;
+  Real wtot = rho + gamma_adi/(gamma_adi-1.0) * pgas + b_sq;
   Real ptot = pgas + 0.5 * b_sq;
   rho_u0 = rho * u0;
-  t0_0 = wtot_u0 * u_0 - b0 * b_0 + ptot;
-  t0_1 = wtot_u0 * u_1 - b0 * b_1;
-  t0_2 = wtot_u0 * u_2 - b0 * b_2;
-  t0_3 = wtot_u0 * u_3 - b0 * b_3;
+  t0_0 = wtot * u0 * u_0 - b0 * b_0 + ptot;
+  t0_1 = wtot * u0 * u_1 - b0 * b_1;
+  t0_2 = wtot * u0 * u_2 - b0 * b_2;
+  t0_3 = wtot * u0 * u_3 - b0 * b_3;
   return;
 }
 } // namespace
@@ -683,14 +642,19 @@ void PrimitiveToConservedSingle(
 // Outputs:
 //   lambdas_p,lambdas_m: 1D arrays set to +/- wavespeeds
 // Notes:
+//   references Mignone & Bodo 2005, MNRAS 364 126 (MB2005)
+//   references Mignone & Bodo 2006, MNRAS 368 1040 (MB2006)
+//   references Numerical Recipes, 3rd ed. (NR)
 //   follows advice in NR for avoiding large cancellations in solving quadratics
-//   uses same approximation as FastMagnetosonicSpeedsGR()
 //   almost same function as in adiabatic_mhd_sr.cpp
 
 void EquationOfState::FastMagnetosonicSpeedsSR(
     const AthenaArray<Real> &prim, const AthenaArray<Real> &bbx_vals,
     int k, int j, int il, int iu, int ivx,
     AthenaArray<Real> &lambdas_p, AthenaArray<Real> &lambdas_m) {
+  // Parameters
+  const double v_limit = 1.0e-12;  // squared velocities less than this are considered 0
+  const double b_limit = 1.0e-14;  // squared B^x less than this is considered 0
 
   // Calculate cyclic permutations of indices
   int ivy = IVX + ((ivx-IVX)+1)%3;
@@ -701,46 +665,157 @@ void EquationOfState::FastMagnetosonicSpeedsSR(
   const Real gamma_adi_red = gamma_adi/(gamma_adi-1.0);
 
   // Go through states
-#pragma omp simd simdlen(SIMD_WIDTH)
-  for (int i = il; i <= iu; ++i) {
+#pragma omp simd
+  for (int i=il; i<=iu; ++i) {
     // Extract primitives
-    Real rho = prim(IDN,i);
-    Real pgas = prim(IPR,i);
-    Real u1 = prim(ivx,i);
-    Real u2 = prim(ivy,i);
-    Real u3 = prim(ivz,i);
-    Real bb1 = bbx_vals(i);
-    Real bb2 = prim(IBY,i);
-    Real bb3 = prim(IBZ,i);
+    const Real &rho = prim(IDN,i);
+    const Real &pgas = prim(IPR,i);
+    Real u[4];
+    u[1] = prim(ivx,i);
+    u[2] = prim(ivy,i);
+    u[3] = prim(ivz,i);
+    u[0] = std::sqrt(1.0 + SQR(u[1]) + SQR(u[2]) + SQR(u[3]));
+    const Real &bbx = bbx_vals(i);
+    const Real &bby = prim(IBY,i);
+    const Real &bbz = prim(IBZ,i);
 
-    // Calculate Lorentz factor and (twice) magnetic pressure
-    Real u0 = std::sqrt(1.0 + SQR(u1) + SQR(u2) + SQR(u3));
-    Real b0 = bb1 * u1 + bb2 * u2 + bb3 * u3;
-    Real b1 = (bb1 + b0 * u1) / u0;
-    Real b2 = (bb2 + b0 * u2) / u0;
-    Real b3 = (bb3 + b0 * u3) / u0;
-    Real b_sq = -SQR(b0) + SQR(b1) + SQR(b2) + SQR(b3);
+    // Calculate 3-velocity
+    Real vx = u[1]/u[0];
+    Real vy = u[2]/u[0];
+    Real vz = u[3]/u[0];
 
-    // Calculate comoving fast magnetosonic speed
+    // Calculate contravariant magnetic field
+    Real b[4];
+    b[0] = bbx*u[1] + bby*u[2] + bbz*u[3];
+    b[1] = (bbx + b[0] * u[1]) / u[0];
+    b[2] = (bby + b[0] * u[2]) / u[0];
+    b[3] = (bbz + b[0] * u[3]) / u[0];
+
+    // Calculate intermediate quantities
+    Real v_sq = SQR(vx) + SQR(vy) + SQR(vz);
+    Real gamma_rel_sq = 1.0/(1.0-v_sq);
     Real w_gas = rho + gamma_adi_red * pgas;
-    Real cs_sq = gamma_adi * pgas / w_gas;
-    Real va_sq = b_sq / (w_gas + b_sq);
-    Real cms_sq = cs_sq + va_sq - cs_sq * va_sq;
+    Real cs_sq = gamma_adi * pgas / w_gas;                       // (MB2005 4)
+    Real b_sq = -SQR(b[0]) + SQR(b[1]) + SQR(b[2]) + SQR(b[3]);
+    Real bbx_sq = SQR(bbx);
 
-    // Set fast magnetosonic speeds in appropriate coordinates
-    Real a = SQR(u0) - (SQR(u0) - 1.0) * cms_sq;
-    Real b = -2.0 * u0 * u1 * (1.0 - cms_sq);
-    Real c = SQR(u1) - (SQR(u1) + 1.0) * cms_sq;
-    Real d = std::max(SQR(b) - 4.0 * a * c, 0.0);
-    Real d_sqrt = std::sqrt(d);
-    Real root_1 = (-b + d_sqrt) / (2.0*a);
-    Real root_2 = (-b - d_sqrt) / (2.0*a);
-    if (root_1 > root_2) {
-      lambdas_p(i) = root_1;
-      lambdas_m(i) = root_2;
+    // Calculate wavespeeds in vanishing velocity case (MB2006 57)
+    Real lambda_plus_no_v, lambda_minus_no_v;
+    {
+      Real w_tot = w_gas + b_sq;
+      Real a1 = -(b_sq + cs_sq * (w_gas + bbx_sq)) / w_tot;
+      Real a0 = cs_sq * bbx_sq / w_tot;
+      Real s2 = SQR(a1) - 4.0*a0;
+      Real s = (s2 > 0.0) ? std::sqrt(s2) : 0.0;
+      Real lambda_sq = 0.5 * (-a1 + s);
+      lambda_plus_no_v = std::sqrt(lambda_sq);
+      lambda_minus_no_v = -lambda_plus_no_v;
+    }
+
+    // Calculate wavespeeds in vanishing normal field case (MB2006 58)
+    Real lambda_plus_no_bbx, lambda_minus_no_bbx;
+    {
+      Real vx_sq = SQR(vx);
+      Real v_dot_bb_perp = vy*bby + vz*bbz;
+      Real q = b_sq - cs_sq*SQR(v_dot_bb_perp);
+      Real denominator = w_gas * (cs_sq + gamma_rel_sq*(1.0-cs_sq)) + q;
+      Real a1 = -2.0 * w_gas * gamma_rel_sq * vx * (1.0-cs_sq) / denominator;
+      Real a0 = (w_gas * (-cs_sq + gamma_rel_sq*vx_sq*(1.0-cs_sq)) - q) / denominator;
+      Real s2 = SQR(a1) - 4.0*a0;
+      Real s = (s2 > 0.0) ? std::sqrt(s2) : 0.0;
+      lambda_plus_no_bbx = (a1 >= 0.0) ? -2.0*a0/(a1+s) : (-a1+s)/2.0;
+      lambda_minus_no_bbx = (a1 >= 0.0) ? (-a1-s)/2.0 : -2.0*a0/(a1-s);
+    }
+
+    // Calculate wavespeeds in general case (MB2006 56)
+    Real lambda_plus, lambda_minus;
+    {
+      // Calculate quartic coefficients
+      Real vx2 = SQR(vx);
+      Real vx3 = vx2 * vx;
+      Real vx4 = SQR(vx2);
+      Real bt_sq = SQR(b[0]);
+      Real bx_sq = SQR(b[1]);
+      Real tmp1 = SQR(gamma_rel_sq) * w_gas * (1.0-cs_sq);
+      Real tmp2 = gamma_rel_sq * (b_sq + w_gas * cs_sq);
+      Real denominator = tmp1 + tmp2 - cs_sq * bt_sq;
+      Real a3 = (-(4.0*tmp1+2.0*tmp2)*vx + 2.0*cs_sq*b[0]*b[1]) / denominator;
+      Real a2 = (6.0*tmp1*vx2 + tmp2*(vx2-1.0) + cs_sq*(bt_sq-bx_sq)) / denominator;
+      Real a1 = (-4.0*tmp1*vx3 + 2.0*tmp2*vx - 2.0*cs_sq*b[0]*b[1]) / denominator;
+      Real a0 = (tmp1*vx4 - tmp2*vx2 + cs_sq*bx_sq) / denominator;
+
+      // Calculate reduced quartic coefficients
+      Real b2 = a2 - 3.0/8.0*SQR(a3);
+      Real b1 = a1 - 1.0/2.0*a2*a3 + 1.0/8.0*a3*SQR(a3);
+      Real b0 = a0 - 1.0/4.0*a1*a3 + 1.0/16.0*a2*SQR(a3) - 3.0/256.0*SQR(SQR(a3));
+
+      // Solve reduced quartic equation
+      Real y1, y2, y3, y4;
+      {
+        // Calculate resolvent cubic coefficients
+        Real c2 = -b2;
+        Real c1 = -4.0*b0;
+        Real c0 = 4.0*b0*b2 - SQR(b1);
+
+        // Solve resolvent cubic equation
+        Real q = (c2*c2 - 3.0*c1) / 9.0;                       // (NR 5.6.10)
+        Real r = (2.0*c2*c2*c2 - 9.0*c1*c2 + 27.0*c0) / 54.0;  // (NR 5.6.10)
+        Real q3 = q*q*q;
+        Real r2 = SQR(r);
+        Real s2 = r2 - q3;
+        Real z0;
+        if (s2 < 0.0) {
+          Real theta = std::acos(r/std::sqrt(q3));             // (NR 5.6.11)
+          z0 = -2.0 * std::sqrt(q) * std::cos(theta/3.0) - c2/3.0;  // (NR 5.6.12)
+        } else {
+          Real s = std::sqrt(s2);
+          Real aa = -copysign(1.0, r) * std::cbrt(std::abs(r) + s);  // (NR 5.6.15)
+          Real bb = (aa != 0.0) ? q/aa : 0.0;                   // (NR 5.6.16)
+          z0 = aa + bb - c2/3.0;
+        }
+
+        // Calculate quadratic coefficients
+        Real d1 = (z0-b2 > 0.0) ? std::sqrt(z0-b2) : 0.0;
+        Real e1 = -d1;
+        s2 = SQR(z0)/4.0 - b0;
+        Real s = (s2 < 0.0) ? 0.0 : std::sqrt(s2);
+        Real d0 = (b1 < 0) ? 0.5*z0+s : 0.5*z0-s;
+        Real e0 = (b1 < 0) ? 0.5*z0-s : 0.5*z0+s;
+
+        // Solve quadratic equations
+        s2 = SQR(d1) - 4.0*d0;
+        s = (s2 < 0.0) ? 0.0 : std::sqrt(s2);
+        y1 = (d1 >= 0.0) ? (-d1-s)/2.0 : -2.0*d0/(d1-s);
+        y2 = (d1 >= 0.0) ? -2.0*d0/(d1+s) : (-d1+s)/2.0;
+        s2 = SQR(e1) - 4.0*e0;
+        s = (s2 < 0.0) ? 0.0 : std::sqrt(s2);
+        y3 = (e1 >= 0.0) ? (-e1-s)/2.0 : -2.0*e0/(e1-s);
+        y4 = (e1 >= 0.0) ? -2.0*e0/(e1+s) : (-e1+s)/2.0;
+      }
+
+      // Calculate extremal original quartic roots
+      lambda_minus = std::min(y1, y3) - a3/4.0;
+      lambda_plus = std::max(y2, y4) - a3/4.0;
+
+      // Ensure wavespeeds are not superluminal
+      if (!std::isfinite(lambda_minus) || lambda_minus < -1.0) {
+        lambda_minus = -1.0;
+      }
+      if (!std::isfinite(lambda_plus) || lambda_plus > 1.0) {
+        lambda_plus = 1.0;
+      }
+    }
+
+    // Set wavespeeds based on velocity and magnetic field
+    if (v_sq < v_limit) {
+      lambdas_p(i) = lambda_plus_no_v;
+      lambdas_m(i) = lambda_minus_no_v;
+    } else if (bbx_sq < b_limit) {
+      lambdas_p(i) = lambda_plus_no_bbx;
+      lambdas_m(i) = lambda_minus_no_bbx;
     } else {
-      lambdas_p(i) = root_2;
-      lambdas_m(i) = root_1;
+      lambdas_p(i) = lambda_plus;
+      lambdas_m(i) = lambda_minus;
     }
   }
   return;

--- a/src/eos/adiabatic_mhd_sr.cpp
+++ b/src/eos/adiabatic_mhd_sr.cpp
@@ -60,12 +60,10 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 //   follows Mignone & McKinney 2007, MNRAS 378 1118 (MM)
 //   follows hlld_sr.c in Athena 4.2 in using W and E rather than W' and E'
 
-void EquationOfState::ConservedToPrimitive(AthenaArray<Real> &cons,
-                                           const AthenaArray<Real> &prim_old,
-                                           const FaceField &bb, AthenaArray<Real> &prim,
-                                           AthenaArray<Real> &bb_cc, Coordinates *pco,
-                                           int il, int iu, int jl,
-                                           int ju, int kl, int ku) {
+void EquationOfState::ConservedToPrimitive(
+    AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
+    AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
   // Parameters
   const Real gamma_prime = gamma_/(gamma_-1.0);
   const Real v_sq_max = 1.0 - 1.0/SQR(gamma_max_);
@@ -197,11 +195,10 @@ void EquationOfState::ConservedToPrimitive(AthenaArray<Real> &cons,
 // Outputs:
 //   cons: 3D array of conserved variables
 
-void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
-                                           const AthenaArray<Real> &bc,
-                                           AthenaArray<Real> &cons, Coordinates *pco,
-                                           int il, int iu, int jl,
-                                           int ju, int kl, int ku) {
+void EquationOfState::PrimitiveToConserved(
+    const AthenaArray<Real> &prim, const AthenaArray<Real> &bc,
+    AthenaArray<Real> &cons, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
   // Calculate reduced ratio of specific heats
   Real gamma_adi_red = gamma_/(gamma_-1.0);
 
@@ -261,15 +258,20 @@ void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
 // Outputs:
 //   lambdas_p,lambdas_m: 1D arrays set to +/- wavespeeds
 // Notes:
+//   references Mignone & Bodo 2005, MNRAS 364 126 (MB2005)
+//   references Mignone & Bodo 2006, MNRAS 368 1040 (MB2006)
+//   references Numerical Recipes, 3rd ed. (NR)
 //   follows advice in NR for avoiding large cancellations in solving quadratics
-//   applies approximation that may slightly overestimate wavespeeds
 //   almost same function as in adiabatic_mhd_gr.cpp
 
-void EquationOfState::FastMagnetosonicSpeedsSR(const AthenaArray<Real> &prim,
-                                               const AthenaArray<Real> &bbx_vals,
-                                               int k, int j, int il, int iu, int ivx,
-                                               AthenaArray<Real> &lambdas_p,
-                                               AthenaArray<Real> &lambdas_m) {
+void EquationOfState::FastMagnetosonicSpeedsSR(
+    const AthenaArray<Real> &prim, const AthenaArray<Real> &bbx_vals,
+    int k, int j, int il, int iu, int ivx,
+    AthenaArray<Real> &lambdas_p, AthenaArray<Real> &lambdas_m) {
+  // Parameters
+  const double v_limit = 1.0e-12;  // squared velocities less than this are considered 0
+  const double b_limit = 1.0e-14;  // squared B^x less than this is considered 0
+
   // Calculate cyclic permutations of indices
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
@@ -284,48 +286,148 @@ void EquationOfState::FastMagnetosonicSpeedsSR(const AthenaArray<Real> &prim,
     // Extract primitives
     Real rho = prim(IDN,i);
     Real pgas = prim(IPR,i);
-    Real v1 = prim(ivx,i);
-    Real v2 = prim(ivy,i);
-    Real v3 = prim(ivz,i);
-    Real bb1 = bbx_vals(i);
-    Real bb2 = prim(IBY,i);
-    Real bb3 = prim(IBZ,i);
+    Real vx = prim(ivx,i);
+    Real vy = prim(ivy,i);
+    Real vz = prim(ivz,i);
+    Real bbx = bbx_vals(i);
+    Real bby = prim(IBY,i);
+    Real bbz = prim(IBZ,i);
 
-    // Calculate Lorentz factor and (twice) magnetic pressure
-    Real v_sq = SQR(v1) + SQR(v2) + SQR(v3);
+    // Calculate velocity
+    Real v_sq = SQR(vx) + SQR(vy) + SQR(vz);
     Real u0 = std::sqrt(1.0 / (1.0 - v_sq));
-    Real b0 = (bb1 * v1 + bb2 * v2 + bb3 * v3) * u0;
-    Real b1 = bb1 / u0 + b0 * v1;
-    Real b2 = bb2 / u0 + b0 * v2;
-    Real b3 = bb3 / u0 + b0 * v3;
-    Real b_sq = -SQR(b0) + SQR(b1) + SQR(b2) + SQR(b3);
 
-    // Calculate comoving fast magnetosonic speed
+    // Calculate contravariant magnetic field
+    Real b[4];
+    b[0] = (bbx*vx + bby*vy + bbz*vz) * u0;
+    b[1] = bbx / u0 + b[0] * vx;
+    b[2] = bby / u0 + b[0] * vy;
+    b[3] = bbz / u0 + b[0] * vz;
+
+    // Calculate intermediate quantities
+    Real gamma_rel_sq = u0 * u0;
     Real w_gas = rho + gamma_adi_red * pgas;
-    Real cs_sq = gamma_adi * pgas / w_gas;
-    Real va_sq = b_sq / (w_gas + b_sq);
-    Real cms_sq = cs_sq + va_sq - cs_sq * va_sq;
+    Real cs_sq = gamma_adi * pgas / w_gas;                       // (MB2005 4)
+    Real b_sq = -SQR(b[0]) + SQR(b[1]) + SQR(b[2]) + SQR(b[3]);
+    Real bbx_sq = SQR(bbx);
+    Real vx_sq = SQR(vx);
 
-    // Set fast magnetosonic speeds
-    Real a = SQR(u0) - (SQR(u0) - 1.0) * cms_sq;
-    Real b = -2.0 * SQR(u0) * v1 * (1.0 - cms_sq);
-    Real c = SQR(u0 * v1) - (SQR(u0 * v1) + 1.0) * cms_sq;
-    Real d = std::max(SQR(b) - 4.0 * a * c, 0.0);
-    Real d_sqrt = std::sqrt(d);
-    Real root_1 = (-b + d_sqrt) / (2.0*a);
-    Real root_2 = (-b - d_sqrt) / (2.0*a);
-    if (root_1 > root_2) {
-      lambdas_p(i) = root_1;
-      lambdas_m(i) = root_2;
+    // Calculate wavespeeds in vanishing velocity case (MB2006 57)
+    Real lambda_plus_no_v, lambda_minus_no_v;
+    {
+      Real w_tot_inv = 1.0 / (w_gas + b_sq);
+      Real a1 = -(b_sq + cs_sq * (w_gas + bbx_sq)) * w_tot_inv;
+      Real a0 = cs_sq * bbx_sq * w_tot_inv;
+      Real s2 = SQR(a1) - 4.0*a0;
+      Real s = (s2 < 0.0) ? 0.0 : std::sqrt(s2);
+      Real lambda_sq = 0.5 * (-a1 + s);
+      lambda_plus_no_v = std::sqrt(lambda_sq);
+      lambda_minus_no_v = -lambda_plus_no_v;
+    }
+
+    // Calculate wavespeeds in vanishing normal field case (MB2006 58)
+    Real lambda_plus_no_bbx, lambda_minus_no_bbx;
+    {
+      Real v_dot_bb_perp = vy*bby + vz*bbz;
+      Real q = b_sq - cs_sq*SQR(v_dot_bb_perp);
+      Real denominator_inv = 1.0 / (w_gas * (cs_sq + gamma_rel_sq*(1.0-cs_sq)) + q);
+      Real a1 = -2.0 * w_gas * gamma_rel_sq * vx * (1.0-cs_sq) * denominator_inv;
+      Real a0 = (w_gas * (-cs_sq + gamma_rel_sq*vx_sq*(1.0-cs_sq)) - q) * denominator_inv;
+      Real s2 = SQR(a1) - 4.0*a0;
+      Real s = (s2 < 0.0) ? 0.0 : std::sqrt(s2);
+      lambda_plus_no_bbx = (s2 >= 0.0 && a1 >= 0.0) ? -2.0*a0/(a1+s) : 0.5*(-a1+s);
+      lambda_minus_no_bbx = (s2 >= 0.0 && a1 < 0.0) ? -2.0*a0/(a1-s) : 0.5*(-a1-s);
+    }
+
+    // Calculate wavespeeds in general case (MB2006 56)
+    Real lambda_plus, lambda_minus;
+    {
+      // Calculate quartic coefficients
+      Real bt_sq = SQR(b[0]);
+      Real bx_sq = SQR(b[1]);
+      Real tmp1 = SQR(gamma_rel_sq) * w_gas * (1.0-cs_sq);
+      Real tmp2 = gamma_rel_sq * (b_sq + w_gas * cs_sq);
+      Real denominator_inv = 1.0 / (tmp1 + tmp2 - cs_sq * bt_sq);
+      Real a3 = (-(4.0*tmp1+2.0*tmp2)*vx + 2.0*cs_sq*b[0]*b[1]) * denominator_inv;
+      Real a2 = (6.0*tmp1*vx_sq + tmp2*(vx_sq-1.0) + cs_sq*(bt_sq-bx_sq))
+                * denominator_inv;
+      Real a1 = (-4.0*tmp1*vx_sq*vx + 2.0*tmp2*vx - 2.0*cs_sq*b[0]*b[1])
+                * denominator_inv;
+      Real a0 = (tmp1*SQR(vx_sq) - tmp2*vx_sq + cs_sq*bx_sq) * denominator_inv;
+
+      // Calculate reduced quartic coefficients
+      Real b2 = a2 - 0.375*SQR(a3);
+      Real b1 = a1 - 0.5*a2*a3 + 0.125*a3*SQR(a3);
+      Real b0 = a0 - 0.25*a1*a3 + 0.0625*a2*SQR(a3) - 3.0/256.0*SQR(SQR(a3));
+
+      // Solve reduced quartic equation
+      Real y1, y2, y3, y4;
+      {
+        // Calculate resolvent cubic coefficients
+        Real c2 = -b2;
+        Real c1 = -4.0*b0;
+        Real c0 = 4.0*b0*b2 - SQR(b1);
+
+        // Solve resolvent cubic equation
+        Real q = (c2*c2 - 3.0*c1) / 9.0;                       // (NR 5.6.10)
+        Real r = (2.0*c2*c2*c2 - 9.0*c1*c2 + 27.0*c0) / 54.0;  // (NR 5.6.10)
+        Real q3 = q*q*q;
+        Real r2 = SQR(r);
+        Real s2 = r2 - q3;
+        Real z0;
+        if (s2 < 0.0) {
+          Real theta = std::acos(r/std::sqrt(q3));             // (NR 5.6.11)
+          z0 = -2.0 * std::sqrt(q) * std::cos(theta/3.0) - c2/3.0;  // (NR 5.6.12)
+        } else {
+          Real s = std::sqrt(s2);
+          Real aa = -copysign(1.0, r) * std::cbrt(std::abs(r) + s);  // (NR 5.6.15)
+          Real bb = (aa != 0.0) ? q/aa : 0.0;                   // (NR 5.6.16)
+          z0 = aa + bb - c2/3.0;
+        }
+
+        // Calculate quadratic coefficients
+        Real d1 = (z0-b2 > 0.0) ? std::sqrt(z0-b2) : 0.0;
+        Real e1 = -d1;
+        s2 = 0.25*SQR(z0) - b0;
+        Real s = (s2 < 0.0) ? 0.0 : std::sqrt(s2);
+        Real d0 = (b1 < 0) ? 0.5*z0+s : 0.5*z0-s;
+        Real e0 = (b1 < 0) ? 0.5*z0-s : 0.5*z0+s;
+
+        // Solve quadratic equations
+        s2 = SQR(d1) - 4.0*d0;
+        s = (s2 < 0.0) ? 0.0 : std::sqrt(s2);
+        y1 = (s2 >= 0.0 && d1 < 0.0) ? -2.0*d0/(d1-s) : 0.5*(-d1-s);
+        y2 = (s2 >= 0.0 && d1 >= 0.0) ? -2.0*d0/(d1+s) : 0.5*(-d1+s);
+        s2 = SQR(e1) - 4.0*e0;
+        s = (s2 < 0.0) ? 0.0 : std::sqrt(s2);
+        y3 = (s2 >= 0.0 && e1 < 0.0) ? -2.0*e0/(e1-s) : 0.5*(-e1-s);
+        y4 = (s2 >= 0.0 && e1 >= 0.0) ? -2.0*e0/(e1+s) : 0.5*(-e1+s);
+      }
+
+      // Calculate extremal original quartic roots
+      lambda_minus = std::min(y1, y3) - 0.25*a3;
+      lambda_plus = std::max(y2, y4) - 0.25*a3;
+
+      // Ensure wavespeeds are not superluminal
+      lambda_minus = std::max(lambda_minus, -1.0);
+      lambda_plus = std::min(lambda_plus, 1.0);
+    }
+
+    // Set wavespeeds based on velocity and magnetic field
+    if (v_sq < v_limit) {
+      lambdas_p(i) = lambda_plus_no_v;
+      lambdas_m(i) = lambda_minus_no_v;
+    } else if (bbx_sq < b_limit) {
+      lambdas_p(i) = lambda_plus_no_bbx;
+      lambdas_m(i) = lambda_minus_no_bbx;
     } else {
-      lambdas_p(i) = root_2;
-      lambdas_m(i) = root_1;
+      lambdas_p(i) = lambda_plus;
+      lambdas_m(i) = lambda_minus;
     }
   }
   return;
 }
 
-namespace {
 //----------------------------------------------------------------------------------------
 // Function whose value vanishes for correct enthalpy
 // Inputs:
@@ -342,7 +444,7 @@ namespace {
 //   follows Mignone & McKinney 2007, MNRAS 378 1118 (MM)
 //   implementation follows that of hlld_sr.c in Athena 4.2
 //   same function as in hlld_rel.cpp
-
+namespace {
 Real EResidual(Real w_guess, Real dd, Real ee, Real m_sq, Real bb_sq, Real ss_sq,
                Real gamma_prime) {
   Real v_sq = (m_sq + ss_sq/SQR(w_guess) * (2.0*w_guess + bb_sq))
@@ -381,10 +483,12 @@ Real EResidualPrime(Real w_guess, Real dd, Real m_sq, Real bb_sq, Real ss_sq,
   Real chi = (1.0 - v_sq) * (w_guess - gamma_lorentz * dd);           // (cf. MM A11)
   Real w_cu = SQR(w_guess) * w_guess;
   Real w_b_cu = SQR(w_guess + bb_sq) * (w_guess + bb_sq);
-  Real dv_sq_dw = -2.0 / (w_cu*w_b_cu)                                // (MM A16)
-                  * (ss_sq * (3.0*w_guess*(w_guess+bb_sq) + SQR(bb_sq)) + m_sq*w_cu);
-  Real dchi_dw = 1.0 - v_sq                                           // (cf. MM A14)
-                 - 0.5*gamma_lorentz * (dd + 2.0*gamma_lorentz*chi) * dv_sq_dw;
+  Real dv_sq_dw = -2.0 / (w_cu*w_b_cu)
+                  * (ss_sq * (3.0*w_guess*(w_guess+bb_sq)
+                              + SQR(bb_sq)) + m_sq*w_cu);             // (MM A16)
+  Real dchi_dw = 1.0 - v_sq
+                 - 0.5*gamma_lorentz
+                 * (dd + 2.0*gamma_lorentz*chi) * dv_sq_dw;           // (cf. MM A14)
   Real drho_dw = -0.5*gamma_lorentz*dd*dv_sq_dw;                      // (MM A15)
   Real dpgas_dchi = 1.0/gamma_prime;                                  // (MM A18)
   Real dpgas_drho = 0.0;                                              // (MM A18)

--- a/src/eos/eos.hpp
+++ b/src/eos/eos.hpp
@@ -185,16 +185,12 @@ class EquationOfState {
   Real rho_min_, rho_pow_;               // variables to control power-law denity floor
   Real pgas_min_, pgas_pow_;             // variables to control power-law pressure floor
   AthenaArray<Real> g_, g_inv_;          // metric and its inverse, used in GR
-  AthenaArray<bool> fixed_, success_;    // flags for problems, used in GR
+  AthenaArray<Real> fixed_;              // cells with problems, used in GR hydro
   AthenaArray<Real> normal_dd_;          // normal-frame densities, used in GR MHD
   AthenaArray<Real> normal_ee_;          // normal-frame energies, used in GR MHD
   AthenaArray<Real> normal_mm_;          // normal-frame momenta, used in GR MHD
   AthenaArray<Real> normal_bb_;          // normal-frame fields, used in GR MHD
   AthenaArray<Real> normal_tt_;          // normal-frame M.B, used in GR MHD
-  AthenaArray<Real> dens_floor_local_;   // floor on rho for any reason, used in GR MHD
-  AthenaArray<Real> press_floor_local_;  // floor on pgas for any reason, used in GR MHD
-  AthenaArray<Real> normal_gamma_;       // normal-frame Lorentz factor, used in GR MHD
-  AthenaArray<Real> pmag_;               // fluid-frame magnetic pressure, used in GR MHD
 };
 
 #endif // EOS_EOS_HPP_

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -101,11 +101,6 @@ Hydro::Hydro(MeshBlock *pmb, ParameterInput *pin) :
   cell_volume_.NewAthenaArray(nc1);
   dflx_.NewAthenaArray(NHYDRO, nc1);
   if (MAGNETIC_FIELDS_ENABLED && RELATIVISTIC_DYNAMICS) { // only used in (SR/GR)MHD
-    if (!GENERAL_RELATIVITY) {
-      prim_field_.NewAthenaArray(NWAVE, 1, 1, nc1);
-      lambdas_p_.NewAthenaArray(nc1);
-      lambdas_m_.NewAthenaArray(nc1);
-    }
     bb_normal_.NewAthenaArray(nc1);
     lambdas_p_l_.NewAthenaArray(nc1);
     lambdas_m_l_.NewAthenaArray(nc1);

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -93,11 +93,7 @@ class Hydro {
   // 2D
   AthenaArray<Real> wl_, wr_, wlb_;
   AthenaArray<Real> dflx_;
-  // 1D GR
-  AthenaArray<Real> prim_field_;   // primitives and transverse field, for SR MHD
-  AthenaArray<Real> lambdas_p_;    // most positive wavespeeds in cell, for SR MHD
-  AthenaArray<Real> lambdas_m_;    // most negative wavespeeds in cell, for SR MHD
-  AthenaArray<Real> bb_normal_;    // normal magnetic field, for (SR/GR) MHD
+  AthenaArray<Real> bb_normal_;    // normal magnetic field, for (SR/GR)MHD
   AthenaArray<Real> lambdas_p_l_;  // most positive wavespeeds in left state
   AthenaArray<Real> lambdas_m_l_;  // most negative wavespeeds in left state
   AthenaArray<Real> lambdas_p_r_;  // most positive wavespeeds in right state

--- a/src/hydro/rsolvers/hydro/hllc_rel.cpp
+++ b/src/hydro/rsolvers/hydro/hllc_rel.cpp
@@ -137,216 +137,201 @@ void HLLCTransforming(MeshBlock *pmb, const int k, const int j, const int il,
   const Real gamma_adi = pmb->peos->GetGamma();
   const Real gamma_prime = gamma_adi/(gamma_adi - 1.0);
 
-  Real cons_l[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_l[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_r[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_r[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_hll[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_hll[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_lstar[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_lstar[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_rstar[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_rstar[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_interface[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_interface[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-
   // Go through each interface
-  for (int i=il; i<=iu; i+=SIMD_WIDTH) {
 #pragma omp simd simdlen(SIMD_WIDTH)
-    for (int m=0; m<std::min(SIMD_WIDTH, iu-i+1); m++) {
-      int ipm = i+m;
+  for (int i=il; i<=iu; ++i) {
+    // Extract left primitives
+    Real rho_l = prim_l(IDN,i);
+    Real pgas_l = prim_l(IPR,i);
+    Real u_l[4];
+    if (GENERAL_RELATIVITY) {
+      Real vx_l = prim_l(ivx,i);
+      Real vy_l = prim_l(ivy,i);
+      Real vz_l = prim_l(ivz,i);
+      u_l[0] = std::sqrt(1.0 + SQR(vx_l) + SQR(vy_l) + SQR(vz_l));
+      u_l[1] = vx_l;
+      u_l[2] = vy_l;
+      u_l[3] = vz_l;
+    } else {  // SR
+      Real vx_l = prim_l(ivx,i);
+      Real vy_l = prim_l(ivy,i);
+      Real vz_l = prim_l(ivz,i);
+      u_l[0] = std::sqrt(1.0 / (1.0 - SQR(vx_l) - SQR(vy_l) - SQR(vz_l)));
+      u_l[1] = u_l[0] * vx_l;
+      u_l[2] = u_l[0] * vy_l;
+      u_l[3] = u_l[0] * vz_l;
+    }
 
-      // Extract left primitives
-      Real rho_l = prim_l(IDN,ipm);
-      Real pgas_l = prim_l(IPR,ipm);
-      Real u_l[4];
-      if (GENERAL_RELATIVITY) {
-        Real vx_l = prim_l(ivx,ipm);
-        Real vy_l = prim_l(ivy,ipm);
-        Real vz_l = prim_l(ivz,ipm);
-        u_l[0] = std::sqrt(1.0 + SQR(vx_l) + SQR(vy_l) + SQR(vz_l));
-        u_l[1] = vx_l;
-        u_l[2] = vy_l;
-        u_l[3] = vz_l;
-      } else {  // SR
-        Real vx_l = prim_l(ivx,ipm);
-        Real vy_l = prim_l(ivy,ipm);
-        Real vz_l = prim_l(ivz,ipm);
-        u_l[0] = std::sqrt(1.0 / (1.0 - SQR(vx_l) - SQR(vy_l) - SQR(vz_l)));
-        u_l[1] = u_l[0] * vx_l;
-        u_l[2] = u_l[0] * vy_l;
-        u_l[3] = u_l[0] * vz_l;
-      }
+    // Extract right primitives
+    Real rho_r = prim_r(IDN,i);
+    Real pgas_r = prim_r(IPR,i);
+    Real u_r[4];
+    if (GENERAL_RELATIVITY) {
+      Real vx_r = prim_r(ivx,i);
+      Real vy_r = prim_r(ivy,i);
+      Real vz_r = prim_r(ivz,i);
+      u_r[0] = std::sqrt(1.0 + SQR(vx_r) + SQR(vy_r) + SQR(vz_r));
+      u_r[1] = vx_r;
+      u_r[2] = vy_r;
+      u_r[3] = vz_r;
+    } else {  // SR
+      Real vx_r = prim_r(ivx,i);
+      Real vy_r = prim_r(ivy,i);
+      Real vz_r = prim_r(ivz,i);
+      u_r[0] = std::sqrt(1.0 / (1.0 - SQR(vx_r) - SQR(vy_r) - SQR(vz_r)));
+      u_r[1] = u_r[0] * vx_r;
+      u_r[2] = u_r[0] * vy_r;
+      u_r[3] = u_r[0] * vz_r;
+    }
 
-      // Extract right primitives
-      Real rho_r = prim_r(IDN,ipm);
-      Real pgas_r = prim_r(IPR,ipm);
-      Real u_r[4];
-      if (GENERAL_RELATIVITY) {
-        Real vx_r = prim_r(ivx,ipm);
-        Real vy_r = prim_r(ivy,ipm);
-        Real vz_r = prim_r(ivz,ipm);
-        u_r[0] = std::sqrt(1.0 + SQR(vx_r) + SQR(vy_r) + SQR(vz_r));
-        u_r[1] = vx_r;
-        u_r[2] = vy_r;
-        u_r[3] = vz_r;
-      } else {  // SR
-        Real vx_r = prim_r(ivx,ipm);
-        Real vy_r = prim_r(ivy,ipm);
-        Real vz_r = prim_r(ivz,ipm);
-        u_r[0] = std::sqrt(1.0 / (1.0 - SQR(vx_r) - SQR(vy_r) - SQR(vz_r)));
-        u_r[1] = u_r[0] * vx_r;
-        u_r[2] = u_r[0] * vy_r;
-        u_r[3] = u_r[0] * vz_r;
-      }
+    // Calculate wavespeeds in left state (MB2005 23)
+    Real lambda_p_l, lambda_m_l;
+    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    pmb->peos->SoundSpeedsSR(wgas_l, pgas_l, u_l[1]/u_l[0], SQR(u_l[0]), &lambda_p_l,
+                             &lambda_m_l);
 
-      // Calculate wavespeeds in left state (MB2005 23)
-      Real lambda_p_l, lambda_m_l;
-      Real wgas_l = rho_l + gamma_prime * pgas_l;
-      pmb->peos->SoundSpeedsSR(wgas_l, pgas_l, u_l[1]/u_l[0], SQR(u_l[0]), &lambda_p_l,
-                               &lambda_m_l);
+    // Calculate wavespeeds in right state (MB2005 23)
+    Real lambda_p_r, lambda_m_r;
+    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    pmb->peos->SoundSpeedsSR(wgas_r, pgas_r, u_r[1]/u_r[0], SQR(u_r[0]), &lambda_p_r,
+                             &lambda_m_r);
 
-      // Calculate wavespeeds in right state (MB2005 23)
-      Real lambda_p_r, lambda_m_r;
-      Real wgas_r = rho_r + gamma_prime * pgas_r;
-      pmb->peos->SoundSpeedsSR(wgas_r, pgas_r, u_r[1]/u_r[0], SQR(u_r[0]), &lambda_p_r,
-                               &lambda_m_r);
+    // Calculate extremal wavespeeds
+    Real lambda_l = std::min(lambda_m_l, lambda_m_r);
+    Real lambda_r = std::max(lambda_p_l, lambda_p_r);
 
-      // Calculate extremal wavespeeds
-      Real lambda_l = std::min(lambda_m_l, lambda_m_r);
-      Real lambda_r = std::max(lambda_p_l, lambda_p_r);
+    // Calculate conserved quantities in L region (MB2005 3)
+    Real cons_l[NWAVE];
+    cons_l[IDN] = rho_l * u_l[0];
+    cons_l[IEN] = wgas_l * u_l[0] * u_l[0] - pgas_l;
+    cons_l[ivx] = wgas_l * u_l[1] * u_l[0];
+    cons_l[ivy] = wgas_l * u_l[2] * u_l[0];
+    cons_l[ivz] = wgas_l * u_l[3] * u_l[0];
 
-      // Calculate conserved quantities in L region (MB2005 3)
-      cons_l[IDN][m] = rho_l * u_l[0];
-      cons_l[IEN][m] = wgas_l * u_l[0] * u_l[0] - pgas_l;
-      cons_l[ivx][m] = wgas_l * u_l[1] * u_l[0];
-      cons_l[ivy][m] = wgas_l * u_l[2] * u_l[0];
-      cons_l[ivz][m] = wgas_l * u_l[3] * u_l[0];
+    // Calculate fluxes in L region (MB2005 2,3)
+    Real flux_l[NWAVE];
+    flux_l[IDN] = rho_l * u_l[1];
+    flux_l[IEN] = wgas_l * u_l[0] * u_l[1];
+    flux_l[ivx] = wgas_l * u_l[1] * u_l[1] + pgas_l;
+    flux_l[ivy] = wgas_l * u_l[2] * u_l[1];
+    flux_l[ivz] = wgas_l * u_l[3] * u_l[1];
 
-      // Calculate fluxes in L region (MB2005 2,3)
-      flux_l[IDN][m] = rho_l * u_l[1];
-      flux_l[IEN][m] = wgas_l * u_l[0] * u_l[1];
-      flux_l[ivx][m] = wgas_l * u_l[1] * u_l[1] + pgas_l;
-      flux_l[ivy][m] = wgas_l * u_l[2] * u_l[1];
-      flux_l[ivz][m] = wgas_l * u_l[3] * u_l[1];
+    // Calculate conserved quantities in R region (MB2005 3)
+    Real cons_r[NWAVE];
+    cons_r[IDN] = rho_r * u_r[0];
+    cons_r[IEN] = wgas_r * u_r[0] * u_r[0] - pgas_r;
+    cons_r[ivx] = wgas_r * u_r[1] * u_r[0];
+    cons_r[ivy] = wgas_r * u_r[2] * u_r[0];
+    cons_r[ivz] = wgas_r * u_r[3] * u_r[0];
 
-      // Calculate conserved quantities in R region (MB2005 3)
-      cons_r[IDN][m] = rho_r * u_r[0];
-      cons_r[IEN][m] = wgas_r * u_r[0] * u_r[0] - pgas_r;
-      cons_r[ivx][m] = wgas_r * u_r[1] * u_r[0];
-      cons_r[ivy][m] = wgas_r * u_r[2] * u_r[0];
-      cons_r[ivz][m] = wgas_r * u_r[3] * u_r[0];
+    // Calculate fluxes in R region (MB2005 2,3)
+    Real flux_r[NWAVE];
+    flux_r[IDN] = rho_r * u_r[1];
+    flux_r[IEN] = wgas_r * u_r[0] * u_r[1];
+    flux_r[ivx] = wgas_r * u_r[1] * u_r[1] + pgas_r;
+    flux_r[ivy] = wgas_r * u_r[2] * u_r[1];
+    flux_r[ivz] = wgas_r * u_r[3] * u_r[1];
 
-      // Calculate fluxes in R region (MB2005 2,3)
-      flux_r[IDN][m] = rho_r * u_r[1];
-      flux_r[IEN][m] = wgas_r * u_r[0] * u_r[1];
-      flux_r[ivx][m] = wgas_r * u_r[1] * u_r[1] + pgas_r;
-      flux_r[ivy][m] = wgas_r * u_r[2] * u_r[1];
-      flux_r[ivz][m] = wgas_r * u_r[3] * u_r[1];
+    Real lambda_diff_inv = 1.0 / (lambda_r-lambda_l);
+    // Calculate conserved quantities in HLL region in GR (MB2005 9)
+    Real cons_hll[NWAVE];
+    for (int n = 0; n < NWAVE; ++n) {
+      cons_hll[n] = (lambda_r*cons_r[n] - lambda_l*cons_l[n] + flux_l[n] - flux_r[n])
+                    * lambda_diff_inv;
+    }
 
-      Real lambda_diff_inv = 1.0 / (lambda_r-lambda_l);
-      // Calculate conserved quantities in HLL region in GR (MB2005 9)
+    // Calculate fluxes in HLL region (MB2005 11)
+    Real flux_hll[NWAVE];
+    for (int n = 0; n < NWAVE; ++n) {
+      flux_hll[n] = (lambda_r*flux_l[n] - lambda_l*flux_r[n]
+                     + lambda_l*lambda_r * (cons_r[n] - cons_l[n])) * lambda_diff_inv;
+    }
+
+    // Calculate contact wavespeed (MB2005 18)
+    Real lambda_star;
+    Real b = -(cons_hll[IEN] + flux_hll[ivx]);
+    if (std::abs(flux_hll[IEN]) > TINY_NUMBER) {  // use quadratic formula
+      // Follows algorithm in Numerical Recipes (section 5.6) for avoiding cancellations
+      lambda_star = - 2.0 * cons_hll[ivx]
+                    / (b - std::sqrt(SQR(b) - 4.0*flux_hll[IEN]*cons_hll[ivx]));
+    } else { // no quadratic term
+      lambda_star = - cons_hll[ivx] / b;
+    }
+
+    // Calculate contact pressure (MB2006 48)
+    // Note: Could also use (MB2005 17), but note the first minus sign there is wrong.
+    Real pgas_star = -flux_hll[IEN] * lambda_star + flux_hll[ivx];
+
+    // Calculate conserved quantities in L* region (MB2005 16)
+    Real cons_lstar[NWAVE];
+    Real vx_l_ratio = u_l[1] / u_l[0];
+    lambda_diff_inv = 1.0 / (lambda_l - lambda_star);
+    for (int n = 0; n < NWAVE; ++n) {
+      cons_lstar[n] = cons_l[n] * (lambda_l-vx_l_ratio);
+    }
+    cons_lstar[IEN] += pgas_star*lambda_star - pgas_l*vx_l_ratio;
+    cons_lstar[ivx] += pgas_star - pgas_l;
+    for (int n = 0; n < NWAVE; ++n) {
+      cons_lstar[n] *= lambda_diff_inv;
+    }
+
+    // Calculate fluxes in L* region (MB2005 14)
+    Real flux_lstar[NWAVE];
+    for (int n = 0; n < NWAVE; ++n) {
+      flux_lstar[n] = flux_l[n] + lambda_l * (cons_lstar[n] - cons_l[n]);
+    }
+
+    // Calculate conserved quantities in R* region (MB2005 16)
+    Real cons_rstar[NWAVE];
+    Real vx_r_ratio = u_r[1] / u_r[0];
+    lambda_diff_inv = 1.0 / (lambda_r - lambda_star);
+    for (int n = 0; n < NWAVE; ++n) {
+      cons_rstar[n] = cons_r[n] * (lambda_r-vx_r_ratio);
+    }
+    cons_rstar[IEN] += pgas_star*lambda_star - pgas_r*vx_r_ratio;
+    cons_rstar[ivx] += pgas_star - pgas_r;
+    for (int n = 0; n < NWAVE; ++n) {
+      cons_rstar[n] *= lambda_diff_inv;
+    }
+
+    // Calculate fluxes in R* region (MB2005 14)
+    Real flux_rstar[NWAVE];
+    for (int n = 0; n < NWAVE; ++n) {
+      flux_rstar[n] = flux_r[n] + lambda_r * (cons_rstar[n] - cons_r[n]);
+    }
+
+    // Calculate interface velocity
+    Real v_interface = 0.0;
+    if (GENERAL_RELATIVITY) {
+      v_interface = gi(i01,i) / std::sqrt(SQR(gi(i01,i)) - gi(I00,i)*gi(i11,i));
+    }
+
+    // Determine region of wavefan
+    Real *cons_interface, *flux_interface;
+    if (lambda_l >= v_interface) {  // L region
+      cons_interface = cons_l;
+      flux_interface = flux_l;
+    } else if (lambda_r <= v_interface) { // R region
+      cons_interface = cons_r;
+      flux_interface = flux_r;
+    } else if (lambda_star >= v_interface) {  // aL region
+      cons_interface = cons_lstar;
+      flux_interface = flux_lstar;
+    } else {  // c region
+      cons_interface = cons_rstar;
+      flux_interface = flux_rstar;
+    }
+
+    // Set conserved quantities in GR
+    if (GENERAL_RELATIVITY) {
       for (int n = 0; n < NWAVE; ++n) {
-        cons_hll[n][m] = (lambda_r*cons_r[n][m] - lambda_l*cons_l[n][m]
-                          + flux_l[n][m] - flux_r[n][m]) * lambda_diff_inv;
+        cons(n,i) = cons_interface[n];
       }
+    }
 
-      // Calculate fluxes in HLL region (MB2005 11)
-      for (int n = 0; n < NWAVE; ++n) {
-        flux_hll[n][m] = (lambda_r*flux_l[n][m] - lambda_l*flux_r[n][m]
-                          + lambda_l*lambda_r * (cons_r[n][m] - cons_l[n][m]))
-                         * lambda_diff_inv;
-      }
-
-      // Calculate contact wavespeed (MB2005 18)
-      Real lambda_star;
-      Real b = -(cons_hll[IEN][m] + flux_hll[ivx][m]);
-      if (std::abs(flux_hll[IEN][m]) > TINY_NUMBER) {  // use quadratic formula
-        // Follows algorithm in Numerical Recipes (section 5.6) for avoiding cancellations
-        lambda_star = - 2.0 * cons_hll[ivx][m]
-                      / (b - std::sqrt(SQR(b) - 4.0*flux_hll[IEN][m]*cons_hll[ivx][m]));
-      } else {  // no quadratic term
-        lambda_star = - cons_hll[ivx][m] / b;
-      }
-
-      // Calculate contact pressure (MB2006 48)
-      // Note: Could also use (MB2005 17), but note the first minus sign there is wrong.
-      Real pgas_star = -flux_hll[IEN][m] * lambda_star + flux_hll[ivx][m];
-
-      // Calculate conserved quantities in L* region (MB2005 16)
-      Real vx_l_ratio = u_l[1] / u_l[0];
-      lambda_diff_inv = 1.0 / (lambda_l - lambda_star);
-      for (int n = 0; n < NWAVE; ++n) {
-        cons_lstar[n][m] = cons_l[n][m] * (lambda_l-vx_l_ratio);
-      }
-      cons_lstar[IEN][m] += pgas_star*lambda_star - pgas_l*vx_l_ratio;
-      cons_lstar[ivx][m] += pgas_star - pgas_l;
-      for (int n = 0; n < NWAVE; ++n) {
-        cons_lstar[n][m] *= lambda_diff_inv;
-      }
-
-      // Calculate fluxes in L* region (MB2005 14)
-      for (int n = 0; n < NWAVE; ++n) {
-        flux_lstar[n][m] = flux_l[n][m] + lambda_l * (cons_lstar[n][m] - cons_l[n][m]);
-      }
-
-      // Calculate conserved quantities in R* region (MB2005 16)
-      Real vx_r_ratio = u_r[1] / u_r[0];
-      lambda_diff_inv = 1.0 / (lambda_r - lambda_star);
-      for (int n = 0; n < NWAVE; ++n) {
-        cons_rstar[n][m] = cons_r[n][m] * (lambda_r-vx_r_ratio);
-      }
-      cons_rstar[IEN][m] += pgas_star*lambda_star - pgas_r*vx_r_ratio;
-      cons_rstar[ivx][m] += pgas_star - pgas_r;
-      for (int n = 0; n < NWAVE; ++n) {
-        cons_rstar[n][m] *= lambda_diff_inv;
-      }
-
-      // Calculate fluxes in R* region (MB2005 14)
-      for (int n = 0; n < NWAVE; ++n) {
-        flux_rstar[n][m] = flux_r[n][m] + lambda_r * (cons_rstar[n][m] - cons_r[n][m]);
-      }
-
-      // Calculate interface velocity
-      Real v_interface = 0.0;
-      if (GENERAL_RELATIVITY) {
-        v_interface = gi(i01,ipm) / std::sqrt(SQR(gi(i01,ipm)) - gi(I00,ipm)*gi(i11,ipm));
-      }
-
-      // Determine region of wavefan
-      if (lambda_l >= v_interface) {  // L region
-        for (int n=0; n < NWAVE; ++n) {
-          cons_interface[n][m] = cons_l[n][m];
-          flux_interface[n][m] = flux_l[n][m];
-        }
-      } else if (lambda_r <= v_interface) { // R region
-        for (int n=0; n < NWAVE; ++n) {
-          cons_interface[n][m] = cons_r[n][m];
-          flux_interface[n][m] = flux_r[n][m];
-        }
-      } else if (lambda_star >= v_interface) {  // aL region
-        for (int n=0; n< NWAVE; ++n) {
-          cons_interface[n][m] = cons_lstar[n][m];
-          flux_interface[n][m] = flux_lstar[n][m];
-        }
-      } else {  // c region
-        for (int n=0; n < NWAVE; ++n) {
-          cons_interface[n][m] = cons_rstar[n][m];
-          flux_interface[n][m] = flux_rstar[n][m];
-        }
-      }
-
-      // Set conserved quantities in GR
-      if (GENERAL_RELATIVITY) {
-        for (int n = 0; n < NWAVE; ++n) {
-          cons(n,ipm) = cons_interface[n][m];
-        }
-      }
-
-      // Set fluxes
-      for (int n = 0; n < NHYDRO; ++n) {
-        flux(n,k,j,ipm) = flux_interface[n][m];
-      }
+    // Set fluxes
+    for (int n = 0; n < NHYDRO; ++n) {
+      flux(n,k,j,i) = flux_interface[n];
     }
   }
 
@@ -392,38 +377,37 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 #if GENERAL_RELATIVITY
   // Extract ratio of specific heats
   const Real gamma_adi = pmb->peos->GetGamma();
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
 
   // Get metric components
   pmb->pcoord->Face2Metric(k, j, il, iu, g, gi);
 
   // Go through each interface
-#pragma omp simd simdlen(SIMD_WIDTH)
-  for (int i=il; i<=iu; i++) {
+#pragma omp simd
+  for (int i=il; i<=iu; ++i) {
     // Extract metric
-    Real g_00 = g(I00,i), g_01 = g(I01,i), g_02 = g(I02,i), g_03 = g(I03,i),
-         g_10 = g(I01,i), g_11 = g(I11,i), g_12 = g(I12,i), g_13 = g(I13,i),
-         g_20 = g(I02,i), g_21 = g(I12,i), g_22 = g(I22,i), g_23 = g(I23,i),
-         g_30 = g(I03,i), g_31 = g(I13,i), g_32 = g(I23,i), g_33 = g(I33,i);
-    Real g00 = gi(I00,i), g01 = gi(I01,i), g02 = gi(I02,i), g03 = gi(I03,i),
-         g10 = gi(I01,i), g11 = gi(I11,i), g12 = gi(I12,i), g13 = gi(I13,i),
-         g20 = gi(I02,i), g21 = gi(I12,i), g22 = gi(I22,i), g23 = gi(I23,i),
-         g30 = gi(I03,i), g31 = gi(I13,i), g32 = gi(I23,i), g33 = gi(I33,i);
+    const Real &g_00 = g(I00,i), &g_01 = g(I01,i), &g_02 = g(I02,i), &g_03 = g(I03,i),
+               &g_10 = g(I01,i), &g_11 = g(I11,i), &g_12 = g(I12,i), &g_13 = g(I13,i),
+               &g_20 = g(I02,i), &g_21 = g(I12,i), &g_22 = g(I22,i), &g_23 = g(I23,i),
+               &g_30 = g(I03,i), &g_31 = g(I13,i), &g_32 = g(I23,i), &g_33 = g(I33,i);
+    const Real &g00 = gi(I00,i), &g01 = gi(I01,i), &g02 = gi(I02,i), &g03 = gi(I03,i),
+               &g10 = gi(I01,i), &g11 = gi(I11,i), &g12 = gi(I12,i), &g13 = gi(I13,i),
+               &g20 = gi(I02,i), &g21 = gi(I12,i), &g22 = gi(I22,i), &g23 = gi(I23,i),
+               &g30 = gi(I03,i), &g31 = gi(I13,i), &g32 = gi(I23,i), &g33 = gi(I33,i);
     Real alpha = std::sqrt(-1.0/g00);
 
     // Extract left primitives
-    Real rho_l = prim_l(IDN,i);
-    Real pgas_l = prim_l(IPR,i);
-    Real uu1_l = prim_l(IVX,i);
-    Real uu2_l = prim_l(IVY,i);
-    Real uu3_l = prim_l(IVZ,i);
+    const Real &rho_l = prim_l(IDN,i);
+    const Real &pgas_l = prim_l(IPR,i);
+    const Real &uu1_l = prim_l(IVX,i);
+    const Real &uu2_l = prim_l(IVY,i);
+    const Real &uu3_l = prim_l(IVZ,i);
 
     // Extract right primitives
-    Real rho_r = prim_r(IDN,i);
-    Real pgas_r = prim_r(IPR,i);
-    Real uu1_r = prim_r(IVX,i);
-    Real uu2_r = prim_r(IVY,i);
-    Real uu3_r = prim_r(IVZ,i);
+    const Real &rho_r = prim_r(IDN,i);
+    const Real &pgas_r = prim_r(IPR,i);
+    const Real &uu1_r = prim_r(IVX,i);
+    const Real &uu2_r = prim_r(IVY,i);
+    const Real &uu3_r = prim_r(IVZ,i);
 
     // Calculate 4-velocity in left state
     Real ucon_l[4], ucov_l[4];
@@ -463,7 +447,7 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 
     // Calculate wavespeeds in right state
     Real lambda_p_r, lambda_m_r;
-    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    Real wgas_r = rho_r + gamma_adi/(gamma_adi-1.0) * pgas_r;
     pmb->peos->SoundSpeedsGR(wgas_r, pgas_r, ucon_r[0], ucon_r[IVY], g00, g02, g22,
                              &lambda_p_r, &lambda_m_r);
 
@@ -505,12 +489,11 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
     flux_r[IVZ] = wgas_r * ucon_r[IVY] * ucov_r[3];
     flux_r[IVY] += pgas_r;
 
-    Real flux_hll[NWAVE];
-    Real lambda_diff_inv = 1.0 / (lambda_r - lambda_l);
     // Calculate fluxes in HLL region
+    Real flux_hll[NWAVE];
     for (int n = 0; n < NWAVE; ++n) {
       flux_hll[n] = (lambda_r*flux_l[n] - lambda_l*flux_r[n]
-                     + lambda_r*lambda_l * (cons_r[n] - cons_l[n])) * lambda_diff_inv;
+                     + lambda_r*lambda_l * (cons_r[n] - cons_l[n])) / (lambda_r-lambda_l);
     }
 
     // Determine region of wavefan
@@ -528,7 +511,7 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
       flux(n,k,j,i) = flux_interface[n];
     }
   }
-#endif // GENERAL_RELATIVITY
+#endif  // GENERAL_RELATIVITY
   return;
 }
 } // namespace

--- a/src/hydro/rsolvers/hydro/hlle_rel.cpp
+++ b/src/hydro/rsolvers/hydro/hlle_rel.cpp
@@ -134,160 +134,147 @@ void HLLETransforming(MeshBlock *pmb, const int k, const int j, const int il,
   const Real gamma_adi = pmb->peos->GetGamma();
   const Real gamma_prime = gamma_adi / (gamma_adi - 1.0);
 
-  Real cons_l[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_l[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_r[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_r[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_hll[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_hll[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_interface[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_interface[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-
   // Go through each interface
-  for (int i=il; i<=iu; i+=SIMD_WIDTH) {
 #pragma omp simd simdlen(SIMD_WIDTH)
-    for (int m=0; m<std::min(SIMD_WIDTH, iu-i+1); m++) {
-      int ipm = i+m;
+  for (int i=il; i<=iu; ++i) {
+    // Extract left primitives
+    Real rho_l = prim_l(IDN,i);
+    Real pgas_l = prim_l(IPR,i);
+    Real u_l[4];
+    if (GENERAL_RELATIVITY) {
+      Real vx_l = prim_l(ivx,i);
+      Real vy_l = prim_l(ivy,i);
+      Real vz_l = prim_l(ivz,i);
+      u_l[0] = std::sqrt(1.0 + SQR(vx_l) + SQR(vy_l) + SQR(vz_l));
+      u_l[1] = vx_l;
+      u_l[2] = vy_l;
+      u_l[3] = vz_l;
+    } else {  // SR
+      Real vx_l = prim_l(ivx,i);
+      Real vy_l = prim_l(ivy,i);
+      Real vz_l = prim_l(ivz,i);
+      u_l[0] = std::sqrt(1.0 / (1.0 - SQR(vx_l) - SQR(vy_l) - SQR(vz_l)));
+      u_l[1] = u_l[0] * vx_l;
+      u_l[2] = u_l[0] * vy_l;
+      u_l[3] = u_l[0] * vz_l;
+    }
 
-      // Extract left primitives
-      Real rho_l = prim_l(IDN,ipm);
-      Real pgas_l = prim_l(IPR,ipm);
-      Real u_l[4];
-      if (GENERAL_RELATIVITY) {
-        Real vx_l = prim_l(ivx,ipm);
-        Real vy_l = prim_l(ivy,ipm);
-        Real vz_l = prim_l(ivz,ipm);
-        u_l[0] = std::sqrt(1.0 + SQR(vx_l) + SQR(vy_l) + SQR(vz_l));
-        u_l[1] = vx_l;
-        u_l[2] = vy_l;
-        u_l[3] = vz_l;
-      } else {  // SR
-        Real vx_l = prim_l(ivx,ipm);
-        Real vy_l = prim_l(ivy,ipm);
-        Real vz_l = prim_l(ivz,ipm);
-        u_l[0] = std::sqrt(1.0 / (1.0 - SQR(vx_l) - SQR(vy_l) - SQR(vz_l)));
-        u_l[1] = u_l[0] * vx_l;
-        u_l[2] = u_l[0] * vy_l;
-        u_l[3] = u_l[0] * vz_l;
-      }
+    // Extract right primitives
+    Real rho_r = prim_r(IDN,i);
+    Real pgas_r = prim_r(IPR,i);
+    Real u_r[4];
+    if (GENERAL_RELATIVITY) {
+      Real vx_r = prim_r(ivx,i);
+      Real vy_r = prim_r(ivy,i);
+      Real vz_r = prim_r(ivz,i);
+      u_r[0] = std::sqrt(1.0 + SQR(vx_r) + SQR(vy_r) + SQR(vz_r));
+      u_r[1] = vx_r;
+      u_r[2] = vy_r;
+      u_r[3] = vz_r;
+    } else {  // SR
+      Real vx_r = prim_r(ivx,i);
+      Real vy_r = prim_r(ivy,i);
+      Real vz_r = prim_r(ivz,i);
+      u_r[0] = std::sqrt(1.0 / (1.0 - SQR(vx_r) - SQR(vy_r) - SQR(vz_r)));
+      u_r[1] = u_r[0] * vx_r;
+      u_r[2] = u_r[0] * vy_r;
+      u_r[3] = u_r[0] * vz_r;
+    }
 
-      // Extract right primitives
-      Real rho_r = prim_r(IDN,ipm);
-      Real pgas_r = prim_r(IPR,ipm);
-      Real u_r[4];
-      if (GENERAL_RELATIVITY) {
-        Real vx_r = prim_r(ivx,ipm);
-        Real vy_r = prim_r(ivy,ipm);
-        Real vz_r = prim_r(ivz,ipm);
-        u_r[0] = std::sqrt(1.0 + SQR(vx_r) + SQR(vy_r) + SQR(vz_r));
-        u_r[1] = vx_r;
-        u_r[2] = vy_r;
-        u_r[3] = vz_r;
-      } else {  // SR
-        Real vx_r = prim_r(ivx,ipm);
-        Real vy_r = prim_r(ivy,ipm);
-        Real vz_r = prim_r(ivz,ipm);
-        u_r[0] = std::sqrt(1.0 / (1.0 - SQR(vx_r) - SQR(vy_r) - SQR(vz_r)));
-        u_r[1] = u_r[0] * vx_r;
-        u_r[2] = u_r[0] * vy_r;
-        u_r[3] = u_r[0] * vz_r;
-      }
+    // Calculate wavespeeds in left state (MB 23)
+    Real lambda_p_l, lambda_m_l;
+    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    pmb->peos->SoundSpeedsSR(wgas_l, pgas_l, u_l[1]/u_l[0], SQR(u_l[0]), &lambda_p_l,
+                             &lambda_m_l);
 
-      // Calculate wavespeeds in left state (MB 23)
-      Real lambda_p_l, lambda_m_l;
-      Real wgas_l = rho_l + gamma_prime * pgas_l;
-      pmb->peos->SoundSpeedsSR(wgas_l, pgas_l, u_l[1]/u_l[0], SQR(u_l[0]), &lambda_p_l,
-                               &lambda_m_l);
+    // Calculate wavespeeds in right state (MB 23)
+    Real lambda_p_r, lambda_m_r;
+    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    pmb->peos->SoundSpeedsSR(wgas_r, pgas_r, u_r[1]/u_r[0], SQR(u_r[0]), &lambda_p_r,
+                             &lambda_m_r);
 
-      // Calculate wavespeeds in right state (MB 23)
-      Real lambda_p_r, lambda_m_r;
-      Real wgas_r = rho_r + gamma_prime * pgas_r;
-      pmb->peos->SoundSpeedsSR(wgas_r, pgas_r, u_r[1]/u_r[0], SQR(u_r[0]), &lambda_p_r,
-                               &lambda_m_r);
+    // Calculate extremal wavespeeds
+    Real lambda_l = std::min(lambda_m_l, lambda_m_r);
+    Real lambda_r = std::max(lambda_p_l, lambda_p_r);
 
-      // Calculate extremal wavespeeds
-      Real lambda_l = std::min(lambda_m_l, lambda_m_r);
-      Real lambda_r = std::max(lambda_p_l, lambda_p_r);
+    // Calculate conserved quantities in L region (MB 3)
+    Real cons_l[NWAVE];
+    cons_l[IDN] = rho_l * u_l[0];
+    cons_l[IEN] = wgas_l * u_l[0] * u_l[0] - pgas_l;
+    cons_l[ivx] = wgas_l * u_l[1] * u_l[0];
+    cons_l[ivy] = wgas_l * u_l[2] * u_l[0];
+    cons_l[ivz] = wgas_l * u_l[3] * u_l[0];
 
-      // Calculate conserved quantities in L region (MB 3)
-      cons_l[IDN][m] = rho_l * u_l[0];
-      cons_l[IEN][m] = wgas_l * u_l[0] * u_l[0] - pgas_l;
-      cons_l[ivx][m] = wgas_l * u_l[1] * u_l[0];
-      cons_l[ivy][m] = wgas_l * u_l[2] * u_l[0];
-      cons_l[ivz][m] = wgas_l * u_l[3] * u_l[0];
+    // Calculate fluxes in L region (MB 2,3)
+    Real flux_l[NWAVE];
+    flux_l[IDN] = rho_l * u_l[1];
+    flux_l[IEN] = wgas_l * u_l[0] * u_l[1];
+    flux_l[ivx] = wgas_l * u_l[1] * u_l[1] + pgas_l;
+    flux_l[ivy] = wgas_l * u_l[2] * u_l[1];
+    flux_l[ivz] = wgas_l * u_l[3] * u_l[1];
 
-      // Calculate fluxes in L region (MB 2,3)
-      flux_l[IDN][m] = rho_l * u_l[1];
-      flux_l[IEN][m] = wgas_l * u_l[0] * u_l[1];
-      flux_l[ivx][m] = wgas_l * u_l[1] * u_l[1] + pgas_l;
-      flux_l[ivy][m] = wgas_l * u_l[2] * u_l[1];
-      flux_l[ivz][m]= wgas_l * u_l[3] * u_l[1];
+    // Calculate conserved quantities in R region (MB 3)
+    Real cons_r[NWAVE];
+    cons_r[IDN] = rho_r * u_r[0];
+    cons_r[IEN] = wgas_r * u_r[0] * u_r[0] - pgas_r;
+    cons_r[ivx] = wgas_r * u_r[1] * u_r[0];
+    cons_r[ivy] = wgas_r * u_r[2] * u_r[0];
+    cons_r[ivz] = wgas_r * u_r[3] * u_r[0];
 
-      // Calculate conserved quantities in R region (MB 3)
-      cons_r[IDN][m] = rho_r * u_r[0];
-      cons_r[IEN][m] = wgas_r * u_r[0] * u_r[0] - pgas_r;
-      cons_r[ivx][m] = wgas_r * u_r[1] * u_r[0];
-      cons_r[ivy][m] = wgas_r * u_r[2] * u_r[0];
-      cons_r[ivz][m] = wgas_r * u_r[3] * u_r[0];
+    // Calculate fluxes in R region (MB 2,3)
+    Real flux_r[NWAVE];
+    flux_r[IDN] = rho_r * u_r[1];
+    flux_r[IEN] = wgas_r * u_r[0] * u_r[1];
+    flux_r[ivx] = wgas_r * u_r[1] * u_r[1] + pgas_r;
+    flux_r[ivy] = wgas_r * u_r[2] * u_r[1];
+    flux_r[ivz] = wgas_r * u_r[3] * u_r[1];
 
-      // Calculate fluxes in R region (MB 2,3)
-      flux_r[IDN][m] = rho_r * u_r[1];
-      flux_r[IEN][m] = wgas_r * u_r[0] * u_r[1];
-      flux_r[ivx][m] = wgas_r * u_r[1] * u_r[1] + pgas_r;
-      flux_r[ivy][m] = wgas_r * u_r[2] * u_r[1];
-      flux_r[ivz][m] = wgas_r * u_r[3] * u_r[1];
-
-      Real lambda_diff_inv = 1.0 / (lambda_r-lambda_l);
-      // Calculate conserved quantities in HLL region in GR (MB 9)
-      if (GENERAL_RELATIVITY) {
-        for (int n = 0; n < NWAVE; ++n) {
-          cons_hll[n][m] = (lambda_r*cons_r[n][m] - lambda_l*cons_l[n][m]
-                            + flux_l[n][m] - flux_r[n][m]) * lambda_diff_inv;
-        }
-      }
-
-      // Calculate fluxes in HLL region (MB 11)
+    Real lambda_diff_inv = 1.0 / (lambda_r-lambda_l);
+    // Calculate conserved quantities in HLL region in GR (MB 9)
+    Real cons_hll[NWAVE];
+    if (GENERAL_RELATIVITY) {
       for (int n = 0; n < NWAVE; ++n) {
-        flux_hll[n][m] = (lambda_r*flux_l[n][m] - lambda_l*flux_r[n][m]
-                          + lambda_l*lambda_r * (cons_r[n][m] - cons_l[n][m]))
-                         * lambda_diff_inv;
+        cons_hll[n] = (lambda_r*cons_r[n] - lambda_l*cons_l[n] + flux_l[n] - flux_r[n])
+                      * lambda_diff_inv;
       }
+    }
 
-      // Calculate interface velocity
-      Real v_interface = 0.0;
-      if (GENERAL_RELATIVITY) {
-        v_interface = gi(i01,ipm) / std::sqrt(SQR(gi(i01,ipm)) - gi(I00,ipm)*gi(i11,ipm));
-      }
+    // Calculate fluxes in HLL region (MB 11)
+    Real flux_hll[NWAVE];
+    for (int n = 0; n < NWAVE; ++n) {
+      flux_hll[n] = (lambda_r*flux_l[n] - lambda_l*flux_r[n]
+                     + lambda_l*lambda_r * (cons_r[n] - cons_l[n])) * lambda_diff_inv;
+    }
 
-      // Determine region of wavefan
-      if (lambda_l >= v_interface) {  // L region
-        for (int n=0; n < NWAVE; ++n) {
-          cons_interface[n][m] = cons_l[n][m];
-          flux_interface[n][m] = flux_l[n][m];
-        }
-      } else if (lambda_r <= v_interface) { // R region
-        for (int n=0; n < NWAVE; ++n) {
-          cons_interface[n][m] = cons_r[n][m];
-          flux_interface[n][m] = flux_r[n][m];
-        }
-      } else {  // HLL region
-        for (int n=0; n < NWAVE; ++n) {
-          cons_interface[n][m] = cons_hll[n][m];
-          flux_interface[n][m] = flux_hll[n][m];
-        }
-      }
+    // Calculate interface velocity
+    Real v_interface = 0.0;
+    if (GENERAL_RELATIVITY) {
+      v_interface = gi(i01,i) / std::sqrt(SQR(gi(i01,i)) - gi(I00,i)*gi(i11,i));
+    }
 
-      // Set conserved quantities in GR
-      if (GENERAL_RELATIVITY) {
-        for (int n = 0; n < NWAVE; ++n) {
-          cons(n,ipm) = cons_interface[n][m];
-        }
-      }
+    // Determine region of wavefan
+    Real *cons_interface, *flux_interface;
+    if (lambda_l >= v_interface) {  // L region
+      cons_interface = cons_l;
+      flux_interface = flux_l;
+    } else if (lambda_r <= v_interface) { // R region
+      cons_interface = cons_r;
+      flux_interface = flux_r;
+    } else {  // HLL region
+      cons_interface = cons_hll;
+      flux_interface = flux_hll;
+    }
 
-      // Set fluxes
-      for (int n = 0; n < NHYDRO; ++n) {
-        flux(n,k,j,ipm) = flux_interface[n][m];
+    // Set conserved quantities in GR
+    if (GENERAL_RELATIVITY) {
+      for (int n = 0; n < NWAVE; ++n) {
+        cons(n,i) = cons_interface[n];
       }
+    }
+
+    // Set fluxes
+    for (int n = 0; n < NHYDRO; ++n) {
+      flux(n,k,j,i) = flux_interface[n];
     }
   }
 
@@ -328,42 +315,42 @@ void HLLETransforming(MeshBlock *pmb, const int k, const int j, const int il,
 void HLLENonTransforming(MeshBlock *pmb, const int k, const int j, const int il,
                          const int iu, AthenaArray<Real> &g, AthenaArray<Real> &gi,
                          AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-                         AthenaArray<Real> &flux) {
+                         AthenaArray<Real> &flux)
 #if GENERAL_RELATIVITY
+{
   // Extract ratio of specific heats
   const Real gamma_adi = pmb->peos->GetGamma();
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
 
   // Get metric components
   pmb->pcoord->Face2Metric(k, j, il, iu, g, gi);
 
   // Go through each interface
-#pragma omp simd simdlen(SIMD_WIDTH)
-  for (int i=il; i<=iu; i++) {
+#pragma omp simd
+  for (int i=il; i<=iu; ++i) {
     // Extract metric
-    Real g_00 = g(I00,i), g_01 = g(I01,i), g_02 = g(I02,i), g_03 = g(I03,i),
-         g_10 = g(I01,i), g_11 = g(I11,i), g_12 = g(I12,i), g_13 = g(I13,i),
-         g_20 = g(I02,i), g_21 = g(I12,i), g_22 = g(I22,i), g_23 = g(I23,i),
-         g_30 = g(I03,i), g_31 = g(I13,i), g_32 = g(I23,i), g_33 = g(I33,i);
-    Real g00 = gi(I00,i), g01 = gi(I01,i), g02 = gi(I02,i), g03 = gi(I03,i),
-         g10 = gi(I01,i), g11 = gi(I11,i), g12 = gi(I12,i), g13 = gi(I13,i),
-         g20 = gi(I02,i), g21 = gi(I12,i), g22 = gi(I22,i), g23 = gi(I23,i),
-         g30 = gi(I03,i), g31 = gi(I13,i), g32 = gi(I23,i), g33 = gi(I33,i);
+    const Real &g_00 = g(I00,i), &g_01 = g(I01,i), &g_02 = g(I02,i), &g_03 = g(I03,i),
+               &g_10 = g(I01,i), &g_11 = g(I11,i), &g_12 = g(I12,i), &g_13 = g(I13,i),
+               &g_20 = g(I02,i), &g_21 = g(I12,i), &g_22 = g(I22,i), &g_23 = g(I23,i),
+               &g_30 = g(I03,i), &g_31 = g(I13,i), &g_32 = g(I23,i), &g_33 = g(I33,i);
+    const Real &g00 = gi(I00,i), &g01 = gi(I01,i), &g02 = gi(I02,i), &g03 = gi(I03,i),
+               &g10 = gi(I01,i), &g11 = gi(I11,i), &g12 = gi(I12,i), &g13 = gi(I13,i),
+               &g20 = gi(I02,i), &g21 = gi(I12,i), &g22 = gi(I22,i), &g23 = gi(I23,i),
+               &g30 = gi(I03,i), &g31 = gi(I13,i), &g32 = gi(I23,i), &g33 = gi(I33,i);
     Real alpha = std::sqrt(-1.0/g00);
 
     // Extract left primitives
-    Real rho_l = prim_l(IDN,i);
-    Real pgas_l = prim_l(IPR,i);
-    Real uu1_l = prim_l(IVX,i);
-    Real uu2_l = prim_l(IVY,i);
-    Real uu3_l = prim_l(IVZ,i);
+    const Real &rho_l = prim_l(IDN,i);
+    const Real &pgas_l = prim_l(IPR,i);
+    const Real &uu1_l = prim_l(IVX,i);
+    const Real &uu2_l = prim_l(IVY,i);
+    const Real &uu3_l = prim_l(IVZ,i);
 
     // Extract right primitives
-    Real rho_r = prim_r(IDN,i);
-    Real pgas_r = prim_r(IPR,i);
-    Real uu1_r = prim_r(IVX,i);
-    Real uu2_r = prim_r(IVY,i);
-    Real uu3_r = prim_r(IVZ,i);
+    const Real &rho_r = prim_r(IDN,i);
+    const Real &pgas_r = prim_r(IPR,i);
+    const Real &uu1_r = prim_r(IVX,i);
+    const Real &uu2_r = prim_r(IVY,i);
+    const Real &uu3_r = prim_r(IVZ,i);
 
     // Calculate 4-velocity in left state
     Real ucon_l[4], ucov_l[4];
@@ -397,13 +384,13 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j, const int il,
 
     // Calculate wavespeeds in left state
     Real lambda_p_l, lambda_m_l;
-    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    Real wgas_l = rho_l + gamma_adi/(gamma_adi-1.0) * pgas_l;
     pmb->peos->SoundSpeedsGR(wgas_l, pgas_l, ucon_l[0], ucon_l[IVY], g00, g02, g22,
                              &lambda_p_l, &lambda_m_l);
 
     // Calculate wavespeeds in right state
     Real lambda_p_r, lambda_m_r;
-    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    Real wgas_r = rho_r + gamma_adi/(gamma_adi-1.0) * pgas_r;
     pmb->peos->SoundSpeedsGR(wgas_r, pgas_r, ucon_r[0], ucon_r[IVY], g00, g02, g22,
                              &lambda_p_r, &lambda_m_r);
 
@@ -445,13 +432,11 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j, const int il,
     flux_r[IVZ] = wgas_r * ucon_r[IVY] * ucov_r[3];
     flux_r[IVY] += pgas_r;
 
-    Real flux_hll[NWAVE];
-    Real lambda_diff_inv = 1.0 / (lambda_r-lambda_l);
     // Calculate fluxes in HLL region
+    Real flux_hll[NWAVE];
     for (int n = 0; n < NWAVE; ++n) {
       flux_hll[n] = (lambda_r*flux_l[n] - lambda_l*flux_r[n]
-                     + lambda_r*lambda_l * (cons_r[n] - cons_l[n]))
-                    * lambda_diff_inv;
+                     + lambda_r*lambda_l * (cons_r[n] - cons_l[n])) / (lambda_r-lambda_l);
     }
 
     // Determine region of wavefan
@@ -469,7 +454,12 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j, const int il,
       flux(n,k,j,i) = flux_interface[n];
     }
   }
-#endif // GENERAL_RELATIVITY
   return;
 }
+
+#else
+{
+  return;
+}
+#endif  // GENERAL_RELATIVITY
 } // namespace

--- a/src/hydro/rsolvers/hydro/hlle_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/hydro/hlle_rel_no_transform.cpp
@@ -31,8 +31,8 @@
 // Outputs:
 //   flux: 3D array of hydrodynamical fluxes across interfaces
 // Notes:
-//   implements LLF algorithm similar to that of fluxcalc() in step_ch.c in Harm
-//   cf. LLFNonTransforming() in llf_rel.cpp
+//   implements HLLE algorithm similar to that of fluxcalc() in step_ch.c in Harm
+//   cf. HLLENonTransforming() in hlle_rel.cpp and hllc_rel.cpp
 
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx,
@@ -44,7 +44,6 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
   // Extract ratio of specific heats
   const Real gamma_adi = pmy_block->peos->GetGamma();
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
 
   // Get metric components
   switch (ivx) {
@@ -58,44 +57,51 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
       pmy_block->pcoord->Face3Metric(k, j, il, iu, g_, gi_);
       break;
   }
+
   // Go through each interface
-#pragma omp simd simdlen(SIMD_WIDTH)
-  for (int i=il; i<=iu; ++i) {
+#pragma omp simd
+  for (int i = il; i <= iu; ++i) {
     // Extract metric
-    Real g_00 = g_(I00,i), g_01 = g_(I01,i), g_02 = g_(I02,i), g_03 = g_(I03,i),
-         g_10 = g_(I01,i), g_11 = g_(I11,i), g_12 = g_(I12,i), g_13 = g_(I13,i),
-         g_20 = g_(I02,i), g_21 = g_(I12,i), g_22 = g_(I22,i), g_23 = g_(I23,i),
-         g_30 = g_(I03,i), g_31 = g_(I13,i), g_32 = g_(I23,i), g_33 = g_(I33,i);
-    Real g00 = gi_(I00,i), g01 = gi_(I01,i), g02 = gi_(I02,i), g03 = gi_(I03,i),
-         g10 = gi_(I01,i), g11 = gi_(I11,i), g12 = gi_(I12,i), g13 = gi_(I13,i),
-         g20 = gi_(I02,i), g21 = gi_(I12,i), g22 = gi_(I22,i), g23 = gi_(I23,i),
-         g30 = gi_(I03,i), g31 = gi_(I13,i), g32 = gi_(I23,i), g33 = gi_(I33,i);
+    const Real
+        &g_00 = g_(I00,i), &g_01 = g_(I01,i), &g_02 = g_(I02,i), &g_03 = g_(I03,i),
+        &g_10 = g_(I01,i), &g_11 = g_(I11,i), &g_12 = g_(I12,i), &g_13 = g_(I13,i),
+        &g_20 = g_(I02,i), &g_21 = g_(I12,i), &g_22 = g_(I22,i), &g_23 = g_(I23,i),
+        &g_30 = g_(I03,i), &g_31 = g_(I13,i), &g_32 = g_(I23,i), &g_33 = g_(I33,i);
+    const Real
+        &g00 = gi_(I00,i), &g01 = gi_(I01,i), &g02 = gi_(I02,i), &g03 = gi_(I03,i),
+        &g10 = gi_(I01,i), &g11 = gi_(I11,i), &g12 = gi_(I12,i), &g13 = gi_(I13,i),
+        &g20 = gi_(I02,i), &g21 = gi_(I12,i), &g22 = gi_(I22,i), &g23 = gi_(I23,i),
+        &g30 = gi_(I03,i), &g31 = gi_(I13,i), &g32 = gi_(I23,i), &g33 = gi_(I33,i);
     Real alpha = std::sqrt(-1.0/g00);
     Real gii, g0i;
-    if (ivx==IVX) {
-      gii = g11;
-      g0i = g01;
-    } else if (ivx==IVY) {
-      gii = g22;
-      g0i = g02;
-    } else if (ivx==IVZ) {
-      gii = g33;
-      g0i = g03;
+    switch (ivx) {
+      case IVX:
+        gii = g11;
+        g0i = g01;
+        break;
+      case IVY:
+        gii = g22;
+        g0i = g02;
+        break;
+      case IVZ:
+        gii = g33;
+        g0i = g03;
+        break;
     }
 
     // Extract left primitives
-    Real rho_l = prim_l(IDN,i);
-    Real pgas_l = prim_l(IPR,i);
-    Real uu1_l = prim_l(IVX,i);
-    Real uu2_l = prim_l(IVY,i);
-    Real uu3_l = prim_l(IVZ,i);
+    const Real &rho_l = prim_l(IDN,i);
+    const Real &pgas_l = prim_l(IPR,i);
+    const Real &uu1_l = prim_l(IVX,i);
+    const Real &uu2_l = prim_l(IVY,i);
+    const Real &uu3_l = prim_l(IVZ,i);
 
     // Extract right primitives
-    Real rho_r = prim_r(IDN,i);
-    Real pgas_r = prim_r(IPR,i);
-    Real uu1_r = prim_r(IVX,i);
-    Real uu2_r = prim_r(IVY,i);
-    Real uu3_r = prim_r(IVZ,i);
+    const Real &rho_r = prim_r(IDN,i);
+    const Real &pgas_r = prim_r(IPR,i);
+    const Real &uu1_r = prim_r(IVX,i);
+    const Real &uu2_r = prim_r(IVY,i);
+    const Real &uu3_r = prim_r(IVZ,i);
 
     // Calculate 4-velocity in left state
     Real ucon_l[4], ucov_l[4];
@@ -129,13 +135,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
     // Calculate wavespeeds in left state
     Real lambda_p_l, lambda_m_l;
-    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    Real wgas_l = rho_l + gamma_adi/(gamma_adi-1.0) * pgas_l;
     pmy_block->peos->SoundSpeedsGR(wgas_l, pgas_l, ucon_l[0], ucon_l[ivx], g00, g0i,
                                    gii, &lambda_p_l, &lambda_m_l);
 
     // Calculate wavespeeds in right state
     Real lambda_p_r, lambda_m_r;
-    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    Real wgas_r = rho_r + gamma_adi/(gamma_adi-1.0) * pgas_r;
     pmy_block->peos->SoundSpeedsGR(wgas_r, pgas_r, ucon_r[0], ucon_r[ivx], g00, g0i,
                                    gii, &lambda_p_r, &lambda_m_r);
 
@@ -178,12 +184,10 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     flux_r[ivx] += pgas_r;
 
     // Calculate fluxes in HLL region
-    Real lambda_diff_inv = 1.0 / (lambda_r-lambda_l);
     Real flux_hll[NWAVE];
     for (int n = 0; n < NWAVE; ++n) {
       flux_hll[n] = (lambda_r*flux_l[n] - lambda_l*flux_r[n]
-                     + lambda_r*lambda_l * (cons_r[n] - cons_l[n]))
-                    * lambda_diff_inv;
+                     + lambda_r*lambda_l * (cons_r[n] - cons_l[n])) / (lambda_r-lambda_l);
     }
 
     // Determine region of wavefan

--- a/src/hydro/rsolvers/hydro/llf_rel.cpp
+++ b/src/hydro/rsolvers/hydro/llf_rel.cpp
@@ -259,38 +259,37 @@ void LLFNonTransforming(MeshBlock *pmb, const int k, const int j,
 #if GENERAL_RELATIVITY
   // Extract ratio of specific heats
   const Real gamma_adi = pmb->peos->GetGamma();
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
 
   // Get metric components
   pmb->pcoord->Face2Metric(k, j, il, iu, g, gi);
 
   // Go through each interface
-#pragma omp simd simdlen(SIMD_WIDTH)
+#pragma omp simd
   for (int i=il; i<=iu; ++i) {
     // Extract metric
-    Real g_00 = g(I00,i), g_01 = g(I01,i), g_02 = g(I02,i), g_03 = g(I03,i),
-         g_10 = g(I01,i), g_11 = g(I11,i), g_12 = g(I12,i), g_13 = g(I13,i),
-         g_20 = g(I02,i), g_21 = g(I12,i), g_22 = g(I22,i), g_23 = g(I23,i),
-         g_30 = g(I03,i), g_31 = g(I13,i), g_32 = g(I23,i), g_33 = g(I33,i);
-    Real g00 = gi(I00,i), g01 = gi(I01,i), g02 = gi(I02,i), g03 = gi(I03,i),
-         g10 = gi(I01,i), g11 = gi(I11,i), g12 = gi(I12,i), g13 = gi(I13,i),
-         g20 = gi(I02,i), g21 = gi(I12,i), g22 = gi(I22,i), g23 = gi(I23,i),
-         g30 = gi(I03,i), g31 = gi(I13,i), g32 = gi(I23,i), g33 = gi(I33,i);
+    const Real &g_00 = g(I00,i), &g_01 = g(I01,i), &g_02 = g(I02,i), &g_03 = g(I03,i),
+               &g_10 = g(I01,i), &g_11 = g(I11,i), &g_12 = g(I12,i), &g_13 = g(I13,i),
+               &g_20 = g(I02,i), &g_21 = g(I12,i), &g_22 = g(I22,i), &g_23 = g(I23,i),
+               &g_30 = g(I03,i), &g_31 = g(I13,i), &g_32 = g(I23,i), &g_33 = g(I33,i);
+    const Real &g00 = gi(I00,i), &g01 = gi(I01,i), &g02 = gi(I02,i), &g03 = gi(I03,i),
+               &g10 = gi(I01,i), &g11 = gi(I11,i), &g12 = gi(I12,i), &g13 = gi(I13,i),
+               &g20 = gi(I02,i), &g21 = gi(I12,i), &g22 = gi(I22,i), &g23 = gi(I23,i),
+               &g30 = gi(I03,i), &g31 = gi(I13,i), &g32 = gi(I23,i), &g33 = gi(I33,i);
     Real alpha = std::sqrt(-1.0/g00);
 
     // Extract left primitives
-    Real rho_l = prim_l(IDN,i);
-    Real pgas_l = prim_l(IPR,i);
-    Real uu1_l = prim_l(IVX,i);
-    Real uu2_l = prim_l(IVY,i);
-    Real uu3_l = prim_l(IVZ,i);
+    const Real &rho_l = prim_l(IDN,i);
+    const Real &pgas_l = prim_l(IPR,i);
+    const Real &uu1_l = prim_l(IVX,i);
+    const Real &uu2_l = prim_l(IVY,i);
+    const Real &uu3_l = prim_l(IVZ,i);
 
     // Extract right primitives
-    Real rho_r = prim_r(IDN,i);
-    Real pgas_r = prim_r(IPR,i);
-    Real uu1_r = prim_r(IVX,i);
-    Real uu2_r = prim_r(IVY,i);
-    Real uu3_r = prim_r(IVZ,i);
+    const Real &rho_r = prim_r(IDN,i);
+    const Real &pgas_r = prim_r(IPR,i);
+    const Real &uu1_r = prim_r(IVX,i);
+    const Real &uu2_r = prim_r(IVY,i);
+    const Real &uu3_r = prim_r(IVZ,i);
 
     // Calculate 4-velocity in left state
     Real ucon_l[4], ucov_l[4];
@@ -324,13 +323,13 @@ void LLFNonTransforming(MeshBlock *pmb, const int k, const int j,
 
     // Calculate wavespeeds in left state
     Real lambda_p_l, lambda_m_l;
-    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    Real wgas_l = rho_l + gamma_adi/(gamma_adi-1.0) * pgas_l;
     pmb->peos->SoundSpeedsGR(wgas_l, pgas_l, ucon_l[0], ucon_l[IVY], g00, g02, g22,
                              &lambda_p_l, &lambda_m_l);
 
     // Calculate wavespeeds in right state
     Real lambda_p_r, lambda_m_r;
-    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    Real wgas_r = rho_r + gamma_adi/(gamma_adi-1.0) * pgas_r;
     pmb->peos->SoundSpeedsGR(wgas_r, pgas_r, ucon_r[0], ucon_r[IVY], g00, g02, g22,
                              &lambda_p_r, &lambda_m_r);
 
@@ -378,7 +377,7 @@ void LLFNonTransforming(MeshBlock *pmb, const int k, const int j,
       flux(n,k,j,i) = 0.5 * (flux_l[n] + flux_r[n] - lambda * (cons_r[n] - cons_l[n]));
     }
   }
-#endif // GENERAL_RELATIVITY
+#endif  // GENERAL_RELATIVITY
   return;
 }
 } // namespace

--- a/src/hydro/rsolvers/hydro/llf_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/hydro/llf_rel_no_transform.cpp
@@ -45,7 +45,6 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
   // Extract ratio of specific heats
   const Real gamma_adi = pmy_block->peos->GetGamma();
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
 
   // Get metric components
   switch (ivx) {
@@ -61,44 +60,49 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   }
 
   // Go through each interface
-#pragma omp simd simdlen(SIMD_WIDTH)
-  for (int i=il; i<=iu; ++i) {
+#pragma omp simd
+  for (int i = il; i <= iu; ++i) {
     // Extract metric
-    Real g_00 = g_(I00,i), g_01 = g_(I01,i), g_02 = g_(I02,i), g_03 = g_(I03,i),
-         g_10 = g_(I01,i), g_11 = g_(I11,i), g_12 = g_(I12,i), g_13 = g_(I13,i),
-         g_20 = g_(I02,i), g_21 = g_(I12,i), g_22 = g_(I22,i), g_23 = g_(I23,i),
-         g_30 = g_(I03,i), g_31 = g_(I13,i), g_32 = g_(I23,i), g_33 = g_(I33,i);
-    Real g00 = gi_(I00,i), g01 = gi_(I01,i), g02 = gi_(I02,i), g03 = gi_(I03,i),
-         g10 = gi_(I01,i), g11 = gi_(I11,i), g12 = gi_(I12,i), g13 = gi_(I13,i),
-         g20 = gi_(I02,i), g21 = gi_(I12,i), g22 = gi_(I22,i), g23 = gi_(I23,i),
-         g30 = gi_(I03,i), g31 = gi_(I13,i), g32 = gi_(I23,i), g33 = gi_(I33,i);
+    const Real
+        &g_00 = g_(I00,i), &g_01 = g_(I01,i), &g_02 = g_(I02,i), &g_03 = g_(I03,i),
+        &g_10 = g_(I01,i), &g_11 = g_(I11,i), &g_12 = g_(I12,i), &g_13 = g_(I13,i),
+        &g_20 = g_(I02,i), &g_21 = g_(I12,i), &g_22 = g_(I22,i), &g_23 = g_(I23,i),
+        &g_30 = g_(I03,i), &g_31 = g_(I13,i), &g_32 = g_(I23,i), &g_33 = g_(I33,i);
+    const Real
+        &g00 = gi_(I00,i), &g01 = gi_(I01,i), &g02 = gi_(I02,i), &g03 = gi_(I03,i),
+        &g10 = gi_(I01,i), &g11 = gi_(I11,i), &g12 = gi_(I12,i), &g13 = gi_(I13,i),
+        &g20 = gi_(I02,i), &g21 = gi_(I12,i), &g22 = gi_(I22,i), &g23 = gi_(I23,i),
+        &g30 = gi_(I03,i), &g31 = gi_(I13,i), &g32 = gi_(I23,i), &g33 = gi_(I33,i);
     Real alpha = std::sqrt(-1.0/g00);
     Real gii, g0i;
-
-    if (ivx==IVX) {
-      gii = g11;
-      g0i = g01;
-    } else if (ivx==IVY) {
-      gii = g22;
-      g0i = g02;
-    } else if (ivx==IVZ) {
-      gii = g33;
-      g0i = g03;
+    switch (ivx) {
+      case IVX:
+        gii = g11;
+        g0i = g01;
+        break;
+      case IVY:
+        gii = g22;
+        g0i = g02;
+        break;
+      case IVZ:
+        gii = g33;
+        g0i = g03;
+        break;
     }
 
     // Extract left primitives
-    Real rho_l = prim_l(IDN,i);
-    Real pgas_l = prim_l(IPR,i);
-    Real uu1_l = prim_l(IVX,i);
-    Real uu2_l = prim_l(IVY,i);
-    Real uu3_l = prim_l(IVZ,i);
+    const Real &rho_l = prim_l(IDN,i);
+    const Real &pgas_l = prim_l(IPR,i);
+    const Real &uu1_l = prim_l(IVX,i);
+    const Real &uu2_l = prim_l(IVY,i);
+    const Real &uu3_l = prim_l(IVZ,i);
 
     // Extract right primitives
-    Real rho_r = prim_r(IDN,i);
-    Real pgas_r = prim_r(IPR,i);
-    Real uu1_r = prim_r(IVX,i);
-    Real uu2_r = prim_r(IVY,i);
-    Real uu3_r = prim_r(IVZ,i);
+    const Real &rho_r = prim_r(IDN,i);
+    const Real &pgas_r = prim_r(IPR,i);
+    const Real &uu1_r = prim_r(IVX,i);
+    const Real &uu2_r = prim_r(IVY,i);
+    const Real &uu3_r = prim_r(IVZ,i);
 
     // Calculate 4-velocity in left state
     Real ucon_l[4], ucov_l[4];
@@ -132,13 +136,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
     // Calculate wavespeeds in left state
     Real lambda_p_l, lambda_m_l;
-    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    Real wgas_l = rho_l + gamma_adi/(gamma_adi-1.0) * pgas_l;
     pmy_block->peos->SoundSpeedsGR(wgas_l, pgas_l, ucon_l[0], ucon_l[ivx], g00, g0i,
                                    gii, &lambda_p_l, &lambda_m_l);
 
     // Calculate wavespeeds in right state
     Real lambda_p_r, lambda_m_r;
-    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    Real wgas_r = rho_r + gamma_adi/(gamma_adi-1.0) * pgas_r;
     pmy_block->peos->SoundSpeedsGR(wgas_r, pgas_r, ucon_r[0], ucon_r[ivx], g00, g0i,
                                    gii, &lambda_p_r, &lambda_m_r);
 

--- a/src/hydro/rsolvers/mhd/hlld_rel.cpp
+++ b/src/hydro/rsolvers/mhd/hlld_rel.cpp
@@ -53,7 +53,7 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 //   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
 //   bb: 3D array of normal magnetic fields
 //   prim_l,prim_r: 1D arrays of left and right primitive states
-//   dxw: 1D arrays of mesh spacing in the x-direction
+//   dxw: 1D array of mesh spacing in the x-direction
 // Outputs:
 //   flux: 3D array of hydrodynamical fluxes across interfaces
 //   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
@@ -72,17 +72,19 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           AthenaArray<Real> &ey, AthenaArray<Real> &ez,
                           AthenaArray<Real> &wct, const AthenaArray<Real> &dxw) {
   Real dt = pmy_block->pmy_mesh->dt;
-
   if (GENERAL_RELATIVITY && ivx == IVY && pmy_block->pcoord->IsPole(j)) {
     HLLENonTransforming(pmy_block, k, j, il, iu, bb, g_, gi_, prim_l, prim_r, flux, ey,
                         ez);
   } else {
-    HLLDTransforming(pmy_block, k, j, il, iu, ivx, bb, bb_normal_, lambdas_p_l_,
-                     lambdas_m_l_, lambdas_p_r_, lambdas_m_r_, g_, gi_, prim_l, prim_r,
-                     cons_, flux, ey, ez);
+    HLLDTransforming(pmy_block, k, j, il, iu, ivx, bb, bb_normal_,
+                     lambdas_p_l_, lambdas_m_l_, lambdas_p_r_, lambdas_m_r_,
+                     g_, gi_,
+                     prim_l, prim_r, cons_, flux,
+                     ey, ez);
   }
   for(int i=il; i<=iu; ++i) {
-    wct(k,j,i)=GetWeightForCT(flux(IDN,k,j,i), prim_l(IDN,i), prim_r(IDN,i), dxw(i), dt);
+    wct(k,j,i) = GetWeightForCT(flux(IDN,k,j,i), prim_l(IDN,i), prim_r(IDN,i), dxw(i),
+                                dt);
   }
   return;
 }
@@ -449,7 +451,7 @@ void HLLDTransforming(MeshBlock *pmb, const int k, const int j,
       Real eta_l, eta_r;
 
       // Apply secant method to find total pressure
-      Real tol_ptot = 1.0e-8 * ptot_init[m];
+      Real tol_ptot = 1.0e-8 * ptot_init[m];  // unused variable
       // Calculate initial pressure residual
       ptot_0[m] = ptot_init[m];
       {
@@ -663,11 +665,9 @@ void HLLDTransforming(MeshBlock *pmb, const int k, const int j,
         vx_al = (bbx * (al*bbx+lambda_l*cl)
                  - (al+gl) * (ptot_n+r_l[ivx][m])) * xl_inv;  // (MUB 23)
         vy_al = (ql*r_l[ivy][m] + r_l[IBY][m]
-                 * (cl + bbx * (lambda_l*r_l[ivx][m]
-                                -r_l[IEN][m]))) * xl_inv;  // (MUB 24)
+                 * (cl + bbx * (lambda_l*r_l[ivx][m] -r_l[IEN][m]))) * xl_inv; // (MUB 24)
         vz_al = (ql*r_l[ivz][m] + r_l[IBZ][m]
-                 * (cl + bbx * (lambda_l*r_l[ivx][m]
-                                -r_l[IEN][m]))) * xl_inv;  // (MUB 24)
+                 * (cl + bbx * (lambda_l*r_l[ivx][m] -r_l[IEN][m]))) * xl_inv; // (MUB 24)
         Real ar = r_r[ivx][m] - lambda_r*r_r[IEN][m]
                   + ptot_n*(1.0-SQR(lambda_r));  // (MUB 26)
         Real gr = SQR(r_r[IBY][m]) + SQR(r_r[IBZ][m]);  // (MUB 27)
@@ -678,11 +678,9 @@ void HLLDTransforming(MeshBlock *pmb, const int k, const int j,
         vx_ar = (bbx * (ar*bbx+lambda_r*cr)
                  - (ar+gr) * (ptot_n+r_r[ivx][m])) * xr_inv;  // (MUB 23)
         vy_ar = (qr*r_r[ivy][m] + r_r[IBY][m]
-                 * (cr + bbx * (lambda_r*r_r[ivx][m]
-                                -r_r[IEN][m]))) * xr_inv;  // (MUB 24)
+                 * (cr + bbx * (lambda_r*r_r[ivx][m] -r_r[IEN][m]))) * xr_inv; // (MUB 24)
         vz_ar = (qr*r_r[ivz][m] + r_r[IBZ][m]
-                 * (cr + bbx * (lambda_r*r_r[ivx][m]
-                                -r_r[IEN][m]))) * xr_inv;  // (MUB 24)
+                 * (cr + bbx * (lambda_r*r_r[ivx][m] -r_r[IEN][m]))) * xr_inv; // (MUB 24)
 
         // Calculate B_aL and B_aR (MUB 21)
         cons_al[IBY][m] = (r_l[IBY][m] - bbx*vy_al) / (lambda_l-vx_al);
@@ -983,7 +981,7 @@ Real EResidualPrime(Real w_guess, Real dd, Real m_sq, Real bb_sq, Real ss_sq,
   Real w_cu = SQR(w_guess) * w_guess;
   Real w_b_cu = SQR(w_guess + bb_sq) * (w_guess + bb_sq);
   Real dv_sq_dw = -2.0 / (w_cu*w_b_cu)                                // (MM A16)
-                  * (ss_sq * (3.0*w_guess*(w_guess+bb_sq) + SQR(bb_sq)) + m_sq*w_cu);
+                  * (ss_sq* (3.0*w_guess*(w_guess+bb_sq) + SQR(bb_sq)) + m_sq*w_cu);
   Real dchi_dw = 1.0 - v_sq                                           // (cf. MM A14)
                  - gamma_lorentz/2.0 * (dd + 2.0*gamma_lorentz*chi) * dv_sq_dw;
   Real drho_dw = -gamma_lorentz*dd/2.0 * dv_sq_dw;                    // (MM A15)
@@ -1001,7 +999,7 @@ Real EResidualPrime(Real w_guess, Real dd, Real m_sq, Real bb_sq, Real ss_sq,
 //   il,iu: lower and upper x1-indices
 //   bb: 3D array of normal magnetic fields
 //   g,gi: 1D scratch arrays for metric coefficients
-//   prim_l,prim_r: 1D arrays of left and right primitive states
+//   prim_l,prim_r: 3D arrays of left and right primitive states
 // Outputs:
 //   flux: 3D array of hydrodynamical fluxes across interfaces
 //   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
@@ -1020,44 +1018,43 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 #if GENERAL_RELATIVITY
   // Extract ratio of specific heats
   const Real gamma_adi = pmb->peos->GetGamma();
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
 
   // Get metric components
   pmb->pcoord->Face2Metric(k, j, il, iu, g, gi);
 
   // Go through each interface
-#pragma omp simd simdlen(SIMD_WIDTH)
-  for (int i=il; i<=iu; i++) {
+#pragma omp simd
+  for (int i=il; i<=iu; ++i) {
     // Extract metric
-    Real g_00 = g(I00,i), g_01 = g(I01,i), g_02 = g(I02,i), g_03 = g(I03,i),
-         g_10 = g(I01,i), g_11 = g(I11,i), g_12 = g(I12,i), g_13 = g(I13,i),
-         g_20 = g(I02,i), g_21 = g(I12,i), g_22 = g(I22,i), g_23 = g(I23,i),
-         g_30 = g(I03,i), g_31 = g(I13,i), g_32 = g(I23,i), g_33 = g(I33,i);
-    Real g00 = gi(I00,i), g01 = gi(I01,i), g02 = gi(I02,i), g03 = gi(I03,i),
-         g10 = gi(I01,i), g11 = gi(I11,i), g12 = gi(I12,i), g13 = gi(I13,i),
-         g20 = gi(I02,i), g21 = gi(I12,i), g22 = gi(I22,i), g23 = gi(I23,i),
-         g30 = gi(I03,i), g31 = gi(I13,i), g32 = gi(I23,i), g33 = gi(I33,i);
+    const Real &g_00 = g(I00,i), &g_01 = g(I01,i), &g_02 = g(I02,i), &g_03 = g(I03,i),
+               &g_10 = g(I01,i), &g_11 = g(I11,i), &g_12 = g(I12,i), &g_13 = g(I13,i),
+               &g_20 = g(I02,i), &g_21 = g(I12,i), &g_22 = g(I22,i), &g_23 = g(I23,i),
+               &g_30 = g(I03,i), &g_31 = g(I13,i), &g_32 = g(I23,i), &g_33 = g(I33,i);
+    const Real &g00 = gi(I00,i), &g01 = gi(I01,i), &g02 = gi(I02,i), &g03 = gi(I03,i),
+               &g10 = gi(I01,i), &g11 = gi(I11,i), &g12 = gi(I12,i), &g13 = gi(I13,i),
+               &g20 = gi(I02,i), &g21 = gi(I12,i), &g22 = gi(I22,i), &g23 = gi(I23,i),
+               &g30 = gi(I03,i), &g31 = gi(I13,i), &g32 = gi(I23,i), &g33 = gi(I33,i);
     Real alpha = std::sqrt(-1.0/g00);
 
     // Extract left primitives
-    Real rho_l = prim_l(IDN,i);
-    Real pgas_l = prim_l(IPR,i);
-    Real uu1_l = prim_l(IVX,i);
-    Real uu2_l = prim_l(IVY,i);
-    Real uu3_l = prim_l(IVZ,i);
-    Real bb2_l = bb(k,j,i);
-    Real bb3_l = prim_l(IBY,i);
-    Real bb1_l = prim_l(IBZ,i);
+    const Real &rho_l = prim_l(IDN,i);
+    const Real &pgas_l = prim_l(IPR,i);
+    const Real &uu1_l = prim_l(IVX,i);
+    const Real &uu2_l = prim_l(IVY,i);
+    const Real &uu3_l = prim_l(IVZ,i);
+    const Real &bb2_l = bb(k,j,i);
+    const Real &bb3_l = prim_l(IBY,i);
+    const Real &bb1_l = prim_l(IBZ,i);
 
     // Extract right primitives
-    Real rho_r = prim_r(IDN,i);
-    Real pgas_r = prim_r(IPR,i);
-    Real uu1_r = prim_r(IVX,i);
-    Real uu2_r = prim_r(IVY,i);
-    Real uu3_r = prim_r(IVZ,i);
-    Real bb2_r = bb(k,j,i);
-    Real bb3_r = prim_r(IBY,i);
-    Real bb1_r = prim_r(IBZ,i);
+    const Real &rho_r = prim_r(IDN,i);
+    const Real &pgas_r = prim_r(IPR,i);
+    const Real &uu1_r = prim_r(IVX,i);
+    const Real &uu2_r = prim_r(IVY,i);
+    const Real &uu3_r = prim_r(IVZ,i);
+    const Real &bb2_r = bb(k,j,i);
+    const Real &bb3_r = prim_r(IBY,i);
+    const Real &bb1_r = prim_r(IBZ,i);
 
     // Calculate 4-velocity in left state
     Real ucon_l[4], ucov_l[4];
@@ -1123,13 +1120,13 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 
     // Calculate wavespeeds in left state
     Real lambda_p_l, lambda_m_l;
-    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    Real wgas_l = rho_l + gamma_adi/(gamma_adi-1.0) * pgas_l;
     pmb->peos->FastMagnetosonicSpeedsGR(wgas_l, pgas_l, ucon_l[0], ucon_l[IVY], b_sq_l,
                                         g00, g02, g22, &lambda_p_l, &lambda_m_l);
 
     // Calculate wavespeeds in right state
     Real lambda_p_r, lambda_m_r;
-    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    Real wgas_r = rho_r + gamma_adi/(gamma_adi-1.0) * pgas_r;
     pmb->peos->FastMagnetosonicSpeedsGR(wgas_r, pgas_r, ucon_r[0], ucon_r[IVY], b_sq_r,
                                         g00, g02, g22, &lambda_p_r, &lambda_m_r);
 
@@ -1187,13 +1184,12 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
     flux_r[IBY] = bcon_r[IVZ] * ucon_r[IVY] - bcon_r[IVY] * ucon_r[IVZ];
     flux_r[IBZ] = bcon_r[IVX] * ucon_r[IVY] - bcon_r[IVY] * ucon_r[IVX];
 
-    Real lambda_diff_inv = 1.0 / (lambda_r-lambda_l);
     // Calculate fluxes in HLL region
     Real flux_hll[NWAVE];
     for (int n = 0; n < NWAVE; ++n) {
       flux_hll[n] = (lambda_r*flux_l[n] - lambda_l*flux_r[n]
                      + lambda_r*lambda_l * (cons_r[n] - cons_l[n]))
-                    * lambda_diff_inv;
+                    / (lambda_r-lambda_l);
     }
 
     // Determine region of wavefan
@@ -1213,8 +1209,7 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
     ey(k,j,i) = -flux_interface[IBY];
     ez(k,j,i) = flux_interface[IBZ];
   }
-#endif // GENERAL_RELATIVITY
+#endif  // GENERAL_RELATIVITY
   return;
 }
-
 } // namespace

--- a/src/hydro/rsolvers/mhd/hlle_mhd_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/mhd/hlle_mhd_rel_no_transform.cpp
@@ -49,7 +49,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
   // Extract ratio of specific heats
   const Real gamma_adi = pmy_block->peos->GetGamma();
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
+  Real dt = pmy_block->pmy_mesh->dt;
 
   // Get metric components
   switch (ivx) {
@@ -65,73 +65,83 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   }
 
   // Go through each interface
-#pragma omp simd simdlen(SIMD_WIDTH)
-  for (int i=il; i<=iu; ++i) {
+#pragma omp simd
+  for (int i = il; i <= iu; ++i) {
     // Extract metric
-    Real g_00 = g_(I00,i), g_01 = g_(I01,i), g_02 = g_(I02,i), g_03 = g_(I03,i),
-         g_10 = g_(I01,i), g_11 = g_(I11,i), g_12 = g_(I12,i), g_13 = g_(I13,i),
-         g_20 = g_(I02,i), g_21 = g_(I12,i), g_22 = g_(I22,i), g_23 = g_(I23,i),
-         g_30 = g_(I03,i), g_31 = g_(I13,i), g_32 = g_(I23,i), g_33 = g_(I33,i);
-    Real g00 = gi_(I00,i), g01 = gi_(I01,i), g02 = gi_(I02,i), g03 = gi_(I03,i),
-         g10 = gi_(I01,i), g11 = gi_(I11,i), g12 = gi_(I12,i), g13 = gi_(I13,i),
-         g20 = gi_(I02,i), g21 = gi_(I12,i), g22 = gi_(I22,i), g23 = gi_(I23,i),
-         g30 = gi_(I03,i), g31 = gi_(I13,i), g32 = gi_(I23,i), g33 = gi_(I33,i);
+    const Real
+        &g_00 = g_(I00,i), &g_01 = g_(I01,i), &g_02 = g_(I02,i), &g_03 = g_(I03,i),
+        &g_10 = g_(I01,i), &g_11 = g_(I11,i), &g_12 = g_(I12,i), &g_13 = g_(I13,i),
+        &g_20 = g_(I02,i), &g_21 = g_(I12,i), &g_22 = g_(I22,i), &g_23 = g_(I23,i),
+        &g_30 = g_(I03,i), &g_31 = g_(I13,i), &g_32 = g_(I23,i), &g_33 = g_(I33,i);
+    const Real
+        &g00 = gi_(I00,i), &g01 = gi_(I01,i), &g02 = gi_(I02,i), &g03 = gi_(I03,i),
+        &g10 = gi_(I01,i), &g11 = gi_(I11,i), &g12 = gi_(I12,i), &g13 = gi_(I13,i),
+        &g20 = gi_(I02,i), &g21 = gi_(I12,i), &g22 = gi_(I22,i), &g23 = gi_(I23,i),
+        &g30 = gi_(I03,i), &g31 = gi_(I13,i), &g32 = gi_(I23,i), &g33 = gi_(I33,i);
     Real alpha = std::sqrt(-1.0/g00);
     Real gii, g0i;
-
-    if(ivx==IVX) {
-      gii = g11;
-      g0i = g01;
-    } else if (ivx==IVY) {
-      gii = g22;
-      g0i = g02;
-    } else if (ivx==IVZ) {
-      gii = g33;
-      g0i = g03;
+    switch (ivx) {
+      case IVX:
+        gii = g11;
+        g0i = g01;
+        break;
+      case IVY:
+        gii = g22;
+        g0i = g02;
+        break;
+      case IVZ:
+        gii = g33;
+        g0i = g03;
+        break;
     }
-
     // Extract left primitives
-    Real rho_l = prim_l(IDN,i);
-    Real pgas_l = prim_l(IPR,i);
-    Real uu1_l = prim_l(IVX,i);
-    Real uu2_l = prim_l(IVY,i);
-    Real uu3_l = prim_l(IVZ,i);
+    const Real &rho_l = prim_l(IDN,i);
+    const Real &pgas_l = prim_l(IPR,i);
+    const Real &uu1_l = prim_l(IVX,i);
+    const Real &uu2_l = prim_l(IVY,i);
+    const Real &uu3_l = prim_l(IVZ,i);
     Real bb1_l, bb2_l, bb3_l;
-
-    if (ivx==IVX) {
-      bb1_l = bb(k,j,i);
-      bb2_l = prim_l(IBY,i);
-      bb3_l = prim_l(IBZ,i);
-    } else if (ivx==IVY) {
-      bb2_l = bb(k,j,i);
-      bb3_l = prim_l(IBY,i);
-      bb1_l = prim_l(IBZ,i);
-    } else if (ivx==IVZ) {
-      bb3_l = bb(k,j,i);
-      bb1_l = prim_l(IBY,i);
-      bb2_l = prim_l(IBZ,i);
+    switch (ivx) {
+      case IVX:
+        bb1_l = bb(k,j,i);
+        bb2_l = prim_l(IBY,i);
+        bb3_l = prim_l(IBZ,i);
+        break;
+      case IVY:
+        bb2_l = bb(k,j,i);
+        bb3_l = prim_l(IBY,i);
+        bb1_l = prim_l(IBZ,i);
+        break;
+      case IVZ:
+        bb3_l = bb(k,j,i);
+        bb1_l = prim_l(IBY,i);
+        bb2_l = prim_l(IBZ,i);
+        break;
     }
 
     // Extract right primitives
-    Real rho_r = prim_r(IDN,i);
-    Real pgas_r = prim_r(IPR,i);
-    Real uu1_r = prim_r(IVX,i);
-    Real uu2_r = prim_r(IVY,i);
-    Real uu3_r = prim_r(IVZ,i);
+    const Real &rho_r = prim_r(IDN,i);
+    const Real &pgas_r = prim_r(IPR,i);
+    const Real &uu1_r = prim_r(IVX,i);
+    const Real &uu2_r = prim_r(IVY,i);
+    const Real &uu3_r = prim_r(IVZ,i);
     Real bb1_r, bb2_r, bb3_r;
-
-    if (ivx==IVZ) {
-      bb1_r = bb(k,j,i);
-      bb2_r = prim_r(IBY,i);
-      bb3_r = prim_r(IBZ,i);
-    } else if (ivx==IVY) {
-      bb2_r = bb(k,j,i);
-      bb3_r = prim_r(IBY,i);
-      bb1_r = prim_r(IBZ,i);
-    } else if (ivx==IVZ) {
-      bb3_r = bb(k,j,i);
-      bb1_r = prim_r(IBY,i);
-      bb2_r = prim_r(IBZ,i);
+    switch (ivx) {
+      case IVX:
+        bb1_r = bb(k,j,i);
+        bb2_r = prim_r(IBY,i);
+        bb3_r = prim_r(IBZ,i);
+        break;
+      case IVY:
+        bb2_r = bb(k,j,i);
+        bb3_r = prim_r(IBY,i);
+        bb1_r = prim_r(IBZ,i);
+        break;
+      case IVZ:
+        bb3_r = bb(k,j,i);
+        bb1_r = prim_r(IBY,i);
+        bb2_r = prim_r(IBZ,i);
+        break;
     }
 
     // Calculate 4-velocity in left state
@@ -198,14 +208,14 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
     // Calculate wavespeeds in left state
     Real lambda_p_l, lambda_m_l;
-    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    Real wgas_l = rho_l + gamma_adi/(gamma_adi-1.0) * pgas_l;
     pmy_block->peos->FastMagnetosonicSpeedsGR(wgas_l, pgas_l, ucon_l[0], ucon_l[ivx],
                                               b_sq_l, g00, g0i, gii,
                                               &lambda_p_l, &lambda_m_l);
 
     // Calculate wavespeeds in right state
     Real lambda_p_r, lambda_m_r;
-    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    Real wgas_r = rho_r + gamma_adi/(gamma_adi-1.0) * pgas_r;
     pmy_block->peos->FastMagnetosonicSpeedsGR(wgas_r, pgas_r, ucon_r[0], ucon_r[ivx],
                                               b_sq_r, g00, g0i, gii,
                                               &lambda_p_r, &lambda_m_r);
@@ -264,13 +274,11 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     flux_r[IBY] = bcon_r[ivy] * ucon_r[ivx] - bcon_r[ivx] * ucon_r[ivy];
     flux_r[IBZ] = bcon_r[ivz] * ucon_r[ivx] - bcon_r[ivx] * ucon_r[ivz];
 
-    Real lambda_diff_inv = 1.0 / (lambda_r-lambda_l);
     // Calculate fluxes in HLL region
     Real flux_hll[NWAVE];
     for (int n = 0; n < NWAVE; ++n) {
       flux_hll[n] = (lambda_r*flux_l[n] - lambda_l*flux_r[n]
-                     + lambda_r*lambda_l * (cons_r[n] - cons_l[n]))
-                    * lambda_diff_inv;
+                     + lambda_r*lambda_l * (cons_r[n] - cons_l[n])) / (lambda_r-lambda_l);
     }
 
     // Determine region of wavefan
@@ -289,6 +297,9 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     }
     ey(k,j,i) = -flux_interface[IBY];
     ez(k,j,i) = flux_interface[IBZ];
+
+    wct(k,j,i) =
+        GetWeightForCT(flux_interface[IDN], prim_l(IDN,i), prim_r(IDN,i), dxw(i), dt);
   }
   return;
 }

--- a/src/hydro/rsolvers/mhd/llf_mhd_rel.cpp
+++ b/src/hydro/rsolvers/mhd/llf_mhd_rel.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// Athenah++ astrophysical MHD code
+// Athena++ astrophysical MHD code
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
@@ -153,149 +153,138 @@ void LLFTransforming(MeshBlock *pmb, const int k, const int j,
   const Real gamma_adi = pmb->peos->GetGamma();
   const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
 
-  Real cons_l[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_l[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_r[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_r[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real cons_hll[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-  Real flux_hll[NWAVE][SIMD_WIDTH] __attribute__((aligned(CACHELINE_BYTES)));
-
   // Go through each interface
-  for (int i=il; i<=iu; i+=SIMD_WIDTH) {
 #pragma omp simd simdlen(SIMD_WIDTH)
-    for (int m=0; m<std::min(SIMD_WIDTH, iu-i+1); m++) {
-      int ipm = i+m;
-
-      // Extract left primitives
-      Real rho_l = prim_l(IDN,ipm);
-      Real pgas_l = prim_l(IPR,ipm);
-      Real u_l[4];
-      if (GENERAL_RELATIVITY) {
-        Real vx_l = prim_l(ivx,ipm);
-        Real vy_l = prim_l(ivy,ipm);
-        Real vz_l = prim_l(ivz,ipm);
-        u_l[0] = std::sqrt(1.0 + SQR(vx_l) + SQR(vy_l) + SQR(vz_l));
-        u_l[1] = vx_l;
-        u_l[2] = vy_l;
-        u_l[3] = vz_l;
-      } else {  // SR
-        Real vx_l = prim_l(ivx,ipm);
-        Real vy_l = prim_l(ivy,ipm);
-        Real vz_l = prim_l(ivz,ipm);
-        u_l[0] = std::sqrt(1.0 / (1.0 - SQR(vx_l) - SQR(vy_l) - SQR(vz_l)));
-        u_l[1] = u_l[0] * vx_l;
-        u_l[2] = u_l[0] * vy_l;
-        u_l[3] = u_l[0] * vz_l;
-      }
-      Real bb2_l = prim_l(IBY,ipm);
-      Real bb3_l = prim_l(IBZ,ipm);
-
-      // Extract right primitives
-      Real rho_r = prim_r(IDN,ipm);
-      Real pgas_r = prim_r(IPR,ipm);
-      Real u_r[4];
-      if (GENERAL_RELATIVITY) {
-        Real vx_r = prim_r(ivx,ipm);
-        Real vy_r = prim_r(ivy,ipm);
-        Real vz_r = prim_r(ivz,ipm);
-        u_r[0] = std::sqrt(1.0 + SQR(vx_r) + SQR(vy_r) + SQR(vz_r));
-        u_r[1] = vx_r;
-        u_r[2] = vy_r;
-        u_r[3] = vz_r;
-      } else {  // SR
-        Real vx_r = prim_r(ivx,ipm);
-        Real vy_r = prim_r(ivy,ipm);
-        Real vz_r = prim_r(ivz,ipm);
-        u_r[0] = std::sqrt(1.0 / (1.0 - SQR(vx_r) - SQR(vy_r) - SQR(vz_r)));
-        u_r[1] = u_r[0] * vx_r;
-        u_r[2] = u_r[0] * vy_r;
-        u_r[3] = u_r[0] * vz_r;
-      }
-      Real bb2_r = prim_r(IBY,ipm);
-      Real bb3_r = prim_r(IBZ,ipm);
-
-      // Extract normal magnetic field
-      Real bb1 = bb_normal(ipm);
-
-      // Calculate 4-magnetic field in left state
-      Real b_l[4];
-      b_l[0] = bb1*u_l[1] + bb2_l*u_l[2] + bb3_l*u_l[3];
-      b_l[1] = (bb1 + b_l[0] * u_l[1]) / u_l[0];
-      b_l[2] = (bb2_l + b_l[0] * u_l[2]) / u_l[0];
-      b_l[3] = (bb3_l + b_l[0] * u_l[3]) / u_l[0];
-      Real b_sq_l = -SQR(b_l[0]) + SQR(b_l[1]) + SQR(b_l[2]) + SQR(b_l[3]);
-
-      // Calculate 4-magnetic field in right state
-      Real b_r[4];
-      b_r[0] = bb1*u_r[1] + bb2_r*u_r[2] + bb3_r*u_r[3];
-      b_r[1] = (bb1 + b_r[0] * u_r[1]) / u_r[0];
-      b_r[2] = (bb2_r + b_r[0] * u_r[2]) / u_r[0];
-      b_r[3] = (bb3_r + b_r[0] * u_r[3]) / u_r[0];
-      Real b_sq_r = -SQR(b_r[0]) + SQR(b_r[1]) + SQR(b_r[2]) + SQR(b_r[3]);
-
-      // Calculate extremal wavespeeds
-      Real lambda_l = std::min(lambdas_m_l(ipm), lambdas_m_r(ipm));  // (MB 55)
-      Real lambda_r = std::max(lambdas_p_l(ipm), lambdas_p_r(ipm));  // (MB 55)
-      Real lambda = std::max(lambda_r, -lambda_l);
-
-      // Calculate conserved quantities in L region (MUB 8)
-      Real wtot_l = rho_l + gamma_prime * pgas_l + b_sq_l;
-      Real ptot_l = pgas_l + 0.5*b_sq_l;
-      cons_l[IDN][m] = rho_l * u_l[0];
-      cons_l[IEN][m] = wtot_l * u_l[0] * u_l[0] - b_l[0] * b_l[0] - ptot_l;
-      cons_l[ivx][m] = wtot_l * u_l[1] * u_l[0] - b_l[1] * b_l[0];
-      cons_l[ivy][m] = wtot_l * u_l[2] * u_l[0] - b_l[2] * b_l[0];
-      cons_l[ivz][m] = wtot_l * u_l[3] * u_l[0] - b_l[3] * b_l[0];
-      cons_l[IBY][m] = b_l[2] * u_l[0] - b_l[0] * u_l[2];
-      cons_l[IBZ][m] = b_l[3] * u_l[0] - b_l[0] * u_l[3];
-
-      // Calculate fluxes in L region (MUB 15)
-      flux_l[IDN][m] = rho_l * u_l[1];
-      flux_l[IEN][m] = wtot_l * u_l[0] * u_l[1] - b_l[0] * b_l[1];
-      flux_l[ivx][m] = wtot_l * u_l[1] * u_l[1] - b_l[1] * b_l[1] + ptot_l;
-      flux_l[ivy][m] = wtot_l * u_l[2] * u_l[1] - b_l[2] * b_l[1];
-      flux_l[ivz][m] = wtot_l * u_l[3] * u_l[1] - b_l[3] * b_l[1];
-      flux_l[IBY][m] = b_l[2] * u_l[1] - b_l[1] * u_l[2];
-      flux_l[IBZ][m] = b_l[3] * u_l[1] - b_l[1] * u_l[3];
-
-      // Calculate conserved quantities in R region (MUB 8)
-      Real wtot_r = rho_r + gamma_prime * pgas_r + b_sq_r;
-      Real ptot_r = pgas_r + 0.5*b_sq_r;
-      cons_r[IDN][m] = rho_r * u_r[0];
-      cons_r[IEN][m] = wtot_r * u_r[0] * u_r[0] - b_r[0] * b_r[0] - ptot_r;
-      cons_r[ivx][m] = wtot_r * u_r[1] * u_r[0] - b_r[1] * b_r[0];
-      cons_r[ivy][m] = wtot_r * u_r[2] * u_r[0] - b_r[2] * b_r[0];
-      cons_r[ivz][m] = wtot_r * u_r[3] * u_r[0] - b_r[3] * b_r[0];
-      cons_r[IBY][m] = b_r[2] * u_r[0] - b_r[0] * u_r[2];
-      cons_r[IBZ][m] = b_r[3] * u_r[0] - b_r[0] * u_r[3];
-
-      // Calculate fluxes in R region (MUB 15)
-      flux_r[IDN][m] = rho_r * u_r[1];
-      flux_r[IEN][m] = wtot_r * u_r[0] * u_r[1] - b_r[0] * b_r[1];
-      flux_r[ivx][m] = wtot_r * u_r[1] * u_r[1] - b_r[1] * b_r[1] + ptot_r;
-      flux_r[ivy][m] = wtot_r * u_r[2] * u_r[1] - b_r[2] * b_r[1];
-      flux_r[ivz][m] = wtot_r * u_r[3] * u_r[1] - b_r[3] * b_r[1];
-      flux_r[IBY][m] = b_r[2] * u_r[1] - b_r[1] * u_r[2];
-      flux_r[IBZ][m] = b_r[3] * u_r[1] - b_r[1] * u_r[3];
-
-      // Set conserved quantities in GR
-      if (GENERAL_RELATIVITY) {
-        for (int n = 0; n < NWAVE; ++n) {
-          cons(n,ipm) = 0.5 * (cons_r[n][m] + cons_l[n][m] + (flux_l[n][m] - flux_r[n][m])
-                               / lambda);
-        }
-      }
-
-      // Set fluxes
-      for (int n = 0; n < NHYDRO; ++n) {
-        flux(n,k,j,ipm) = 0.5 * (flux_l[n][m] + flux_r[n][m] - lambda
-                                 * (cons_r[n][m] - cons_l[n][m]));
-      }
-      ey(k,j,ipm) = -0.5 * (flux_l[IBY][m] + flux_r[IBY][m] - lambda
-                            * (cons_r[IBY][m] - cons_l[IBY][m]));
-      ez(k,j,ipm) = 0.5 * (flux_l[IBZ][m] + flux_r[IBZ][m] - lambda
-                           * (cons_r[IBZ][m] - cons_l[IBZ][m]));
+  for (int i=il; i<=iu; ++i) {
+    // Extract left primitives
+    Real rho_l = prim_l(IDN,i);
+    Real pgas_l = prim_l(IPR,i);
+    Real u_l[4];
+    if (GENERAL_RELATIVITY) {
+      Real vx_l = prim_l(ivx,i);
+      Real vy_l = prim_l(ivy,i);
+      Real vz_l = prim_l(ivz,i);
+      u_l[0] = std::sqrt(1.0 + SQR(vx_l) + SQR(vy_l) + SQR(vz_l));
+      u_l[1] = vx_l;
+      u_l[2] = vy_l;
+      u_l[3] = vz_l;
+    } else {  // SR
+      Real vx_l = prim_l(ivx,i);
+      Real vy_l = prim_l(ivy,i);
+      Real vz_l = prim_l(ivz,i);
+      u_l[0] = std::sqrt(1.0 / (1.0 - SQR(vx_l) - SQR(vy_l) - SQR(vz_l)));
+      u_l[1] = u_l[0] * vx_l;
+      u_l[2] = u_l[0] * vy_l;
+      u_l[3] = u_l[0] * vz_l;
     }
+    Real bb2_l = prim_l(IBY,i);
+    Real bb3_l = prim_l(IBZ,i);
+
+    // Extract right primitives
+    Real rho_r = prim_r(IDN,i);
+    Real pgas_r = prim_r(IPR,i);
+    Real u_r[4];
+    if (GENERAL_RELATIVITY) {
+      Real vx_r = prim_r(ivx,i);
+      Real vy_r = prim_r(ivy,i);
+      Real vz_r = prim_r(ivz,i);
+      u_r[0] = std::sqrt(1.0 + SQR(vx_r) + SQR(vy_r) + SQR(vz_r));
+      u_r[1] = vx_r;
+      u_r[2] = vy_r;
+      u_r[3] = vz_r;
+    } else {  // SR
+      Real vx_r = prim_r(ivx,i);
+      Real vy_r = prim_r(ivy,i);
+      Real vz_r = prim_r(ivz,i);
+      u_r[0] = std::sqrt(1.0 / (1.0 - SQR(vx_r) - SQR(vy_r) - SQR(vz_r)));
+      u_r[1] = u_r[0] * vx_r;
+      u_r[2] = u_r[0] * vy_r;
+      u_r[3] = u_r[0] * vz_r;
+    }
+    Real bb2_r = prim_r(IBY,i);
+    Real bb3_r = prim_r(IBZ,i);
+
+    // Extract normal magnetic field
+    Real bb1 = bb_normal(i);
+
+    // Calculate 4-magnetic field in left state
+    Real b_l[4];
+    b_l[0] = bb1*u_l[1] + bb2_l*u_l[2] + bb3_l*u_l[3];
+    b_l[1] = (bb1 + b_l[0] * u_l[1]) / u_l[0];
+    b_l[2] = (bb2_l + b_l[0] * u_l[2]) / u_l[0];
+    b_l[3] = (bb3_l + b_l[0] * u_l[3]) / u_l[0];
+    Real b_sq_l = -SQR(b_l[0]) + SQR(b_l[1]) + SQR(b_l[2]) + SQR(b_l[3]);
+
+    // Calculate 4-magnetic field in right state
+    Real b_r[4];
+    b_r[0] = bb1*u_r[1] + bb2_r*u_r[2] + bb3_r*u_r[3];
+    b_r[1] = (bb1 + b_r[0] * u_r[1]) / u_r[0];
+    b_r[2] = (bb2_r + b_r[0] * u_r[2]) / u_r[0];
+    b_r[3] = (bb3_r + b_r[0] * u_r[3]) / u_r[0];
+    Real b_sq_r = -SQR(b_r[0]) + SQR(b_r[1]) + SQR(b_r[2]) + SQR(b_r[3]);
+
+    // Calculate extremal wavespeeds
+    Real lambda_l = std::min(lambdas_m_l(i), lambdas_m_r(i));  // (MB 55)
+    Real lambda_r = std::max(lambdas_p_l(i), lambdas_p_r(i));  // (MB 55)
+    Real lambda = std::max(lambda_r, -lambda_l);
+
+    // Calculate conserved quantities in L region (MUB 8)
+    Real cons_l[NWAVE];
+    Real wtot_l = rho_l + gamma_prime * pgas_l + b_sq_l;
+    Real ptot_l = pgas_l + 0.5*b_sq_l;
+    cons_l[IDN] = rho_l * u_l[0];
+    cons_l[IEN] = wtot_l * u_l[0] * u_l[0] - b_l[0] * b_l[0] - ptot_l;
+    cons_l[ivx] = wtot_l * u_l[1] * u_l[0] - b_l[1] * b_l[0];
+    cons_l[ivy] = wtot_l * u_l[2] * u_l[0] - b_l[2] * b_l[0];
+    cons_l[ivz] = wtot_l * u_l[3] * u_l[0] - b_l[3] * b_l[0];
+    cons_l[IBY] = b_l[2] * u_l[0] - b_l[0] * u_l[2];
+    cons_l[IBZ] = b_l[3] * u_l[0] - b_l[0] * u_l[3];
+
+    // Calculate fluxes in L region (MUB 15)
+    Real flux_l[NWAVE];
+    flux_l[IDN] = rho_l * u_l[1];
+    flux_l[IEN] = wtot_l * u_l[0] * u_l[1] - b_l[0] * b_l[1];
+    flux_l[ivx] = wtot_l * u_l[1] * u_l[1] - b_l[1] * b_l[1] + ptot_l;
+    flux_l[ivy] = wtot_l * u_l[2] * u_l[1] - b_l[2] * b_l[1];
+    flux_l[ivz] = wtot_l * u_l[3] * u_l[1] - b_l[3] * b_l[1];
+    flux_l[IBY] = b_l[2] * u_l[1] - b_l[1] * u_l[2];
+    flux_l[IBZ] = b_l[3] * u_l[1] - b_l[1] * u_l[3];
+
+    // Calculate conserved quantities in R region (MUB 8)
+    Real cons_r[NWAVE];
+    Real wtot_r = rho_r + gamma_prime * pgas_r + b_sq_r;
+    Real ptot_r = pgas_r + 0.5*b_sq_r;
+    cons_r[IDN] = rho_r * u_r[0];
+    cons_r[IEN] = wtot_r * u_r[0] * u_r[0] - b_r[0] * b_r[0] - ptot_r;
+    cons_r[ivx] = wtot_r * u_r[1] * u_r[0] - b_r[1] * b_r[0];
+    cons_r[ivy] = wtot_r * u_r[2] * u_r[0] - b_r[2] * b_r[0];
+    cons_r[ivz] = wtot_r * u_r[3] * u_r[0] - b_r[3] * b_r[0];
+    cons_r[IBY] = b_r[2] * u_r[0] - b_r[0] * u_r[2];
+    cons_r[IBZ] = b_r[3] * u_r[0] - b_r[0] * u_r[3];
+
+    // Calculate fluxes in R region (MUB 15)
+    Real flux_r[NWAVE];
+    flux_r[IDN] = rho_r * u_r[1];
+    flux_r[IEN] = wtot_r * u_r[0] * u_r[1] - b_r[0] * b_r[1];
+    flux_r[ivx] = wtot_r * u_r[1] * u_r[1] - b_r[1] * b_r[1] + ptot_r;
+    flux_r[ivy] = wtot_r * u_r[2] * u_r[1] - b_r[2] * b_r[1];
+    flux_r[ivz] = wtot_r * u_r[3] * u_r[1] - b_r[3] * b_r[1];
+    flux_r[IBY] = b_r[2] * u_r[1] - b_r[1] * u_r[2];
+    flux_r[IBZ] = b_r[3] * u_r[1] - b_r[1] * u_r[3];
+
+    // Set conserved quantities in GR
+    if (GENERAL_RELATIVITY) {
+      for (int n = 0; n < NWAVE; ++n) {
+        cons(n,i) = 0.5 * (cons_r[n] + cons_l[n] + (flux_l[n] - flux_r[n]) / lambda);
+      }
+    }
+
+    // Set fluxes
+    for (int n = 0; n < NHYDRO; ++n) {
+      flux(n,k,j,i) = 0.5 * (flux_l[n] + flux_r[n] - lambda * (cons_r[n] - cons_l[n]));
+    }
+    ey(k,j,i) = -0.5 * (flux_l[IBY] + flux_r[IBY] - lambda * (cons_r[IBY] - cons_l[IBY]));
+    ez(k,j,i) = 0.5 * (flux_l[IBZ] + flux_r[IBZ] - lambda * (cons_r[IBZ] - cons_l[IBZ]));
   }
 
   // Transform fluxes to global coordinates if in GR
@@ -325,7 +314,7 @@ void LLFTransforming(MeshBlock *pmb, const int k, const int j,
 //   il,iu: lower and upper x1-indices
 //   bb: 3D array of normal magnetic fields
 //   g,gi: 1D scratch arrays for metric coefficients
-//   prim_l,prim_r: 1D arrays of left and right primitive states
+//   prim_l,prim_r: 3D arrays of left and right primitive states
 // Outputs:
 //   flux: 3D array of hydrodynamical fluxes across interfaces
 //   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
@@ -342,44 +331,43 @@ void LLFNonTransforming(MeshBlock *pmb, const int k, const int j, const int il,
 #if GENERAL_RELATIVITY
   // Extract ratio of specific heats
   const Real gamma_adi = pmb->peos->GetGamma();
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
 
   // Get metric components
   pmb->pcoord->Face2Metric(k, j, il, iu, g, gi);
 
   // Go through each interface
-#pragma omp simd simdlen(SIMD_WIDTH)
-  for (int i=il; i<=iu; i++) {
+#pragma omp simd
+  for (int i=il; i<=iu; ++i) {
     // Extract metric
-    Real g_00 = g(I00,i), g_01 = g(I01,i), g_02 = g(I02,i), g_03 = g(I03,i),
-         g_10 = g(I01,i), g_11 = g(I11,i), g_12 = g(I12,i), g_13 = g(I13,i),
-         g_20 = g(I02,i), g_21 = g(I12,i), g_22 = g(I22,i), g_23 = g(I23,i),
-         g_30 = g(I03,i), g_31 = g(I13,i), g_32 = g(I23,i), g_33 = g(I33,i);
-    Real g00 = gi(I00,i), g01 = gi(I01,i), g02 = gi(I02,i), g03 = gi(I03,i),
-         g10 = gi(I01,i), g11 = gi(I11,i), g12 = gi(I12,i), g13 = gi(I13,i),
-         g20 = gi(I02,i), g21 = gi(I12,i), g22 = gi(I22,i), g23 = gi(I23,i),
-         g30 = gi(I03,i), g31 = gi(I13,i), g32 = gi(I23,i), g33 = gi(I33,i);
+    const Real &g_00 = g(I00,i), &g_01 = g(I01,i), &g_02 = g(I02,i), &g_03 = g(I03,i),
+               &g_10 = g(I01,i), &g_11 = g(I11,i), &g_12 = g(I12,i), &g_13 = g(I13,i),
+               &g_20 = g(I02,i), &g_21 = g(I12,i), &g_22 = g(I22,i), &g_23 = g(I23,i),
+               &g_30 = g(I03,i), &g_31 = g(I13,i), &g_32 = g(I23,i), &g_33 = g(I33,i);
+    const Real &g00 = gi(I00,i), &g01 = gi(I01,i), &g02 = gi(I02,i), &g03 = gi(I03,i),
+               &g10 = gi(I01,i), &g11 = gi(I11,i), &g12 = gi(I12,i), &g13 = gi(I13,i),
+               &g20 = gi(I02,i), &g21 = gi(I12,i), &g22 = gi(I22,i), &g23 = gi(I23,i),
+               &g30 = gi(I03,i), &g31 = gi(I13,i), &g32 = gi(I23,i), &g33 = gi(I33,i);
     Real alpha = std::sqrt(-1.0/g00);
 
     // Extract left primitives
-    Real rho_l = prim_l(IDN,i);
-    Real pgas_l = prim_l(IPR,i);
-    Real uu1_l = prim_l(IVX,i);
-    Real uu2_l = prim_l(IVY,i);
-    Real uu3_l = prim_l(IVZ,i);
-    Real bb2_l = bb(k,j,i);
-    Real bb3_l = prim_l(IBY,i);
-    Real bb1_l = prim_l(IBZ,i);
+    const Real &rho_l = prim_l(IDN,i);
+    const Real &pgas_l = prim_l(IPR,i);
+    const Real &uu1_l = prim_l(IVX,i);
+    const Real &uu2_l = prim_l(IVY,i);
+    const Real &uu3_l = prim_l(IVZ,i);
+    const Real &bb2_l = bb(k,j,i);
+    const Real &bb3_l = prim_l(IBY,i);
+    const Real &bb1_l = prim_l(IBZ,i);
 
     // Extract right primitives
-    Real rho_r = prim_r(IDN,i);
-    Real pgas_r = prim_r(IPR,i);
-    Real uu1_r = prim_r(IVX,i);
-    Real uu2_r = prim_r(IVY,i);
-    Real uu3_r = prim_r(IVZ,i);
-    Real bb2_r = bb(k,j,i);
-    Real bb3_r = prim_r(IBY,i);
-    Real bb1_r = prim_r(IBZ,i);
+    const Real &rho_r = prim_r(IDN,i);
+    const Real &pgas_r = prim_r(IPR,i);
+    const Real &uu1_r = prim_r(IVX,i);
+    const Real &uu2_r = prim_r(IVY,i);
+    const Real &uu3_r = prim_r(IVZ,i);
+    const Real &bb2_r = bb(k,j,i);
+    const Real &bb3_r = prim_r(IBY,i);
+    const Real &bb1_r = prim_r(IBZ,i);
 
     // Calculate 4-velocity in left state
     Real ucon_l[4], ucov_l[4];
@@ -445,13 +433,13 @@ void LLFNonTransforming(MeshBlock *pmb, const int k, const int j, const int il,
 
     // Calculate wavespeeds in left state
     Real lambda_p_l, lambda_m_l;
-    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    Real wgas_l = rho_l + gamma_adi/(gamma_adi-1.0) * pgas_l;
     pmb->peos->FastMagnetosonicSpeedsGR(wgas_l, pgas_l, ucon_l[0], ucon_l[IVY], b_sq_l,
                                         g00, g02, g22, &lambda_p_l, &lambda_m_l);
 
     // Calculate wavespeeds in right state
     Real lambda_p_r, lambda_m_r;
-    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    Real wgas_r = rho_r + gamma_adi/(gamma_adi-1.0) * pgas_r;
     pmb->peos->FastMagnetosonicSpeedsGR(wgas_r, pgas_r, ucon_r[0], ucon_r[IVY], b_sq_r,
                                         g00, g02, g22, &lambda_p_r, &lambda_m_r);
 
@@ -512,15 +500,12 @@ void LLFNonTransforming(MeshBlock *pmb, const int k, const int j, const int il,
 
     // Set fluxes
     for (int n = 0; n < NHYDRO; ++n) {
-      flux(n,k,j,i) = 0.5 * (flux_l[n] + flux_r[n] - lambda
-                             * (cons_r[n] - cons_l[n]));
+      flux(n,k,j,i) = 0.5 * (flux_l[n] + flux_r[n] - lambda * (cons_r[n] - cons_l[n]));
     }
-    ey(k,j,i) = -0.5 * (flux_l[IBY] + flux_r[IBY] - lambda
-                        * (cons_r[IBY] - cons_l[IBY]));
-    ez(k,j,i) = 0.5 * (flux_l[IBZ] + flux_r[IBZ] - lambda
-                       * (cons_r[IBZ] - cons_l[IBZ]));
+    ey(k,j,i) = -0.5 * (flux_l[IBY] + flux_r[IBY] - lambda * (cons_r[IBY] - cons_l[IBY]));
+    ez(k,j,i) = 0.5 * (flux_l[IBZ] + flux_r[IBZ] - lambda * (cons_r[IBZ] - cons_l[IBZ]));
   }
-#endif // GENERAL_RELATIVITY
   return;
+#endif  // GENERAL_RELATIVITY
 }
 } // namespace

--- a/src/hydro/rsolvers/mhd/llf_mhd_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/mhd/llf_mhd_rel_no_transform.cpp
@@ -23,15 +23,16 @@
 //----------------------------------------------------------------------------------------
 // Riemann solver
 // Inputs:
-//   kl,ku,jl,ju,il,iu: lower and upper x1-, x2-, and x3-indices
+//   k,j: x3- and x2-indices
+//   il,iu: lower and upper x1-indices
+//   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
 //   bb: 3D array of normal magnetic fields
 //   prim_l,prim_r: 1D arrays of left and right primitive states
+//   dxw: 1D array of mesh spacing in the x-direction
 // Outputs:
 //   flux: 3D array of hydrodynamical fluxes across interfaces
 //   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
-// Notes:
-//   implements LLF algorithm similar to that of fluxcalc() in step_ch.c in Harm
-//   cf. LLFNonTransforming() in llf_mhd_rel.cpp
+//   wct: 3D array of weighting factors for CT
 
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx, const AthenaArray<Real> &bb,
@@ -45,7 +46,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
   // Extract ratio of specific heats
   const Real gamma_adi = pmy_block->peos->GetGamma();
-  const Real gamma_prime = gamma_adi/(gamma_adi-1.0);
+  Real dt = pmy_block->pmy_mesh->dt;
 
   // Get metric components
   switch (ivx) {
@@ -61,71 +62,84 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   }
 
   // Go through each interface
-#pragma omp simd simdlen(SIMD_WIDTH)
-  for (int i=il; i<=iu; ++i) {
+#pragma omp simd
+  for (int i = il; i <= iu; ++i) {
     // Extract metric
-    Real g_00 = g_(I00,i), g_01 = g_(I01,i), g_02 = g_(I02,i), g_03 = g_(I03,i),
-         g_10 = g_(I01,i), g_11 = g_(I11,i), g_12 = g_(I12,i), g_13 = g_(I13,i),
-         g_20 = g_(I02,i), g_21 = g_(I12,i), g_22 = g_(I22,i), g_23 = g_(I23,i),
-         g_30 = g_(I03,i), g_31 = g_(I13,i), g_32 = g_(I23,i), g_33 = g_(I33,i);
-    Real g00 = gi_(I00,i), g01 = gi_(I01,i), g02 = gi_(I02,i), g03 = gi_(I03,i),
-         g10 = gi_(I01,i), g11 = gi_(I11,i), g12 = gi_(I12,i), g13 = gi_(I13,i),
-         g20 = gi_(I02,i), g21 = gi_(I12,i), g22 = gi_(I22,i), g23 = gi_(I23,i),
-         g30 = gi_(I03,i), g31 = gi_(I13,i), g32 = gi_(I23,i), g33 = gi_(I33,i);
+    const Real
+        &g_00 = g_(I00,i), &g_01 = g_(I01,i), &g_02 = g_(I02,i), &g_03 = g_(I03,i),
+        &g_10 = g_(I01,i), &g_11 = g_(I11,i), &g_12 = g_(I12,i), &g_13 = g_(I13,i),
+        &g_20 = g_(I02,i), &g_21 = g_(I12,i), &g_22 = g_(I22,i), &g_23 = g_(I23,i),
+        &g_30 = g_(I03,i), &g_31 = g_(I13,i), &g_32 = g_(I23,i), &g_33 = g_(I33,i);
+    const Real
+        &g00 = gi_(I00,i), &g01 = gi_(I01,i), &g02 = gi_(I02,i), &g03 = gi_(I03,i),
+        &g10 = gi_(I01,i), &g11 = gi_(I11,i), &g12 = gi_(I12,i), &g13 = gi_(I13,i),
+        &g20 = gi_(I02,i), &g21 = gi_(I12,i), &g22 = gi_(I22,i), &g23 = gi_(I23,i),
+        &g30 = gi_(I03,i), &g31 = gi_(I13,i), &g32 = gi_(I23,i), &g33 = gi_(I33,i);
     Real alpha = std::sqrt(-1.0/g00);
-
     Real gii, g0i;
-    if(ivx==IVX) {
-      gii = g11;
-      g0i = g01;
-    } else if (ivx==IVY) {
-      gii = g22;
-      g0i = g02;
-    } else if (ivx==IVZ) {
-      gii = g33;
-      g0i = g03;
+    switch (ivx) {
+      case IVX:
+        gii = g11;
+        g0i = g01;
+        break;
+      case IVY:
+        gii = g22;
+        g0i = g02;
+        break;
+      case IVZ:
+        gii = g33;
+        g0i = g03;
+        break;
     }
 
     // Extract left primitives
-    Real rho_l = prim_l(IDN,i);
-    Real pgas_l = prim_l(IPR,i);
-    Real uu1_l = prim_l(IVX,i);
-    Real uu2_l = prim_l(IVY,i);
-    Real uu3_l = prim_l(IVZ,i);
+    const Real &rho_l = prim_l(IDN,k,j,i);
+    const Real &pgas_l = prim_l(IPR,k,j,i);
+    const Real &uu1_l = prim_l(IVX,k,j,i);
+    const Real &uu2_l = prim_l(IVY,k,j,i);
+    const Real &uu3_l = prim_l(IVZ,k,j,i);
     Real bb1_l, bb2_l, bb3_l;
-    if (ivx==IVX) {
-      bb1_l = bb(k,j,i);
-      bb2_l = prim_l(IBY,i);
-      bb3_l = prim_l(IBZ,i);
-    } else if (ivx==IVY) {
-      bb2_l = bb(k,j,i);
-      bb3_l = prim_l(IBY,i);
-      bb1_l = prim_l(IBZ,i);
-    } else if (ivx==IVZ) {
-      bb3_l = bb(k,j,i);
-      bb1_l = prim_l(IBY,i);
-      bb2_l = prim_l(IBZ,i);
+    switch (ivx) {
+      case IVX:
+        bb1_l = bb(k,j,i);
+        bb2_l = prim_l(IBY,k,j,i);
+        bb3_l = prim_l(IBZ,k,j,i);
+        break;
+      case IVY:
+        bb2_l = bb(k,j,i);
+        bb3_l = prim_l(IBY,k,j,i);
+        bb1_l = prim_l(IBZ,k,j,i);
+        break;
+      case IVZ:
+        bb3_l = bb(k,j,i);
+        bb1_l = prim_l(IBY,k,j,i);
+        bb2_l = prim_l(IBZ,k,j,i);
+        break;
     }
 
     // Extract right primitives
-    Real rho_r = prim_r(IDN,i);
-    Real pgas_r = prim_r(IPR,i);
-    Real uu1_r = prim_r(IVX,i);
-    Real uu2_r = prim_r(IVY,i);
-    Real uu3_r = prim_r(IVZ,i);
+    const Real &rho_r = prim_r(IDN,k,j,i);
+    const Real &pgas_r = prim_r(IPR,k,j,i);
+    const Real &uu1_r = prim_r(IVX,k,j,i);
+    const Real &uu2_r = prim_r(IVY,k,j,i);
+    const Real &uu3_r = prim_r(IVZ,k,j,i);
     Real bb1_r, bb2_r, bb3_r;
-    if (ivx==IVZ) {
-      bb1_r = bb(k,j,i);
-      bb2_r = prim_r(IBY,i);
-      bb3_r = prim_r(IBZ,i);
-    } else if (ivx==IVY) {
-      bb2_r = bb(k,j,i);
-      bb3_r = prim_r(IBY,i);
-      bb1_r = prim_r(IBZ,i);
-    } else if (ivx==IVZ) {
-      bb3_r = bb(k,j,i);
-      bb1_r = prim_r(IBY,i);
-      bb2_r = prim_r(IBZ,i);
+    switch (ivx) {
+      case IVX:
+        bb1_r = bb(k,j,i);
+        bb2_r = prim_r(IBY,k,j,i);
+        bb3_r = prim_r(IBZ,k,j,i);
+        break;
+      case IVY:
+        bb2_r = bb(k,j,i);
+        bb3_r = prim_r(IBY,k,j,i);
+        bb1_r = prim_r(IBZ,k,j,i);
+        break;
+      case IVZ:
+        bb3_r = bb(k,j,i);
+        bb1_r = prim_r(IBY,k,j,i);
+        bb2_r = prim_r(IBZ,k,j,i);
+        break;
     }
 
     // Calculate 4-velocity in left state
@@ -192,14 +206,14 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
     // Calculate wavespeeds in left state
     Real lambda_p_l, lambda_m_l;
-    Real wgas_l = rho_l + gamma_prime * pgas_l;
+    Real wgas_l = rho_l + gamma_adi/(gamma_adi-1.0) * pgas_l;
     pmy_block->peos->FastMagnetosonicSpeedsGR(wgas_l, pgas_l, ucon_l[0], ucon_l[ivx],
                                               b_sq_l, g00, g0i, gii,
                                               &lambda_p_l, &lambda_m_l);
 
     // Calculate wavespeeds in right state
     Real lambda_p_r, lambda_m_r;
-    Real wgas_r = rho_r + gamma_prime * pgas_r;
+    Real wgas_r = rho_r + gamma_adi/(gamma_adi-1.0) * pgas_r;
     pmy_block->peos->FastMagnetosonicSpeedsGR(wgas_r, pgas_r, ucon_r[0], ucon_r[ivx],
                                               b_sq_r, g00, g0i, gii,
                                               &lambda_p_r, &lambda_m_r);
@@ -268,6 +282,10 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
         -0.5 * (flux_l[IBY] + flux_r[IBY] - lambda * (cons_r[IBY] - cons_l[IBY]));
     ez(k,j,i) =
         0.5 * (flux_l[IBZ] + flux_r[IBZ] - lambda * (cons_r[IBZ] - cons_l[IBZ]));
+
+    wct(k,j,i) =
+        GetWeightForCT(flux(IDN,k,j,i), prim_l(IDN,i), prim_r(IDN,i), dxw(i), dt);
   }
+
   return;
 }


### PR DESCRIPTION
Despite passing all the tests we came up with, it seems the optimized relativity is too fragile for some production runs. The simulation quickly goes NAN in the case of a highly magnetized disk around a rapidly spinning black hole in a GRMHD production run with SMR on about 5000 cores with an effective resolution of 512 * 160 * 320. There are no issues with the unoptimized version on this problem.

We should remove the optimizations until this issue is fixed, and more generally until we have better methods for testing such inherently nonrobust algorithms in actual production runs.

This commit was generated via `git revert`, which did everything automatically except for a couple trivial conflicts. I don't think it impacted anything else, but we'll see what the regression tests say.

(This explains why restarting with the most updated code produced NANs in #271.)