### PR TITLE
Modifying the KH problem and a input file for MHD KH

### DIFF
--- a/inputs/mhd/athinput.kh-shear
+++ b/inputs/mhd/athinput.kh-shear
@@ -1,7 +1,7 @@
 <comment>
 problem   = MHD Kelvin-Helmholtz instability
 reference = "Lecoanet" test
-configure = --prob=kh -b
+configure = --prob=kh -b --nscalars=1
 
 <job>
 problem_id = kh-shear  # problem ID: basename of output filenames

--- a/src/pgen/kh.cpp
+++ b/src/pgen/kh.cpp
@@ -56,7 +56,7 @@ void Mesh::InitUserMeshData(ParameterInput *pin) {
     threshold = pin->GetReal("problem", "thr");
     EnrollUserRefinementCondition(RefinementCondition);
   }
-  if (iprob == 4) {
+  if (iprob == 4 && NSCALARS > 0) {
     AllocateUserHistoryOutput(1);
     EnrollUserHistoryOutput(0, PassiveDyeEntropy, "tot-S");
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The MHD KH problem potentially has a issue. When the configuration follows <comment> configure in "src/mhd/athinput.kh-shear", a simulation will have segment fault. This is because the KH problem requires NSCALARS > 0 for iprob == 4. 

There are two minor changes. one is a modification <comment> configure of the input file. The other is a modification of the line 59 in "src/kh.cpp" to avoid the segmentation fault. 

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

There is no segment fault in a simulation with the configuration (python configure.py --prob kh -b) using the input file. 

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->

- [ ] Future development task
