### PR TITLE
Fix shearing boundary flag for corner neighbors

### DIFF
--- a/src/bvals/bvals_base.cpp
+++ b/src/bvals/bvals_base.cpp
@@ -713,11 +713,19 @@ void BoundaryBase::SearchAndSetNeighbors(MeshBlockTree &tree, int *ranklist,
         int nlevel = neibt->loc_.level;
         nblevel[l+1][m+1][n+1] = nlevel;
         if (nlevel >= loc.level || (myox1 == n && myox2 == m && myox3 == l)) {
+          bool shear = false;
+          if ((nlevel == loc.level) &&
+              ((n == -1 && block_bcs[BoundaryFace::inner_x1]
+                                 == BoundaryFlag::shear_periodic) &&
+               (n ==  1 && block_bcs[BoundaryFace::outer_x1]
+                                 == BoundaryFlag::shear_periodic))) {
+            shear = true; // neighbor is shearing periodic
+          }
           int nid = neibt->gid_;
           int tbid = FindBufferID(-n, polar ? m : -m, -l, 0, 0);
           neighbor[nneighbor].SetNeighbor(
               ranklist[nid], nlevel, nid, nid-nslist[ranklist[nid]], n, m, l,
-              NeighborConnect::corner, bufid, tbid, polar, false);
+              NeighborConnect::corner, bufid, tbid, polar, shear);
           nneighbor++;
         }
         bufid++;


### PR DESCRIPTION
According to #337, the shear boundary flag was not set properly for corner neighbors. This PR fix the bug. Even using this PR, neither the simulation results nor the limitation of the shear periodic boundary with SMR/AMR has any change.