### PR TITLE
Fix lack of deallocating dynamic memory

### DIFF
--- a/src/bvals/orbital/bvals_orbital.cpp
+++ b/src/bvals/orbital/bvals_orbital.cpp
@@ -88,14 +88,13 @@ OrbitalBoundaryCommunication::~OrbitalBoundaryCommunication() {
       DestroyBoundaryData(orbital_bd_fc_[upper]);
     }
   }
-  if(pmy_orbital_->orbital_refinement) {
-    for (int n=0; n<2; n++) {
-      delete[] size_cc_send[n];
-      delete[] size_cc_recv[n];
-      if (MAGNETIC_FIELDS_ENABLED) {
-        delete[] size_fc_send[n];
-        delete[] size_fc_recv[n];
-      }
+
+  for (int n=0; n<2; n++) {
+    delete[] size_cc_send[n];
+    delete[] size_cc_recv[n];
+    if (MAGNETIC_FIELDS_ENABLED) {
+      delete[] size_fc_send[n];
+      delete[] size_fc_recv[n];
     }
   }
 }

--- a/src/bvals/orbital/bvals_orbital.hpp
+++ b/src/bvals/orbital/bvals_orbital.hpp
@@ -83,8 +83,8 @@ class OrbitalBoundaryCommunication {
 
   int *size_cc_send[2];  //same, coarser, fine*4
   int *size_cc_recv[2];  //same, coarser, fine*4
-  int *size_fc_send[2];  //same, coarser, fine*8
-  int *size_fc_recv[2];  //same, coarser, fine*8
+  int *size_fc_send[2];  //same, coarser, fine*4
+  int *size_fc_recv[2];  //same, coarser, fine*4
 
   // ptr to MeshBlock, Mesh, BoundaryValues, OrbitalAdvection
   MeshBlock *pmy_block_;


### PR DESCRIPTION
In the OrbitalBoundaryCommunication class, there were bugs about the lack of deallocating dynamic memory. I fix the bugs in this PR. 