### PR TITLE
Low-dissipation HLLC/HLLD solvers (Minoshima et al. 2021)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -98,7 +98,7 @@ parser.add_argument('--eos',
 # --flux=[name] argument
 parser.add_argument('--flux',
                     default='default',
-                    choices=['default', 'hlle', 'hllc', 'hlld', 'roe', 'llf'],
+                    choices=['default', 'hlle', 'hllc', 'lhllc', 'hlld', 'lhlld', 'roe', 'llf'], # noqa
                     help='select Riemann solver')
 
 # --nghost=[value] argument
@@ -312,8 +312,16 @@ if args['flux'] == 'hllc' and args['eos'] == 'isothermal':
     raise SystemExit('### CONFIGURE ERROR: HLLC flux cannot be used with isothermal EOS')
 if args['flux'] == 'hllc' and args['b']:
     raise SystemExit('### CONFIGURE ERROR: HLLC flux cannot be used with MHD')
+if args['flux'] == 'lhllc' and args['eos'] == 'isothermal':
+    raise SystemExit('### CONFIGURE ERROR: LHLLC flux cannot be used with isothermal EOS') # noqa
+if args['flux'] == 'lhllc' and args['b']:
+    raise SystemExit('### CONFIGURE ERROR: LHLLC flux cannot be used with MHD')
 if args['flux'] == 'hlld' and not args['b']:
     raise SystemExit('### CONFIGURE ERROR: HLLD flux can only be used with MHD')
+if args['flux'] == 'lhlld' and args['eos'] == 'isothermal':
+    raise SystemExit('### CONFIGURE ERROR: LHLLD flux cannot be used with isothermal EOS') # noqa
+if args['flux'] == 'lhlld' and not args['b']:
+    raise SystemExit('### CONFIGURE ERROR: LHLLD flux can only be used with MHD')
 
 # Check relativity
 if args['s'] and args['g']:

--- a/inputs/hydro/athinput.quirk
+++ b/inputs/hydro/athinput.quirk
@@ -1,0 +1,49 @@
+<comment>
+problem   = Quirk's Carbuncle test
+reference = Quirk, J. (1994)
+configure = --prob=quirk (-b)  (use --flux=lhllc/lhlld to suppress Carbuncle)
+
+<job>
+problem_id  = Quirk     # problem ID: basename of output filenames
+
+<output1>
+file_type   = vtk       # Tabular data dump
+variable    = prim      # variables to be output
+data_format = %12.5e    # Optional data format string
+dt          = 0.01      # time increment between outputs
+
+<time>
+cfl_number  = 0.4       # The Courant, Friedrichs, & Lewy (CFL) Number
+nlim        = -1        # cycle limit
+tlim        = 0.4       # time limit
+integrator  = vl2       # time integration algorithm
+xorder      = 2         # order of spatial reconstruction
+ncycle_out  = 1         # interval for stdout summary info
+
+<mesh>
+nx1         = 128       # Number of zones in X1-direction
+x1min       = 0.0       # minimum value of X1
+x1max       = 1.0       # maximum value of X1
+ix1_bc      = outflow   # Inner-X1 boundary condition flag
+ox1_bc      = outflow   # Outer-X1 boundary condition flag
+
+nx2         = 16        # Number of zones in X2-direction
+x2min       = -0.0625   # minimum value of X2
+x2max       =  0.0625   # maximum value of X2
+ix2_bc      = periodic  # Inner-X2 boundary condition flag
+ox2_bc      = periodic  # Outer-X2 boundary condition flag
+
+nx3         = 1         # Number of zones in X3-direction
+x3min       = -0.5      # minimum value of X3
+x3max       = 0.5       # maximum value of X3
+ix3_bc      = periodic  # Inner-X3 boundary condition flag
+ox3_bc      = periodic  # Outer-X3 boundary condition flag
+
+num_threads = 1         # maximum number of OMP threads
+
+<hydro>
+gamma           = 1.666666666666667   # gamma = C_p/C_v
+iso_sound_speed = 1.0   # isothermal sound speed
+
+<problem>
+bx              = 0.0   # x magnetic field (only for MHD)

--- a/src/hydro/calculate_velocity_differences.cpp
+++ b/src/hydro/calculate_velocity_differences.cpp
@@ -1,0 +1,90 @@
+//========================================================================================
+// Athena++ astrophysical MHD code
+// Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//! \file calculate_velocity_differences.cpp
+//! \brief Calculate velocity differences for Carbuncle cure, called from RiemannSolver
+
+// C headers
+
+// C++ headers
+#include <algorithm>   // min,max
+
+// Athena++ headers
+#include "../athena.hpp"
+#include "../athena_arrays.hpp"
+#include "../mesh/mesh.hpp"
+#include "hydro.hpp"
+
+void Hydro::CalculateVelocityDifferences(const int k, const int j,
+            const int il, const int iu, const int ivx,
+            AthenaArray<Real> &dvn, AthenaArray<Real> &dvt) {
+  if (pmy_block->pmy_mesh->f3) {
+    if (ivx == IVX) {
+      for (int i = il; i <= iu; ++i) {
+        dvn(i) = w(IVX, k, j, i) - w(IVX, k, j, i-1);
+        Real dvl = std::min(w(IVY, k, j+1, i-1) - w(IVY, k, j,   i-1),
+                            w(IVY, k, j,   i-1) - w(IVY, k, j-1, i-1));
+        Real dvr = std::min(w(IVY, k, j+1, i)   - w(IVY, k, j,   i),
+                            w(IVY, k, j,   i)   - w(IVY, k, j-1, i));
+        Real dwl = std::min(w(IVZ, k+1, j, i-1) - w(IVZ, k,   j, i-1),
+                            w(IVZ, k,   j, i-1) - w(IVZ, k-1, j, i-1));
+        Real dwr = std::min(w(IVZ, k+1, j, i)   - w(IVZ, k,   j, i),
+                            w(IVZ, k,   j, i)   - w(IVZ, k-1, j, i));
+        dvt(i) = std::min(std::min(dvl, dvr), std::min(dwl, dwr));
+      }
+    } else if (ivx == IVY) {
+      // note: technically, we can reuse dvr/dwr as dvl/dwl in the next j-loop.
+      for (int i = il; i <= iu; ++i) {
+        dvn(i) = w(IVY, k, j, i) - w(IVY, k, j-1, i);
+        Real dvl = std::min(w(IVZ, k+1, j-1, i) - w(IVZ, k,   j-1, i),
+                            w(IVZ, k,   j-1, i) - w(IVZ, k-1, j-1, i));
+        Real dvr = std::min(w(IVZ, k+1, j,   i) - w(IVZ, k,   j,   i),
+                            w(IVZ, k,   j,   i) - w(IVZ, k-1, j,   i));
+        Real dwl = std::min(w(IVX, k, j-1, i+1) - w(IVX, k, j-1, i),
+                            w(IVX, k, j-1, i)   - w(IVX, k, j-1, i-1));
+        Real dwr = std::min(w(IVX, k, j,   i+1) - w(IVX, k, j,   i),
+                            w(IVX, k, j,   i)   - w(IVX, k, j,   i-1));
+        dvt(i) = std::min(std::min(dvl, dvr), std::min(dwl, dwr));
+      }
+    } else { // (ivx == IVZ)
+      for (int i = il; i <= iu; ++i) {
+        dvn(i) = w(IVZ, k, j, i) - w(IVZ, k-1, j, i);
+        Real dvl = std::min(w(IVX, k-1, j, i+1) - w(IVX, k-1, j, i),
+                            w(IVX, k-1, j, i)   - w(IVX, k-1, j, i-1));
+        Real dvr = std::min(w(IVX, k,   j, i+1) - w(IVX, k,   j, i),
+                            w(IVX, k,   j, i)   - w(IVX, k,   j, i-1));
+        Real dwl = std::min(w(IVY, k-1, j+1, i) - w(IVY, k-1, j,   i),
+                            w(IVY, k-1, j,   i) - w(IVY, k-1, j-1, i));
+        Real dwr = std::min(w(IVY, k,   j+1, i) - w(IVY, k,   j,   i),
+                            w(IVY, k,   j,   i) - w(IVY, k,   j-1, i));
+        dvt(i) = std::min(std::min(dvl, dvr), std::min(dwl, dwr));
+      }
+    }
+  } else if (pmy_block->pmy_mesh->f2) {
+    if (ivx == IVX) {
+      for (int i = il; i <= iu; ++i) {
+        dvn(i) = w(IVX, k, j, i) - w(IVX, k, j, i-1);
+        Real dvl = std::min(w(IVY, k, j+1, i-1) - w(IVY, k, j,   i-1),
+                            w(IVY, k, j,   i-1) - w(IVY, k, j-1, i-1));
+        Real dvr = std::min(w(IVY, k, j+1, i)   - w(IVY, k, j,   i),
+                            w(IVY, k, j,   i)   - w(IVY, k, j-1, i));
+        dvt(i) = std::min(dvl, dvr);
+      }
+    } else { //ivx == IVY
+      for (int i = il; i <= iu; ++i) {
+        dvn(i) = w(IVY, k, j, i) - w(IVY, k, j-1, i);\
+        Real dvl = std::min(w(IVX, k, j-1, i+1) - w(IVX, k, j-1, i),
+                            w(IVX, k, j-1, i)   - w(IVX, k, j-1, i-1));
+        Real dvr = std::min(w(IVX, k, j,   i+1) - w(IVX, k, j,   i),
+                            w(IVX, k, j,   i)   - w(IVX, k, j,   i-1));
+        dvt(i) = std::min(dvl, dvr);
+      }
+    }
+  } else {
+    for (int i = il; i <= iu; ++i)
+      dvn(i) = w(IVX, k, j, i) - w(IVX, k, j, i-1);
+  }
+  return;
+}

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -33,6 +33,7 @@ Hydro::Hydro(MeshBlock *pmb, ParameterInput *pin) :
     w(NHYDRO, pmb->ncells3, pmb->ncells2, pmb->ncells1),
     u1(NHYDRO, pmb->ncells3, pmb->ncells2, pmb->ncells1),
     w1(NHYDRO, pmb->ncells3, pmb->ncells2, pmb->ncells1),
+    dvn(pmb->ncells1), dvt(pmb->ncells1),
     // C++11: nested brace-init-list in Hydro member initializer list = aggregate init. of
     // flux[3] array --> direct list init. of each array element --> direct init. via
     // constructor overload resolution of non-aggregate class type AthenaArray<Real>

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -44,6 +44,8 @@ class Hydro {
   AthenaArray<Real> u1, w1;      // time-integrator memory register #2
   AthenaArray<Real> u2;          // time-integrator memory register #3
   AthenaArray<Real> u0, fl_div; // rkl2 STS memory registers;
+  // for the HL3D2 solver
+  AthenaArray<Real> dvn, dvt;
   // (no more than MAX_NREGISTER allowed)
 
   AthenaArray<Real> flux[3];  // face-averaged flux vector
@@ -84,6 +86,8 @@ class Hydro {
       AthenaArray<Real> &ey, AthenaArray<Real> &ez,
       AthenaArray<Real> &wct, const AthenaArray<Real> &dxw);
 #endif
+  void CalculateVelocityDifferences(const int k, const int j, const int il, const int iu,
+    const int ivx, AthenaArray<Real> &dvn, AthenaArray<Real> &dvt);
 
  private:
   AthenaArray<Real> dt1_, dt2_, dt3_;  // scratch arrays used in NewTimeStep

--- a/src/hydro/rsolvers/hydro/lhllc.cpp
+++ b/src/hydro/rsolvers/hydro/lhllc.cpp
@@ -1,0 +1,182 @@
+//========================================================================================
+// Athena++ astrophysical MHD code
+// Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//! \file lhllc.cpp
+//! \brief Low-dissipation HLLC (LHLLC) Riemann solver for adiabatic hydrodynamics.
+//!        (Minoshima et al. 2021)
+
+// C headers
+
+// C++ headers
+#include <algorithm>  // max(), min()
+#include <cmath>      // sqrt()
+
+// Athena++ headers
+#include "../../../athena.hpp"
+#include "../../../athena_arrays.hpp"
+#include "../../../eos/eos.hpp"
+#include "../../hydro.hpp"
+
+//----------------------------------------------------------------------------------------
+//! \fn void Hydro::RiemannSolver
+//! \brief The Low-dissipation HLLC (LHLLC) Riemann solver for adiabatic hydrodynamics
+
+void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
+                          const int ivx, AthenaArray<Real> &wl,
+                          AthenaArray<Real> &wr, AthenaArray<Real> &flx,
+                          const AthenaArray<Real> &dxw) {
+  int ivy = IVX + ((ivx-IVX)+1)%3;
+  int ivz = IVX + ((ivx-IVX)+2)%3;
+  Real wli[(NHYDRO)],wri[(NHYDRO)];
+  Real flxi[(NHYDRO)],fl[(NHYDRO)],fr[(NHYDRO)];
+  Real gamma;
+  if (GENERAL_EOS) {
+    gamma = std::nan("");
+  } else {
+    gamma = pmy_block->peos->GetGamma();
+  }
+  Real gm1 = gamma - 1.0;
+  Real igm1 = 1.0/gm1;
+
+  CalculateVelocityDifferences(k, j, il, iu, ivx, dvn, dvt);
+
+#pragma distribute_point
+#pragma omp simd private(wli,wri,flxi,fl,fr)
+  for (int i=il; i<=iu; ++i) {
+    //--- Step 1.  Load L/R states into local variables
+    wli[IDN]=wl(IDN,i);
+    wli[IVX]=wl(ivx,i);
+    wli[IVY]=wl(ivy,i);
+    wli[IVZ]=wl(ivz,i);
+    wli[IPR]=wl(IPR,i);
+
+    wri[IDN]=wr(IDN,i);
+    wri[IVX]=wr(ivx,i);
+    wri[IVY]=wr(ivy,i);
+    wri[IVZ]=wr(ivz,i);
+    wri[IPR]=wr(IPR,i);
+
+    //--- Step 2.  Compute middle state estimates with PVRS (Toro 10.5.2)
+
+    Real al, ar, el, er;
+    Real cl = pmy_block->peos->SoundSpeed(wli);
+    Real cr = pmy_block->peos->SoundSpeed(wri);
+    Real vsql = SQR(wli[IVX]) + SQR(wli[IVY]) + SQR(wli[IVZ]);
+    Real vsqr = SQR(wri[IVX]) + SQR(wri[IVY]) + SQR(wri[IVZ]);
+    if (GENERAL_EOS) {
+      el = pmy_block->peos->EgasFromRhoP(wli[IDN], wli[IPR]) + 0.5*wli[IDN]*vsql;
+      er = pmy_block->peos->EgasFromRhoP(wri[IDN], wri[IPR]) + 0.5*wri[IDN]*vsqr;
+    } else {
+      el = wli[IPR]*igm1 + 0.5*wli[IDN]*vsql;
+      er = wri[IPR]*igm1 + 0.5*wri[IDN]*vsqr;
+    }
+    Real rhoa = .5 * (wli[IDN] + wri[IDN]); // average density
+    Real ca = .5 * (cl + cr); // average sound speed
+    Real pmid = .5 * (wli[IPR] + wri[IPR] + (wli[IVX]-wri[IVX]) * rhoa * ca);
+    Real umid = .5 * (wli[IVX] + wri[IVX] + (wli[IPR]-wri[IPR]) / (rhoa * ca));
+    Real rhol = wli[IDN] + (wli[IVX] - umid) * rhoa / ca; // mid-left density
+    Real rhor = wri[IDN] + (umid - wri[IVX]) * rhoa / ca; // mid-right density
+
+    //--- Step 3.  Compute sound speed in L,R
+
+    Real ql, qr;
+    if (GENERAL_EOS) {
+      Real gl = pmy_block->peos->AsqFromRhoP(rhol, pmid) * rhol / pmid;
+      Real gr = pmy_block->peos->AsqFromRhoP(rhor, pmid) * rhor / pmid;
+      ql = (pmid <= wli[IPR]) ? 1.0 :
+           std::sqrt(1.0 + (gl + 1) / (2 * gl) * (pmid / wli[IPR]-1.0));
+      qr = (pmid <= wri[IPR]) ? 1.0 :
+           std::sqrt(1.0 + (gr + 1) / (2 * gr) * (pmid / wri[IPR]-1.0));
+    } else {
+      ql = (pmid <= wli[IPR]) ? 1.0 :
+           std::sqrt(1.0 + (gamma + 1) / (2 * gamma) * (pmid / wli[IPR]-1.0));
+      qr = (pmid <= wri[IPR]) ? 1.0 :
+           std::sqrt(1.0 + (gamma + 1) / (2 * gamma) * (pmid / wri[IPR]-1.0));
+    }
+
+    //--- Step 4.  Compute the max/min wave speeds based on L/R
+
+    al = wli[IVX] - cl*ql;
+    ar = wri[IVX] + cr*qr;
+
+    Real bp = ar > 0.0 ? ar : (TINY_NUMBER);
+    Real bm = al < 0.0 ? al : -(TINY_NUMBER);
+
+    //--- Step 5. Compute the contact wave speed and pressure
+
+    Real vxl = al - wli[IVX];
+    Real vxr = ar - wri[IVX];
+
+    Real ml = wli[IDN]*vxl;
+    Real mr = wri[IDN]*vxr;
+
+    // shock detector
+    // Real cmax = std::max(cl*ql, cr*qr);
+    Real cmax = std::max(cl, cr);
+    Real th1 = std::min(1.0, (cmax-std::min(dvn(i),0.0)) / (cmax-std::min(dvt(i),0.0)));
+    Real th = th1 * th1 * th1 * th1; // this 4th power is empirical (see Minoshima+)
+
+    // Determine the contact wave speed...
+    Real am = (mr*wri[IVX] - ml*wli[IVX] - th*(wri[IPR]-wli[IPR])) / (mr - ml);
+
+    // ...and the pressure at the contact surface
+    Real chi = std::min(1.0, std::sqrt(std::max(vsql, vsqr)) / cmax);
+    Real phi = chi * (2.0 - chi);
+
+    Real cp = (mr*wli[IPR] - ml*wri[IPR] + phi*mr*ml*(wri[IVX]-wli[IVX])) / (mr - ml);
+    cp = cp > 0.0 ? cp : 0.0;
+
+    // No loop-carried dependencies anywhere in this loop
+    //    #pragma distribute_point
+    //--- Step 6. Compute L/R fluxes along the line bm, bp
+
+    Real uxl = wli[IVX] - bm;
+    Real uxr = wri[IVX] - bp;
+
+    fl[IDN] = wli[IDN]*uxl;
+    fr[IDN] = wri[IDN]*uxr;
+
+    fl[IVX] = wli[IDN]*wli[IVX]*uxl + wli[IPR];
+    fr[IVX] = wri[IDN]*wri[IVX]*uxr + wri[IPR];
+
+    fl[IVY] = wli[IDN]*wli[IVY]*uxl;
+    fr[IVY] = wri[IDN]*wri[IVY]*uxr;
+
+    fl[IVZ] = wli[IDN]*wli[IVZ]*uxl;
+    fr[IVZ] = wri[IDN]*wri[IVZ]*uxr;
+
+    fl[IEN] = el*uxl + wli[IPR]*wli[IVX];
+    fr[IEN] = er*uxr + wri[IPR]*wri[IVX];
+
+    //--- Step 8. Compute flux weights or scales
+
+    Real sl,sr,sm;
+    if (am >= 0.0) {
+      sl =  am/(am - bm);
+      sr = 0.0;
+      sm = -bm/(am - bm);
+    } else {
+      sl =  0.0;
+      sr = -am/(bp - am);
+      sm =  bp/(bp - am);
+    }
+
+    //--- Step 9. Compute the HLLC flux at interface, including weighted contribution
+    // of the flux along the contact
+
+    flxi[IDN] = sl*fl[IDN] + sr*fr[IDN];
+    flxi[IVX] = sl*fl[IVX] + sr*fr[IVX] + sm*cp;
+    flxi[IVY] = sl*fl[IVY] + sr*fr[IVY];
+    flxi[IVZ] = sl*fl[IVZ] + sr*fr[IVZ];
+    flxi[IEN] = sl*fl[IEN] + sr*fr[IEN] + sm*cp*am;
+
+    flx(IDN,k,j,i) = flxi[IDN];
+    flx(ivx,k,j,i) = flxi[IVX];
+    flx(ivy,k,j,i) = flxi[IVY];
+    flx(ivz,k,j,i) = flxi[IVZ];
+    flx(IEN,k,j,i) = flxi[IEN];
+  }
+  return;
+}

--- a/src/hydro/rsolvers/mhd/hlld_iso.cpp
+++ b/src/hydro/rsolvers/mhd/hlld_iso.cpp
@@ -31,6 +31,8 @@ struct Cons1D {
 #define SMALL_NUMBER 1.0e-8
 
 //----------------------------------------------------------------------------------------
+//! \fn void Hydro::RiemannSolver
+//! \brief The HLLD Riemann solver for isothermal MHD
 
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx, const AthenaArray<Real> &bx,

--- a/src/hydro/rsolvers/mhd/hlle_mhd.cpp
+++ b/src/hydro/rsolvers/mhd/hlle_mhd.cpp
@@ -19,6 +19,8 @@
 #include "../../hydro.hpp"
 
 //----------------------------------------------------------------------------------------
+//! \fn void Hydro::RiemannSolver
+//! \brief The HLLE Riemann solver for adiabatic magnetohydrodynamics
 
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx, const AthenaArray<Real> &bx,

--- a/src/hydro/rsolvers/mhd/lhlld.cpp
+++ b/src/hydro/rsolvers/mhd/lhlld.cpp
@@ -183,8 +183,8 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     //--- Step 5.  Compute intermediate states
     // eqn (23) explicitly becomes eq (41) of Miyoshi & Kusano
     // TODO(felker): place an assertion that ptstl==ptstr
-    Real clsq = ((pbl + kel) + sqrt(SQR(pbl + kel) - 2.0*kel*bxsq)) / ul.d;
-    Real crsq = ((pbr + ker) + sqrt(SQR(pbr + ker) - 2.0*ker*bxsq)) / ur.d;
+    Real clsq = ((pbl + kel) + std::sqrt(SQR(pbl + kel) - 2.0*kel*bxsq)) / ul.d;
+    Real crsq = ((pbr + ker) + std::sqrt(SQR(pbr + ker) - 2.0*ker*bxsq)) / ur.d;
     Real chi = std::min(1.0, std::sqrt(std::max(clsq, crsq)) / cfmax);
     Real phi = chi * (2.0 - chi);
     Real ptst = (sdrd*ptl - sdld*ptr + phi*sdrd*sdld*(wri[IVX]-wli[IVX]))/(sdrd - sdld);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -518,8 +518,15 @@ int main(int argc, char *argv[]) {
   if (Globals::my_rank == 0 && wtlim > 0)
     SignalHandler::CancelWallTimeAlarm();
 
+
   //--- Step 9. --------------------------------------------------------------------------
-  // Make the final outputs
+  // Output the final cycle diagnostics and make the final outputs
+
+  if (Globals::my_rank == 0)
+    pmesh->OutputCycleDiagnostics();
+
+  pmesh->UserWorkAfterLoop(pinput);
+
 #ifdef ENABLE_EXCEPTIONS
   try {
 #endif
@@ -543,12 +550,10 @@ int main(int argc, char *argv[]) {
   }
 #endif // ENABLE_EXCEPTIONS
 
-  pmesh->UserWorkAfterLoop(pinput);
-
   //--- Step 10. -------------------------------------------------------------------------
   // Print diagnostic messages related to the end of the simulation
+
   if (Globals::my_rank == 0) {
-    pmesh->OutputCycleDiagnostics();
     if (SignalHandler::GetSignalFlag(SIGTERM) != 0) {
       std::cout << std::endl << "Terminating on Terminate signal" << std::endl;
     } else if (SignalHandler::GetSignalFlag(SIGINT) != 0) {

--- a/src/pgen/quirk.cpp
+++ b/src/pgen/quirk.cpp
@@ -75,7 +75,7 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
   Real igm1 = 1.0 / (gm - 1.0);
 
   Real xshock = 0.4;
-  for (ishock = 0; pcoord->x1v(ishock) < xshock; ++ishock);
+  for (ishock = 0; pcoord->x1v(ishock) < xshock; ++ishock) {}
   ishock--;
 
   Real dl =  3.692;
@@ -110,7 +110,7 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
           phydro->u(IM2,k,j,i) = 0.0;
           phydro->u(IM3,k,j,i) = 0.0;
           phydro->u(IEN,k,j,i) = pd*igm1 + 0.5*dd*SQR(ud);
-        } 
+        }
       }
     }
   }

--- a/src/pgen/quirk.cpp
+++ b/src/pgen/quirk.cpp
@@ -1,0 +1,145 @@
+//========================================================================================
+// Athena++ astrophysical MHD code
+// Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//! \file quirk.cpp
+//! \brief Problem generator for the Quirk test (Quirk 1994)
+//!
+//! Problem generator for a shock tube with odd-even perturbation.
+//! Physically such a perturbation should not grow but with high resolution schemes
+//! such as Roe/HLLC/HLLD often suffer from unphysical amplification of the perturbation
+//! at strong shocks. This problem is well known as the Carbuncle phenomenon.
+//! To suppress it, use the new LHLLC/LHLLD solvers (Minoshima et al. 2021).
+//========================================================================================
+
+// C headers
+
+// C++ headers
+#include <cmath>      // sqrt()
+#include <cstdio>     // fopen(), freopen(), fprintf(), fclose()
+#include <iostream>   // endl
+#include <sstream>    // stringstream
+#include <stdexcept>  // runtime_error
+#include <string>
+
+// Athena++ headers
+#include "../athena.hpp"
+#include "../athena_arrays.hpp"
+#include "../coordinates/coordinates.hpp"
+#include "../eos/eos.hpp"
+#include "../field/field.hpp"
+#include "../hydro/hydro.hpp"
+#include "../mesh/mesh.hpp"
+#include "../parameter_input.hpp"
+#include "../scalars/scalars.hpp"
+
+namespace {
+int ishock;
+Real gm;
+}
+
+//========================================================================================
+//! \fn void Mesh::UserWorkAfterLoop(ParameterInput *pin)
+//! \brief Calculate the difference of the post-shock entropy in odd and even rows
+//========================================================================================
+
+void Mesh::UserWorkAfterLoop(ParameterInput *pin) {
+  if (Globals::my_rank == 0) {
+    MeshBlock *pmb = my_blocks(0);
+    AthenaArray<Real> &w = pmb->phydro->w;
+    Real dodd  = w(IDN, pmb->ks, pmb->js+1, ishock);
+    Real podd  = w(IPR, pmb->ks, pmb->js+1, ishock);
+    Real deven = w(IDN, pmb->ks, pmb->js,   ishock);
+    Real peven = w(IPR, pmb->ks, pmb->js,   ishock);
+    Real sodd  = podd  / std::pow(dodd,  gm);
+    Real seven = peven / std::pow(deven, gm);
+    Real deltas = std::abs(sodd - seven);
+    if (deltas > 0.05)
+      std::cout << "The scheme suffers from the Carbuncle phenomenon : delta s = "
+                << deltas << std::endl;
+    else
+      std::cout << "The scheme looks stable against the Carbuncle phenomenon : delta s = "
+                << deltas << std::endl;
+  }
+  return;
+}
+
+//========================================================================================
+//! \fn void MeshBlock::ProblemGenerator(ParameterInput *pin)
+//! \brief Problem Generator for the shock tube tests
+//========================================================================================
+
+void MeshBlock::ProblemGenerator(ParameterInput *pin) {
+  gm = peos->GetGamma();
+  Real igm1 = 1.0 / (gm - 1.0);
+
+  Real xshock = 0.4;
+  for (ishock = 0; pcoord->x1v(ishock) < xshock; ++ishock);
+  ishock--;
+
+  Real dl =  3.692;
+  Real ul = -0.625;
+  Real pl =  26.85;
+  Real dr =  1.0;
+  Real ur = -5.0;
+  Real pr =  0.6;
+  Real dd = dl - 0.135;
+  Real ud = ul + 0.219;
+  Real pd = pl - 1.31;
+
+  for (int k=ks; k<=ke; ++k) {
+    for (int j=js; j<=je; ++j) {
+      for (int i=is; i<=ie; ++i) {
+        if (i <= ishock) {
+          phydro->u(IDN,k,j,i) = dl;
+          phydro->u(IM1,k,j,i) = dl*ul;
+          phydro->u(IM2,k,j,i) = 0.0;
+          phydro->u(IM3,k,j,i) = 0.0;
+          phydro->u(IEN,k,j,i) = pl*igm1 + 0.5*dl*SQR(ul);
+        } else {
+          phydro->u(IDN,k,j,i) = dr;
+          phydro->u(IM1,k,j,i) = dr*ur;
+          phydro->u(IM2,k,j,i) = 0.0;
+          phydro->u(IM3,k,j,i) = 0.0;
+          phydro->u(IEN,k,j,i) = pr*igm1 + 0.5*dr*SQR(ur);
+        }
+        if (i == ishock && j % 2 == 0) {
+          phydro->u(IDN,k,j,i) = dd;
+          phydro->u(IM1,k,j,i) = dd*ud;
+          phydro->u(IM2,k,j,i) = 0.0;
+          phydro->u(IM3,k,j,i) = 0.0;
+          phydro->u(IEN,k,j,i) = pd*igm1 + 0.5*dd*SQR(ud);
+        } 
+      }
+    }
+  }
+  if (MAGNETIC_FIELDS_ENABLED) {
+    Real bx = pin->GetReal("problem", "bx");
+    for (int k=ks; k<=ke; ++k) {
+      for (int j=js; j<=je; ++j) {
+        for (int i=is; i<=ie+1; ++i)
+          pfield->b.x1f(k,j,i) = bx;
+      }
+    }
+    for (int k=ks; k<=ke; ++k) {
+      for (int j=js; j<=je+1; ++j) {
+        for (int i=is; i<=ie; ++i)
+          pfield->b.x2f(k,j,i) = 0.0;
+      }
+    }
+    for (int k=ks; k<=ke+1; ++k) {
+      for (int j=js; j<=je; ++j) {
+        for (int i=is; i<=ie; ++i)
+          pfield->b.x3f(k,j,i) = 0.0;
+      }
+    }
+    for (int k=ks; k<=ke; ++k) {
+      for (int j=js; j<=je; ++j) {
+        for (int i=is; i<=ie; ++i)
+          phydro->u(IEN,k,j,i) += 0.5*SQR(bx);
+      }
+    }
+  }
+  return;
+}


### PR DESCRIPTION
These are newly proposed low-dissipation and Carbuncle-free extension of the HLLC (for hydro) and HLLD (for MHD) approximate Riemann solvers. The additional cost is only a few %.

Reference: Minoshima et al. 2021, arXiv:2108:04991 (JCoPh accepted)

## Prerequisite checklist
- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [x] I have added tests to cover my changes. (quirk.cpp)
- [ ] All new and existing tests passed.

## Description
Besides the new LHLLC/LHLLD solvers, I moved `OutputCycleDiagnostics` to be called before `UserWorkAfterLoop` in the finalizing process in main.cpp.


## Testing and validation
quirk.cpp is the Quirk test (Quirk 1994), in which a strong shock with odd-even perturbation propagates aligned to the grid. This odd-even perturbation should not grow physically, but standard high-resolution schemes such as HLLC/HLLD/Roe fail. The new LHLLC/LHLLD schemes are free from this issue. This test code checks the growth of the perturbation.
...
