### PR TITLE
Reduce overly greedy NGHOST requirement for PPM+MHD

### DIFF
--- a/src/hydro/calculate_fluxes.cpp
+++ b/src/hydro/calculate_fluxes.cpp
@@ -64,15 +64,14 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
   AthenaArray<Real> &x1flux = flux[X1DIR];
   // set the loop limits
   jl = js, ju = je, kl = ks, ku = ke;
-  // TODO(felker): fix loop limits for fourth-order hydro
-  //  if (MAGNETIC_FIELDS_ENABLED) {
-  if (pmb->block_size.nx2 > 1) {
-    if (pmb->block_size.nx3 == 1) // 2D
-      jl = js-1, ju = je+1, kl = ks, ku = ke;
-    else // 3D
-      jl = js-1, ju = je+1, kl = ks-1, ku = ke+1;
+  if (MAGNETIC_FIELDS_ENABLED || order == 4) {
+    if (pmb->block_size.nx2 > 1) {
+      if (pmb->block_size.nx3 == 1) // 2D
+        jl = js-1, ju = je+1, kl = ks, ku = ke;
+      else // 3D
+        jl = js-1, ju = je+1, kl = ks-1, ku = ke+1;
+    }
   }
-  //  }
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -166,13 +165,12 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
     AthenaArray<Real> &x2flux = flux[X2DIR];
     // set the loop limits
     il = is-1, iu = ie+1, kl = ks, ku = ke;
-    // TODO(felker): fix loop limits for fourth-order hydro
-    //    if (MAGNETIC_FIELDS_ENABLED) {
-    if (pmb->block_size.nx3 == 1) // 2D
-      kl = ks, ku = ke;
-    else // 3D
-      kl = ks-1, ku = ke+1;
-    //    }
+    if (MAGNETIC_FIELDS_ENABLED || order == 4) {
+      if (pmb->block_size.nx3 == 1) // 2D
+        kl = ks, ku = ke;
+      else // 3D
+        kl = ks-1, ku = ke+1;
+    }
 
     for (int k=kl; k<=ku; ++k) {
       // reconstruct the first row
@@ -275,9 +273,9 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
   if (pmb->pmy_mesh->f3) {
     AthenaArray<Real> &x3flux = flux[X3DIR];
     // set the loop limits
-    // TODO(felker): fix loop limits for fourth-order hydro
-    //    if (MAGNETIC_FIELDS_ENABLED)
-    il = is-1, iu = ie+1, jl = js-1, ju = je+1;
+    if (MAGNETIC_FIELDS_ENABLED || order == 4) {
+      il = is-1, iu = ie+1, jl = js-1, ju = je+1;
+    }
 
     for (int j=jl; j<=ju; ++j) { // this loop ordering is intentional
       // reconstruct the first row

--- a/src/reconstruct/reconstruction.cpp
+++ b/src/reconstruct/reconstruction.cpp
@@ -89,8 +89,6 @@ Reconstruction::Reconstruction(MeshBlock *pmb, ParameterInput *pin) :
   // check for necessary number of ghost zones for PPM w/o fourth-order flux corrections
   if (xorder == 3) {
     int req_nghost = 3;
-    if (MAGNETIC_FIELDS_ENABLED)
-      req_nghost += 1;
     if (NGHOST < req_nghost) {
       std::stringstream msg;
       msg << "### FATAL ERROR in Reconstruction constructor" << std::endl


### PR DESCRIPTION
Also restore MHD and fourth-order Hydro switch for extending transverse
loop limits in flux calculation.

Closes #339.