### PR TITLE
Fix Bug with Mesh Structure Output

### DIFF
--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -925,8 +925,8 @@ void Mesh::OutputMeshStructure(int ndim) {
   std::cout << "Number of logical  refinement levels = " << current_level << std::endl;
 
   // compute/output number of blocks per level, and cost per level
-  int *nb_per_plevel = new int[max_level];
-  int *cost_per_plevel = new int[max_level];
+  int *nb_per_plevel = new int[max_level+1];
+  int *cost_per_plevel = new int[max_level+1];
   for (int i=0; i<=max_level; ++i) {
     nb_per_plevel[i] = 0;
     cost_per_plevel[i] = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When giving the `m` option to output the mesh structure, a core dump is sometimes created due to the segment fault. This change is to fix it.

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When giving the `m` option to output mesh structure, the segment faults are found in some cases. To fix it, I give a change in `Mesh::OutputMeshStructure` from 
```
int *nb_per_plevel = new int[max_level];
int *cost_per_plevel = new int[max_level];
```
to 
```
int *nb_per_plevel = new int[max_level+1];
int *cost_per_plevel = new int[max_level+1];
```
This is just a minor change. 

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->
