### PR TITLE
Move Poisson solve to after ptlist->DoTaskListOneStage()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -457,11 +457,11 @@ int main(int argc, char *argv[]) {
     if (pmesh->turb_flag > 1) pmesh->ptrbd->Driving(); // driven turbulence
 
     for (int stage=1; stage<=ptlist->nstages; ++stage) {
+      ptlist->DoTaskListOneStage(pmesh, stage);
       if (SELF_GRAVITY_ENABLED == 1) // fft (flag 0 for discrete kernel, 1 for continuous)
         pmesh->pfgrd->Solve(stage, 0);
       else if (SELF_GRAVITY_ENABLED == 2) // multigrid
         pmesh->pmgrd->Solve(stage);
-      ptlist->DoTaskListOneStage(pmesh, stage);
     }
 
     if (STS_ENABLED && pmesh->sts_integrator == "rkl2") {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR (1) eliminates a redundant Poisson solve in the first cycle of explicit integration and (2) fixes the outputted gravitational potential energy history variable to use the correct `phi`, hence, closes #308 .  

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Moves Poisson `Solve` to after `ptlist->DoTaskListOneStage()` in explicit integration.

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
The `phi` used when constructing gravity fluxes or applying gravity source terms does not change after this PR, therefore, we should see no change in behavior, save for the `grav-E` history output. 

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
