### PR TITLE
Fix 4th-order hydro with non-periodic BCs

### DIFF
--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1556,6 +1556,12 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin) {
           // for MHD, shrink buffer by 3
           //! \todo (felker):
           //! * add MHD loop limit calculation for 4th order W(U)
+          // Apply physical boundaries prior to 4th order W(U)
+          ph->hbvar.SwapHydroQuantity(ph->w, HydroBoundaryQuantity::prim);
+          if (NSCALARS > 0)
+            ps->sbvar.var_cc = &(ps->r);
+          pbval->ApplyPhysicalBoundaries(time, 0.0, pbval->bvars_main_int);
+          // Perform 4th order W(U)
           pmb->peos->ConservedToPrimitiveCellAverage(ph->u, ph->w1, pf->b,
                                                      ph->w, pf->bcc, pmb->pcoord,
                                                      il, iu, jl, ju, kl, ku);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
4th order hydrodynamics in Athena++ is not compatible with non-periodic BCs (see Issue #298).  This issue stems from the 4th order inversion `ConservedToPrimitiveCellAverage`.  In particular, the `Laplacian` operator accesses ghost zones corresponding to physical boundaries, which I believe must be updated prior to the inversion.  This PR applies physical boundaries prior to the inversion and closes #298.  

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The application of physical boundaries before 4th order inversion must happen in `Mesh::Initialize`, `TimeIntegratorTaskList::Primitives`, and `SuperTimeStepTaskList::Primitives`.  This application of physical boundaries *does not* replace the `PHY_BVAL` following `CONS2PRIM`.  It is an *additional* application of physical boundaries.  To sketch out a single cycle in `TimeIntegratorTaskList`, 

(1) `IntegrateHydro` gives updated `u`.  Now we need to update `w`.
(2) As usual, perform normal `ConservedToPrimitive`.  `u` and `w1` are now consistent, but ghost zone values corresponding to physical boundaries are not yet updated.  This is normally resolved with `TimeIntegratorTaskList::PhysicalBoundary`, but with `xorder==4`, ghost zones corresponding to physical boundaries are accessed before `TimeIntegratorTaskList::PhysicalBoundary`.  This PR introduces a call to `ApplyPhysicalBoundaries` here.  
(3)`u` and `w1` are now consistent, even at physical boundaries.
(4) Call `ConservedToPrimitiveCellAverage`.
(5) Swap `w` and `w1`.  `u` and `w` are now consistent.
(6) The physical boundaries in `u` and `w` are consistent with `u` and `w1` from (3), but now we need the physical boundaries to be consistent with the most up-to-date `u` and `w`.  Therefore, we need to set physical boundaries again.  This happens in `PHY_BVAL` following `CONS2PRIM`.  

This is messy.  Could others double-check my logic and implementation?  Is there a better way to do this? Also, do my edits break shearing box/orbital advection with `xorder==4`, @tomo-ono? 

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-The `fourth_order_bug.cpp` problem in Issue #298 is resolved after these changes.  
-The `visc.cpp` problem converges as expected with `SSPRK5_4` integrator + `xorder==4` + STS.  (Note that prior to this PR, this configuration for this problem would yield `nan`s).
![l1_visc_sts](https://user-images.githubusercontent.com/33095288/103965774-19e45900-5124-11eb-93ea-3082c9d4bb74.png)
-And the before/after solution for a Sod shocktube with `xorder==4`.  
![sod_solution](https://user-images.githubusercontent.com/33095288/103965787-210b6700-5124-11eb-9666-b761d4ceacb4.png)
-The `hydro4` test suite passes, but all of those tests use periodic BCs.  
