### PR TITLE
Fix mismatch between WeightedAve prototype and definition

### DIFF
--- a/src/mesh/weighted_ave.cpp
+++ b/src/mesh/weighted_ave.cpp
@@ -233,7 +233,7 @@ void MeshBlock::WeightedAve(AthenaArray<Real> &u_out, AthenaArray<Real> &u_in1,
 
 void MeshBlock::WeightedAve(FaceField &b_out, FaceField &b_in1,
                             FaceField &b_in2, FaceField &b_in3,
-                            FaceField &b_in4, const Real wght[3]) {
+                            FaceField &b_in4, const Real wght[5]) {
   int jl=js; int ju=je+1;
   // move these limit modifications outside the loop
   if (pbval->block_bcs[BoundaryFace::inner_x2] == BoundaryFlag::polar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When the `WeightedAve` functions were extended to the four register case (for RKL2 STS, PR #299), the array size was not updated in the `WeightedAve` function definition for `FaceField`s.  As @felker says,

> The size of the array is ignored in the function prototype and definition in C++ since it implicitly gets converted to `const Real *`, like in C.

so there should have been no adverse effects due to this typo.  This PR closes #318.  @changgoo asked me to submit this PR, but all credit belongs to @changgoo for identifying the typo.  

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description
<!--- Describe your changes in detail -->
Change `const Real wght[3]` to `const Real wght[5]` in the `WeightedAve` function definition for `FaceField`s. 