### PR TITLE
Fix logic in bvars_sts designation

### DIFF
--- a/src/field/field.cpp
+++ b/src/field/field.cpp
@@ -96,7 +96,7 @@ Field::Field(MeshBlock *pmb, ParameterInput *pin) :
   pmb->pbval->bvars_main_int.push_back(&fbvar);
   if (STS_ENABLED) {
     if (fdif.field_diffusion_defined) {
-      if (pmb->phydro->hdif.hydro_diffusion_defined && NON_BAROTROPIC_EOS) {
+      if (!pmb->phydro->hdif.hydro_diffusion_defined && NON_BAROTROPIC_EOS) {
         pmb->pbval->bvars_sts.push_back(pmb->pbval->bvars_main_int[0]);
       }
       pmb->pbval->bvars_sts.push_back(&fbvar);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes the logic in the if statements that decide which BoundaryVariable objects enter the `bvars_sts` subset when field diffusion is enabled.  

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
This PR adds a negation operator to the first term in the following line

https://github.com/PrincetonUniversity/athena/blob/065920c006448a37ba7cfe93b5345232a2c23b76/src/field/field.cpp#L99.  
If STS is enabled, then we must check what diffusive physics is turned on.  If field diffusion is enabled, and using a `NON_BAROTROPIC_EOS`, then in addition to updating fields, we must also account for the Poynting flux.  Thus when constructing the `bvars_sts` subset of BoundaryVariable Objects  (with `NON_BAROTROPIC_EOS`), we must make sure that both `&hbvar` and `&fbvar` are included.   However, if `&hbvar` has already been added to `bvars_sts` because hydro diffusion is enabled, then we don't want to add it again.  

Adding the negation operator to the first term in the aforementioned if clause correctly encapsulates the above logic.  

This bug showed its face in an MPI + field diffusion (but no hydro diffusion!) + `NON_BAROTROPIC_EOS` pgen, in this form:
```
Fatal error in MPI_Start: Request pending due to failure, error stack:
MPI_Start(121): MPI_Start(request=0x2871258) failed
MPI_Start(92).: Persistent request passed to MPI_Start or MPI_Startall is already active.
```
The error did not show up on my Mac, I only saw it when using `mpich/3.2.1` on my group's cluster.  

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->
This issue was not addressed in the regression tests.  No test in the diffusion suite tests MPI.  Also, no test enables field diffusion with a `NON_BAROTROPIC_EOS` _without_ hydro diffusion.  As always, producing more diffusion regression tests can help catch these kinks sooner.  
