### PR TITLE
New Limitation of MeshBlock Size

### DIFF
--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -125,7 +125,8 @@ BoundaryValues::BoundaryValues(MeshBlock *pmb, BoundaryFlag *input_bcs,
   // set parameters for shearing box bc and allocate buffers
   shearing_box = 0;
   if (pmy_mesh_->shear_periodic) {
-    // TODO(tomo-ono): Reading input file about xorder should not be done here.
+    // It is required to know the reconstruction scheme before pmb->precon is defined.
+    // If a higher-order scheme than PPM is implemented, xgh_ must be larger than 2.
     std::string input_recon = pin->GetOrAddString("time", "xorder", "2");
     if (input_recon == "1") {
       xorder_ = 1;


### PR DESCRIPTION
The current code requires that the mesh block size is no less than 4 cells. However, this limitation is not adequate in some cases. For example, the boundary communications will fail in the coarse mesh blocks when `nx1=nx2=nx3=4`, `nghost=4`, and using SMR. Without the mesh refinement, the communications go well. However, the performance must be very bad. Therefore, I propose that the the mesh block size should be no less than `NGHOST*2` cells. 