### PR TITLE
Fix a bug in OA hydro source term

### DIFF
--- a/src/hydro/srcterms/rotating_system_srcterms.cpp
+++ b/src/hydro/srcterms/rotating_system_srcterms.cpp
@@ -36,13 +36,13 @@ void HydroSourceTerms::RotatingSystemSourceTerms
       for (int j=pmb->js; j<=pmb->je; ++j) {
 #pragma omp simd
         for (int i=pmb->is; i<=pmb->ie; ++i) {
-          Real den  = prim(IDN,k,j,i);
-          Real mom1 = den*prim(IVX,k,j,i);
-          Real ri   = pmb->pcoord->coord_src1_i_(i);
-          Real rv   = pmb->pcoord->x1v(i);
-          Real vc   = rv*Omega_0_;
-          Real src  = SQR(vc); // (rOmega)^2
-          Real flux_c = 0.5*(flux[X1DIR](IDN,k,j,i)+flux[X1DIR](IDN,k,j,i+1));
+          const Real &den = prim(IDN,k,j,i);
+          const Real mom1 = den*prim(IVX,k,j,i);
+          const Real &ri  = pmb->pcoord->coord_src1_i_(i);
+          const Real &rv  = pmb->pcoord->x1v(i);
+          const Real vc   = rv*Omega_0_;
+          const Real src  = SQR(vc); // (rOmega)^2
+          const Real flux_c = 0.5*(flux[X1DIR](IDN,k,j,i)+flux[X1DIR](IDN,k,j,i+1));
           cons(IM1,k,j,i) += dt*ri*(2.0*vc*(den*prim(IVY,k,j,i))+den*src);
           cons(IM2,k,j,i) -= dt*ri*vc*(mom1 + flux_c);
           if(NON_BAROTROPIC_EOS) {
@@ -64,19 +64,19 @@ void HydroSourceTerms::RotatingSystemSourceTerms
     // vc     = r sin(\theta)\Omega
     for (int k=pmb->ks; k<=pmb->ke; ++k) {
       for (int j=pmb->js; j<=pmb->je; ++j) {
-        Real cv1 = pmb->pcoord->coord_src1_j_(j); // cot(theta)
-        Real cv3 = pmb->pcoord->coord_src3_j_(j); // cot(\theta)
-        Real sv  = std::sin(pmb->pcoord->x2v(j)); // sin(\theta)
+        const Real &cv1 = pmb->pcoord->coord_src1_j_(j); // cot(theta)
+        const Real &cv3 = pmb->pcoord->coord_src3_j_(j); // cot(\theta)
+        const Real &sv  = std::sin(pmb->pcoord->x2v(j)); // sin(\theta)
 #pragma omp simd
         for (int i=pmb->is; i<=pmb->ie; ++i) {
-          Real den  = prim(IDN,k,j,i);
-          Real rv   = pmb->pcoord->x1v(i);
-          Real ri   = pmb->pcoord->coord_src1_i_(i); // 1/r
-          Real vc   = rv*sv*Omega_0_;
-          Real src  = SQR(vc); // vc^2
-          Real force = den*ri*(2.0*vc*prim(IVZ,k,j,i)+src);
-          Real flux_xc = 0.5*(flux[X1DIR](IDN,k,j,i+1)+flux[X1DIR](IDN,k,j,i));
-          Real flux_yc = 0.5*(flux[X2DIR](IDN,k,j+1,i)+flux[X2DIR](IDN,k,j,i));
+          const Real &den  = prim(IDN,k,j,i);
+          const Real &rv   = pmb->pcoord->x1v(i);
+          const Real &ri   = pmb->pcoord->coord_src1_i_(i); // 1/r
+          const Real vc    = rv*sv*Omega_0_;
+          const Real src   = SQR(vc); // vc^2
+          const Real force = den*ri*(2.0*vc*prim(IVZ,k,j,i)+src);
+          const Real flux_xc = 0.5*(flux[X1DIR](IDN,k,j,i+1)+flux[X1DIR](IDN,k,j,i));
+          const Real flux_yc = 0.5*(flux[X2DIR](IDN,k,j+1,i)+flux[X2DIR](IDN,k,j,i));
           cons(IM1,k,j,i) += dt*force;
           cons(IM2,k,j,i) += dt*force*cv1;
           cons(IM3,k,j,i) -= dt*ri*vc*(den*prim(IVX,k,j,i)+flux_xc

--- a/src/hydro/srcterms/shearing_box.cpp
+++ b/src/hydro/srcterms/shearing_box.cpp
@@ -47,16 +47,16 @@ void HydroSourceTerms::ShearingBoxSourceTerms(const Real dt,
       for (int j=pmb->js; j<=pmb->je; ++j) {
 #pragma omp simd
         for (int i=pmb->is; i<=pmb->ie; ++i) {
-          Real den  = prim(IDN,k,j,i);
-          Real qO2  = qshear_*SQR(Omega_0_);
-          Real mom1 = den*prim(IVX,k,j,i);
-          Real xc = pmb->pcoord->x1v(i);
+          const Real &den = prim(IDN,k,j,i);
+          const Real qO2  = qshear_*SQR(Omega_0_);
+          const Real mom1 = den*prim(IVX,k,j,i);
+          const Real &xc  = pmb->pcoord->x1v(i);
           cons(IM1,k,j,i) += 2.0*dt*(Omega_0_*(den*prim(IVY,k,j,i))+qO2*den*xc);
           cons(IM2,k,j,i) -= 2.0*dt*Omega_0_*mom1;
           if (NON_BAROTROPIC_EOS) {
-            Real phic = qO2*SQR(xc);
-            Real phil = qO2*SQR(pmb->pcoord->x1f(i));
-            Real phir = qO2*SQR(pmb->pcoord->x1f(i+1));
+            const Real phic = qO2*SQR(xc);
+            const Real phil = qO2*SQR(pmb->pcoord->x1f(i));
+            const Real phir = qO2*SQR(pmb->pcoord->x1f(i+1));
             cons(IEN,k,j,i) += dt*(flux[X1DIR](IDN,k,j,i)*(phic-phil)+
                                    flux[X1DIR](IDN,k,j,i+1)*(phir-phic))
                                    /pmb->pcoord->dx1f(i);
@@ -69,16 +69,16 @@ void HydroSourceTerms::ShearingBoxSourceTerms(const Real dt,
     for (int j=pmb->js; j<=pmb->je; ++j) {
 #pragma omp simd
       for (int i=pmb->is; i<=pmb->ie; ++i) {
-        Real den  = prim(IDN,ks,j,i);
-        Real qO2  = qshear_*SQR(Omega_0_);
-        Real mom1 = den*prim(IVX,ks,j,i);
-        Real xc = pmb->pcoord->x1v(i);
+        const Real &den = prim(IDN,ks,j,i);
+        const Real qO2  = qshear_*SQR(Omega_0_);
+        const Real mom1 = den*prim(IVX,ks,j,i);
+        const Real &xc  = pmb->pcoord->x1v(i);
         cons(IM1,ks,j,i) += 2.0*dt*(Omega_0_*(den*prim(IVZ,ks,j,i))+qO2*den*xc);
         cons(IM3,ks,j,i) -= 2.0*dt*Omega_0_*mom1;
         if (NON_BAROTROPIC_EOS) {
-          Real phic = qO2*SQR(xc);
-          Real phil = qO2*SQR(pmb->pcoord->x1f(i));
-          Real phir = qO2*SQR(pmb->pcoord->x1f(i+1));
+          const Real phic = qO2*SQR(xc);
+          const Real phil = qO2*SQR(pmb->pcoord->x1f(i));
+          const Real phir = qO2*SQR(pmb->pcoord->x1f(i+1));
           cons(IEN,ks,j,i) += dt*(flux[X1DIR](IDN,ks,j,i)*(phic-phil)+
                                   flux[X1DIR](IDN,ks,j,i+1)*(phir-phic))
                                   /pmb->pcoord->dx1f(i);


### PR DESCRIPTION
The previous version had a bug in the hydro term for with the orbital advection in spherical polar coordinates. This PR gives a correct expression to the force from the OA system in the azimuthal direction. Some of `Real`  are rewritten by `const Real` or `const Real &` for the safety in `orbital_advection_srcterms.cpp`, .`rotating_system_srcterms.cpp`, and  `shearing_box.cpp`. 