### PR TITLE
put cast in the min or max function

### DIFF
--- a/src/eos/adiabatic_hydro_gr.cpp
+++ b/src/eos/adiabatic_hydro_gr.cpp
@@ -155,8 +155,10 @@ void EquationOfState::ConservedToPrimitive(
         }
 
         // Apply density and gas pressure floors in normal frame
-        Real rho_add = std::max(density_floor_local-prim(IDN,k,j,i), 0.0);
-        Real pgas_add = std::max(pressure_floor_local-prim(IPR,k,j,i), 0.0);
+        Real rho_add = std::max(density_floor_local-prim(IDN,k,j,i),
+                                                static_cast<Real>(0.0));
+        Real pgas_add = std::max(pressure_floor_local-prim(IPR,k,j,i),
+                                                static_cast<Real>(0.0));
         if (success && (rho_add > 0.0 || pgas_add > 0.0)) {
           // Adjust conserved density and energy
           Real wgas_add = rho_add + gamma_adi/(gamma_adi-1.0) * pgas_add;
@@ -483,7 +485,7 @@ bool ConservedToPrimitiveNormal(
     Real v_sq;
     if (n%3 != 2) {
       v_sq = mm_sq / SQR(a);                                     // (NH 5.2)
-      v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
+      v_sq = std::min(std::max(v_sq, static_cast<Real>(0.0)), v_sq_max);
       Real gamma_sq = 1.0/(1.0-v_sq);                            // (NH 3.1)
       Real gamma = std::sqrt(gamma_sq);                          // (NH 3.1)
       Real wgas = a/gamma_sq;                                    // (NH 5.1)
@@ -524,7 +526,7 @@ bool ConservedToPrimitiveNormal(
   Real a = ee + prim(IPR,k,j,i);                   // (NH 5.7)
   a = std::max(a, a_min);
   Real v_sq = mm_sq / SQR(a);                      // (NH 5.2)
-  v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
+  v_sq = std::min(std::max(v_sq, static_cast<Real>(0.0)), v_sq_max);
   Real gamma_sq = 1.0/(1.0-v_sq);                  // (NH 3.1)
   Real gamma = std::sqrt(gamma_sq);                // (NH 3.1)
   prim(IDN,k,j,i) = dd/gamma;                      // (NH 4.5)

--- a/src/eos/adiabatic_hydro_sr.cpp
+++ b/src/eos/adiabatic_hydro_sr.cpp
@@ -142,8 +142,10 @@ void EquationOfState::ConservedToPrimitive(
         }
 
         // Apply density and gas pressure floors in coordinate frame
-        Real rho_add = std::max(density_floor_-prim(IDN,k,j,i), 0.0);
-        Real pgas_add = std::max(pressure_floor_-prim(IPR,k,j,i), 0.0);
+        Real rho_add = std::max(density_floor_-prim(IDN,k,j,i),
+                                                static_cast<Real>(0.0));
+        Real pgas_add = std::max(pressure_floor_-prim(IPR,k,j,i),
+                                                static_cast<Real>(0.0));
         if (success && (rho_add > 0.0 || pgas_add > 0.0)) {
           // Adjust conserved density and energy
           Real wgas_add = rho_add + gamma_adi/(gamma_adi-1.0) * pgas_add;
@@ -359,7 +361,7 @@ bool ConservedToPrimitiveNormal(
     Real v_sq;
     if (n%3 != 2) {
       v_sq = mm_sq / SQR(a);                                     // (NH 5.2)
-      v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
+      v_sq = std::min(std::max(v_sq, static_cast<Real>(0.0)), v_sq_max);
       Real gamma_sq = 1.0/(1.0-v_sq);                            // (NH 3.1)
       Real gamma = std::sqrt(gamma_sq);                          // (NH 3.1)
       Real wgas = a/gamma_sq;                                    // (NH 5.1)
@@ -400,7 +402,7 @@ bool ConservedToPrimitiveNormal(
   Real a = ee + prim(IPR,k,j,i);                   // (NH 5.7)
   a = std::max(a, a_min);
   Real v_sq = mm_sq / SQR(a);                      // (NH 5.2)
-  v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
+  v_sq = std::min(std::max(v_sq, static_cast<Real>(0.0)), v_sq_max);
   Real gamma_sq = 1.0/(1.0-v_sq);                  // (NH 3.1)
   Real gamma = std::sqrt(gamma_sq);                // (NH 3.1)
   prim(IDN,k,j,i) = dd/gamma;                      // (NH 4.5)

--- a/src/eos/adiabatic_mhd_gr.cpp
+++ b/src/eos/adiabatic_mhd_gr.cpp
@@ -173,8 +173,10 @@ void EquationOfState::ConservedToPrimitive(
         if (beta_min_ > 0.0) {
           pressure_floor_local = std::max(pressure_floor_local, beta_min_*pmag);
         }
-        Real rho_add = std::max(density_floor_local-prim(IDN,k,j,i), 0.0);
-        Real pgas_add = std::max(pressure_floor_local-prim(IPR,k,j,i), 0.0);
+        Real rho_add = std::max(density_floor_local-prim(IDN,k,j,i),
+                                                static_cast<Real>(0.0));
+        Real pgas_add = std::max(pressure_floor_local-prim(IPR,k,j,i),
+                                                static_cast<Real>(0.0));
         if (success && (rho_add > 0.0 || pgas_add > 0.0)) {
           // Adjust conserved density and energy
           Real wgas_add = rho_add + gamma_adi/(gamma_adi-1.0) * pgas_add;
@@ -470,7 +472,7 @@ bool ConservedToPrimitiveNormal(
 
   // Calculate functions of conserved quantities
   Real d = 0.5 * (mm_sq * bb_sq - SQR(tt));                  // (NH 5.7)
-  d = std::max(d, 0.0);
+  d = std::max(d, static_cast<Real>(0.0));
   Real pgas_min = std::cbrt(27.0/4.0 * d) - ee - 0.5*bb_sq;
   pgas_min = std::max(pgas_min, pgas_uniform_min);
 
@@ -493,7 +495,7 @@ bool ConservedToPrimitiveNormal(
       eee = a/3.0 - 2.0/3.0 * a * std::cos(2.0/3.0 * (phi+PI));               // (NH 5.11)
       ll = eee - bb_sq;                                                       // (NH 5.5)
       v_sq = (mm_sq*SQR(ll) + SQR(tt)*(bb_sq+2.0*ll)) / SQR(ll * (bb_sq+ll)); // (NH 5.2)
-      v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
+      v_sq = std::min(std::max(v_sq, static_cast<Real>(0.0)), v_sq_max);
       Real gamma_sq = 1.0/(1.0-v_sq);                                         // (NH 3.1)
       Real gamma = std::sqrt(gamma_sq);                                       // (NH 3.1)
       Real wgas = ll/gamma_sq;                                                // (NH 5.1)
@@ -538,7 +540,7 @@ bool ConservedToPrimitiveNormal(
   Real ll = eee - bb_sq;                                          // (NH 5.5)
   Real v_sq = (mm_sq*SQR(ll) + SQR(tt)*(bb_sq+2.0*ll))
               / SQR(ll * (bb_sq+ll));                             // (NH 5.2)
-  v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
+  v_sq = std::min(std::max(v_sq, static_cast<Real>(0.0)), v_sq_max);
   Real gamma_sq = 1.0/(1.0-v_sq);                                 // (NH 3.1)
   Real gamma = std::sqrt(gamma_sq);                               // (NH 3.1)
   prim(IDN,k,j,i) = dd/gamma;                                     // (NH 4.5)
@@ -665,7 +667,7 @@ void EquationOfState::FastMagnetosonicSpeedsGR(Real wgas, Real pgas, Real u0, Re
   Real c = SQR(u1) - (g11 + SQR(u1)) * cms_sq;
   Real a1 = b / a;
   Real a0 = c / a;
-  Real s = std::sqrt(std::max(SQR(a1) - 4.0 * a0, 0.0));
+  Real s = std::sqrt(std::max(SQR(a1) - 4.0 * a0, static_cast<Real>(0.0)));
   *p_lambda_plus = (a1 >= 0.0) ? -2.0 * a0 / (a1 + s) : (-a1 + s) / 2.0;
   *p_lambda_minus = (a1 >= 0.0) ? (-a1 - s) / 2.0 : -2.0 * a0 / (a1 - s);
   return;

--- a/src/eos/adiabatic_mhd_sr.cpp
+++ b/src/eos/adiabatic_mhd_sr.cpp
@@ -170,8 +170,10 @@ void EquationOfState::ConservedToPrimitive(
         if (beta_min_ > 0.0) {
           pressure_floor_local = std::max(pressure_floor_local, beta_min_*pmag);
         }
-        Real rho_add = std::max(density_floor_local-prim(IDN,k,j,i), 0.0);
-        Real pgas_add = std::max(pressure_floor_local-prim(IPR,k,j,i), 0.0);
+        Real rho_add = std::max(density_floor_local-prim(IDN,k,j,i),
+                                                static_cast<Real>(0.0));
+        Real pgas_add = std::max(pressure_floor_local-prim(IPR,k,j,i),
+                                                static_cast<Real>(0.0));
         if (success && (rho_add > 0.0 || pgas_add > 0.0)) {
           // Adjust conserved density and energy
           Real wgas_add = rho_add + gamma_adi/(gamma_adi-1.0) * pgas_add;
@@ -361,7 +363,7 @@ void EquationOfState::FastMagnetosonicSpeedsGR(Real wgas, Real pgas, Real u0, Re
   Real c = SQR(u1) - (g11 + SQR(u1)) * cms_sq;
   Real a1 = b / a;
   Real a0 = c / a;
-  Real s = std::sqrt(std::max(SQR(a1) - 4.0 * a0, 0.0));
+  Real s = std::sqrt(std::max(SQR(a1) - 4.0 * a0, static_cast<Real>(0.0)));
   *p_lambda_plus = (a1 >= 0.0) ? -2.0 * a0 / (a1 + s) : (-a1 + s) / 2.0;
   *p_lambda_minus = (a1 >= 0.0) ? (-a1 - s) / 2.0 : -2.0 * a0 / (a1 - s);
   return;
@@ -450,7 +452,7 @@ bool ConservedToPrimitiveNormal(
       eee = a/3.0 - 2.0/3.0 * a * std::cos(2.0/3.0 * (phi+PI));               // (NH 5.11)
       ll = eee - bb_sq;                                                       // (NH 5.5)
       v_sq = (mm_sq*SQR(ll) + SQR(tt)*(bb_sq+2.0*ll)) / SQR(ll * (bb_sq+ll)); // (NH 5.2)
-      v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
+      v_sq = std::min(std::max(v_sq, static_cast<Real>(0.0)), v_sq_max);
       Real gamma_sq = 1.0/(1.0-v_sq);                                         // (NH 3.1)
       Real gamma = std::sqrt(gamma_sq);                                       // (NH 3.1)
       Real wgas = ll/gamma_sq;                                                // (NH 5.1)
@@ -495,7 +497,7 @@ bool ConservedToPrimitiveNormal(
   Real ll = eee - bb_sq;                                          // (NH 5.5)
   Real v_sq = (mm_sq*SQR(ll) + SQR(tt)*(bb_sq+2.0*ll))
               / SQR(ll * (bb_sq+ll));                             // (NH 5.2)
-  v_sq = std::min(std::max(v_sq, 0.0), v_sq_max);
+  v_sq = std::min(std::max(v_sq, static_cast<Real>(0.0)), v_sq_max);
   Real gamma_sq = 1.0/(1.0-v_sq);                                 // (NH 3.1)
   Real gamma = std::sqrt(gamma_sq);                               // (NH 3.1)
   prim(IDN,k,j,i) = dd/gamma;                                     // (NH 4.5)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As reported in #326, using the single precision could lead a bug when either `std::min` or `std::max` function has a real number as an argument. To avoid it, the real number should be cast to `Real`. As long as I see, the relevant parts are only in `src/eos`. Therefore, I fixed them. This change is just minor.