### PR TITLE
Fix of bug in the strat pgen for a restart run

### DIFF
--- a/src/bvals/bvals_base.cpp
+++ b/src/bvals/bvals_base.cpp
@@ -716,7 +716,7 @@ void BoundaryBase::SearchAndSetNeighbors(MeshBlockTree &tree, int *ranklist,
           bool shear = false;
           if ((nlevel == loc.level) &&
               ((n == -1 && block_bcs[BoundaryFace::inner_x1]
-                                 == BoundaryFlag::shear_periodic) &&
+                                 == BoundaryFlag::shear_periodic) ||
                (n ==  1 && block_bcs[BoundaryFace::outer_x1]
                                  == BoundaryFlag::shear_periodic))) {
             shear = true; // neighbor is shearing periodic

--- a/src/pgen/strat.cpp
+++ b/src/pgen/strat.cpp
@@ -76,6 +76,10 @@ Real Omega_0, qshear;
 
 //====================================================================================
 void Mesh::InitUserMeshData(ParameterInput *pin) {
+  // shearing sheet parameter
+  qshear = pin->GetReal("orbital_advection","qshear");
+  Omega_0 = pin->GetReal("orbital_advection","Omega0");
+
   AllocateUserHistoryOutput(2);
   EnrollUserHistoryOutput(0, HistoryBxBy, "-BxBy");
   EnrollUserHistoryOutput(1, HistorydVxVy, "dVxVy");
@@ -113,10 +117,6 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
   Real beta, amp, pres;
   Real iso_cs=1.0;
   Real B0 = 0.0;
-
-  // shearing sheet parameter
-  Omega_0 = porb->Omega0;
-  qshear  = porb->qshear;
 
   Real SumRvx=0.0, SumRvy=0.0, SumRvz=0.0;
   // TODO(felker): tons of unused variables in this file: xmin, xmax, rbx, rby, Ly, ky,...


### PR DESCRIPTION
The `strat` problem is working only in the shearing box. It means that both `qshear` and `Omega_0` should be non-zero. However, those parameters are initialized in the ProblemGenerator function, which is not called in a restart run. This PR makes those parameters initialized in the InitUserMeshData function instead. 
P.S. I don't know why `bvals_base.cpp` is also updated. This fix was done at #379.