### PR TITLE
Fixed typo in GR Bondi problem generator

### DIFF
--- a/src/pgen/gr_bondi.cpp
+++ b/src/pgen/gr_bondi.cpp
@@ -103,9 +103,9 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
     ku += NGHOST;
   }
 
-  // Get mass of black hole
+  // Get mass and spin of black hole
   m = pcoord->GetMass();
-  m = pcoord->GetSpin();
+  a = pcoord->GetSpin();
 
   // Get ratio of specific heats
   Real gamma_adi = peos->GetGamma();


### PR DESCRIPTION
## Prerequisite checklist

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] All new and existing tests passed.

## Description

There was a small typo that broke the Bondi accretion problem by overwriting the black hole mass with the spin.