### PR TITLE
fix typo in setting of shearing boundary flag

### DIFF
--- a/src/bvals/bvals_base.cpp
+++ b/src/bvals/bvals_base.cpp
@@ -716,7 +716,7 @@ void BoundaryBase::SearchAndSetNeighbors(MeshBlockTree &tree, int *ranklist,
           bool shear = false;
           if ((nlevel == loc.level) &&
               ((n == -1 && block_bcs[BoundaryFace::inner_x1]
-                                 == BoundaryFlag::shear_periodic) &&
+                                 == BoundaryFlag::shear_periodic) ||
                (n ==  1 && block_bcs[BoundaryFace::outer_x1]
                                  == BoundaryFlag::shear_periodic))) {
             shear = true; // neighbor is shearing periodic


### PR DESCRIPTION
As @changoo pointed out, #378 has a typo. This PR is just a minor update to fix it. 