### PR TITLE
Check if the necessary Python modules are installed at the beginning of run_tests.py

### DIFF
--- a/tst/regression/run_tests.py
+++ b/tst/regression/run_tests.py
@@ -39,6 +39,9 @@ logger = logging.getLogger('athena')
 # Main function
 def main(**kwargs):
 
+    # check if Python modules are installed
+    check_imports()
+
     # Save existing files
     athena.save_files()
 
@@ -231,6 +234,28 @@ def log_init(args):
             logging.getLogger(log).addHandler(rtd_handler)
 
     logger.debug('Starting Athena++ regression tests')
+
+
+def check_imports(warn=True):
+    out = True
+    import importlib
+    imports = ['sys', 'math', 'os', 'numpy', 'scipy', 'shutil', 'glob', 'logging', 'h5py']
+    for i in imports:
+        try:
+            importlib.import_module(i)
+        except ImportError:
+            logger.warning('Unable to import "{:}".'.format(i))
+            out = False
+    if warn and not out:
+        logger.warning('##########################################################')
+        logger.warning('# WARNING! Not all required Python mdules are available. #')
+        logger.warning('##########################################################')
+        try:
+            from time import sleep
+            sleep(1)
+        except ImportError:
+            pass
+    return out
 
 
 # Execute main function


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds a check testing if the necessary Python modules are installed to run the regression tests, and warns the user if there are missing modules. If no modules are missing, there will be no change in behavior.

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
