### PR TITLE
Fix the switch to default RKL2 STS

### DIFF
--- a/src/field/field.cpp
+++ b/src/field/field.cpp
@@ -60,7 +60,7 @@ Field::Field(MeshBlock *pmb, ParameterInput *pin) :
   }
 
   if (STS_ENABLED) {
-    std::string sts_integrator = pin->GetOrAddString("time", "sts_integrator", "rkl1");
+    std::string sts_integrator = pin->GetOrAddString("time", "sts_integrator", "rkl2");
     if (sts_integrator == "rkl2") {
       b0.x1f.NewAthenaArray( ncells3   , ncells2   ,(ncells1+1));
       b0.x2f.NewAthenaArray( ncells3   ,(ncells2+1), ncells1   );

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -74,7 +74,7 @@ Hydro::Hydro(MeshBlock *pmb, ParameterInput *pin) :
 
   // If STS RKL2, allocate additional memory registers
   if (STS_ENABLED) {
-    std::string sts_integrator = pin->GetOrAddString("time", "sts_integrator", "rkl1");
+    std::string sts_integrator = pin->GetOrAddString("time", "sts_integrator", "rkl2");
     if (sts_integrator == "rkl2") {
       u0.NewAthenaArray(NHYDRO, nc3, nc2, nc1);
       fl_div.NewAthenaArray(NHYDRO, nc3, nc2, nc1);

--- a/src/scalars/scalars.cpp
+++ b/src/scalars/scalars.cpp
@@ -67,7 +67,7 @@ PassiveScalars::PassiveScalars(MeshBlock *pmb, ParameterInput *pin)  :
 
   // If STS RKL2, allocate additional memory registers
   if (STS_ENABLED) {
-    std::string sts_integrator = pin->GetOrAddString("time", "sts_integrator", "rkl1");
+    std::string sts_integrator = pin->GetOrAddString("time", "sts_integrator", "rkl2");
     if (sts_integrator == "rkl2") {
       s0.NewAthenaArray(NSCALARS, nc3, nc2, nc1);
       s_fl_div.NewAthenaArray(NSCALARS, nc3, nc2, nc1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In PR #342, the default STS integrator was set to RKL2 by making the appropriate changes to `mesh.cpp`.  However, there is also a necessary change to `hydro.cpp`, `field.cpp`, and `scalars.cpp`.  This PR makes those changes.  This PR is unrelated to issue #349.  

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
