### PR TITLE
Fix a bug in history output

### DIFF
--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -36,7 +36,7 @@
 // NEW_OUTPUT_TYPES:
 
 // "3" for 1-KE, 2-KE, 3-KE additional columns (come before tot-E)
-#define NHISTORY_VARS ((NHYDRO) + (SELF_GRAVITY_ENABLED) + (NFIELD) + 3 + (NSCALARS))
+#define NHISTORY_VARS ((NHYDRO) + (SELF_GRAVITY_ENABLED > 0) + (NFIELD) + 3 + (NSCALARS))
 
 //----------------------------------------------------------------------------------------
 //! \fn void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
@@ -114,7 +114,7 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
               Real& bcc1 = pfld->bcc(IB1,k,j,i);
               Real& bcc2 = pfld->bcc(IB2,k,j,i);
               Real& bcc3 = pfld->bcc(IB3,k,j,i);
-              constexpr int prev_out = NHYDRO + 3 + SELF_GRAVITY_ENABLED;
+              constexpr int prev_out = NHYDRO + 3 + (SELF_GRAVITY_ENABLED > 0);
               hst_data[prev_out] += vol(i)*0.5*bcc1*bcc1;
               hst_data[prev_out + 1] += vol(i)*0.5*bcc2*bcc2;
               hst_data[prev_out + 2] += vol(i)*0.5*bcc3*bcc3;
@@ -122,7 +122,7 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             // (conserved variable) Passive scalars:
             for (int n=0; n<NSCALARS; n++) {
               Real& s = psclr->s(n,k,j,i);
-              constexpr int prev_out = NHYDRO + 3 + SELF_GRAVITY_ENABLED + NFIELD;
+              constexpr int prev_out = NHYDRO + 3 + (SELF_GRAVITY_ENABLED > 0) + NFIELD;
               hst_data[prev_out + n] += vol(i)*s;
             }
           }
@@ -276,7 +276,7 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
         std::fprintf(pfile,"[%d]=%d-scalar    ", iout++, n);
       }
       for (int n=0; n<pm->nuser_history_output_; n++)
-        std::fprintf(pfile,"[%d]=%-8s", iout++,
+        std::fprintf(pfile,"[%d]=%-7s ", iout++,
                      pm->user_history_output_names_[n].c_str());
       std::fprintf(pfile,"\n");                              // terminate line
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. When the name of user-enrolled history exceeds 7 characters, columns in the header will not be separated by a whitespace character. When read by athena_read.hst(), the greedy match regex `\[\d+\]=(\S+)` leads to two column identified as one.
2. When gravity solver except FFT is used, column indices are calculated incorrectly.
