### PR TITLE
Throw error when reading HDF5 files with ghost zones if their number hasn't been specified.

### DIFF
--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -405,6 +405,8 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
         logical_locations = f['LogicalLocations'][:]
         if dtype is None:
             dtype = f[f.attrs['DatasetNames'][0]].dtype.newbyteorder('=')
+        if num_ghost == 0 and np.array(f['x1v']).min() < f.attrs['RootGridX1'][0]:
+            raise AthenaError('Ghost zones detected but "num_ghost" keyword set to zero.')
         if num_ghost > 0 and not np.all(levels == max_level):
             raise AthenaError('Cannot use ghost zones with different refinement levels')
         nx_vals = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #279 

`athdf` in `athena_read.py` now automatically detects if there are ghost zones in an HDF5 file and throws an error if `num_ghost` is zero.

Also, `athdf` now defaults to setting `dtype` based on the precision saved to the HDF5 file.

