### PR TITLE
Add user ability to specify names of libraries when linking

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -36,7 +36,8 @@
 #   --gcovcmd=name    use name as the command to call the gcov utility
 #   --cflag=string    append string whenever invoking compiler/linker
 #   --include=path    use -Ipath when compiling
-#   --lib=path        use -Lpath when linking
+#   --lib_path=path   use -Lpath when linking
+#   --lib=xxx         use -lxxx when linking
 # ----------------------------------------------------------------------------------------
 
 # Modules
@@ -277,16 +278,22 @@ parser.add_argument(
     default=[],
     action='append',
     help=('extra path for included header files (-I<path>); can be specified multiple '
-          'times')
-)
+          'times'))
+
+# --lib_path=[name] arguments
+parser.add_argument(
+    '--lib_path',
+    default=[],
+    action='append',
+    help=('extra path for linked library files (-L<path>); can be specified multiple '
+          'times'))
+
 # --lib=[name] arguments
 parser.add_argument(
     '--lib',
     default=[],
     action='append',
-    help=('extra path for linked library files (-L<path>); can be specified multiple '
-          'times')
-)
+    help='name of library to link against (-l<lib>); can be specified multiple times')
 
 # Parse command-line inputs
 args = vars(parser.parse_args())
@@ -738,9 +745,13 @@ if args['cflag'] is not None:
 for include_path in args['include']:
     makefile_options['COMPILER_FLAGS'] += ' -I'+include_path
 
-# --lib=[name] arguments
-for library_path in args['lib']:
+# --lib_path=[name] arguments
+for library_path in args['lib_path']:
     makefile_options['LINKER_FLAGS'] += ' -L'+library_path
+
+# --lib=[name] arguments
+for library_name in args['lib']:
+    makefile_options['LIBRARY_FLAGS'] += ' -l'+library_name
 
 # Assemble all flags of any sort given to compiler
 definitions['COMPILER_FLAGS'] = ' '.join(

--- a/tst/ci/jenkins/run_jenkins_perseus.sh
+++ b/tst/ci/jenkins/run_jenkins_perseus.sh
@@ -116,7 +116,7 @@ module list
 # due to presence of -L flag in mpicxx wrapper that overrides LIBRARY_PATH environment variable
 time python -u ./run_tests.py pgen/hdf5_reader_parallel --coverage="${lcov_capture_cmd}" \
      --mpirun=srun --mpirun_opts=--job-name='GCC pgen/hdf5_reader_parallel' \
-     --config=--lib=${mpi_hdf5_library_path} --silent
+     --config=--lib_path=${mpi_hdf5_library_path} --silent
 
 # Combine Lcov tracefiles from individaul regression tests:
 # All .info files in current working directory tst/regression/ -> lcov.info
@@ -209,7 +209,7 @@ module list
 # due to presence of -L flag in mpicxx wrapper that overrides LIBRARY_PATH environment variable
 time python -u ./run_tests.py pgen/hdf5_reader_parallel --config=--cxx=icpc \
      --mpirun=srun --mpirun_opts=--job-name='ICC pgen/hdf5_reader_parallel' \
-     --config=--lib=${mpi_hdf5_library_path} --silent
+     --config=--lib_path=${mpi_hdf5_library_path} --silent
 
 # Test OpenMP 4.5 SIMD-enabled function correctness by disabling IPO and forced inlining w/ Intel compiler flags
 # Check subset of regression test sets to try most EOS functions (which heavily depend on vectorization) that are called in rsolvers


### PR DESCRIPTION
The configure option `--lib`, which added `-L` flags during linking, has been renamed `--lib_path`. A new option `--lib` has been added, which adds `-l` flags during linking. These latter cannot go in `--cflags`, since libraries must be listed after any object files that use them.

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Resolves PrincetonUniversity/athena-public-version#21.