### PR TITLE
Add hydro and MHD regression tests for quirk.cpp

### DIFF
--- a/src/pgen/quirk.cpp
+++ b/src/pgen/quirk.cpp
@@ -5,6 +5,7 @@
 //========================================================================================
 //! \file quirk.cpp
 //! \brief Problem generator for the Quirk test (Quirk 1994)
+//! Variant is from Hanawa et al (2008), section 3.2. First of five shock tubes
 //!
 //! Problem generator for a shock tube with odd-even perturbation.
 //! Physically such a perturbation should not grow but with high resolution schemes

--- a/src/pgen/quirk.cpp
+++ b/src/pgen/quirk.cpp
@@ -61,6 +61,33 @@ void Mesh::UserWorkAfterLoop(ParameterInput *pin) {
     else
       std::cout << "The scheme looks stable against the Carbuncle phenomenon : delta s = "
                 << deltas << std::endl;
+    // open output file and write out errors
+    std::string fname;
+    fname.assign("carbuncle-diff.dat");
+    std::stringstream msg;
+    FILE *pfile;
+
+    // The file exists -- reopen the file in append mode
+    if ((pfile = std::fopen(fname.c_str(), "r")) != nullptr) {
+      if ((pfile = std::freopen(fname.c_str(), "a", pfile)) == nullptr) {
+        msg << "### FATAL ERROR in function Mesh::UserWorkAfterLoop"
+            << std::endl << "Error output file could not be opened" <<std::endl;
+        ATHENA_ERROR(msg);
+      }
+
+      // The file does not exist -- open the file in write mode and add headers
+    } else {
+      if ((pfile = std::fopen(fname.c_str(), "w")) == nullptr) {
+        msg << "### FATAL ERROR in function Mesh::UserWorkAfterLoop"
+            << std::endl << "Error output file could not be opened" <<std::endl;
+        ATHENA_ERROR(msg);
+      }
+      std::fprintf(pfile, "# |s_odd - s_even|\n");
+    }
+
+    // write difference
+    std::fprintf(pfile, "%e\n", deltas);
+    std::fclose(pfile);
   }
   return;
 }

--- a/tst/regression/scripts/tests/hydro/hydro_carbuncle.py
+++ b/tst/regression/scripts/tests/hydro/hydro_carbuncle.py
@@ -1,0 +1,68 @@
+# Regression test based on detection of carbuncle phenomenon (Odd-Even decoupling)
+# Hydro Riemann solvers
+#
+
+# Modules
+import logging
+import scripts.utils.athena as athena
+import sys
+import os
+from shutil import move
+sys.path.insert(0, '../../vis/python')
+import athena_read                             # noqa
+athena_read.check_nan_flag = True
+logger = logging.getLogger('athena' + __name__[7:])  # set logger name based on module
+_fluxes = ['hlle', 'roe', 'llf', 'lhllc', 'hllc']
+_exec = os.path.join('bin', 'athena')
+
+
+# Prepare Athena++
+def prepare(**kwargs):
+    logger.debug('Running test ' + __name__)
+    global _fluxes
+    for i in athena.global_config_args:
+        tmp = i.split('=')
+        if tmp[0] == '--flux' and len(tmp) == 2:
+            _fluxes = [tmp[1]]
+    for flux in _fluxes:
+        athena.configure(
+            prob='quirk',
+            coord='cartesian',
+            flux=flux, **kwargs)
+        # to save time, reuse compiled .o files for all executables created in this test:
+        athena.make(clean_first=False)
+        move(_exec, _exec + '_' + flux)
+        os.system('cp -r obj obj_' + flux)
+    os.system('rm -rf obj')
+
+
+# Run Athena++
+def run(**kwargs):
+    for flux in _fluxes:
+        move(_exec + '_' + flux, _exec)
+        os.system('mv obj_' + flux + ' obj')
+        athena.run('hydro/athinput.quirk',
+                   arguments=[])
+    return 'skip_lcov'
+
+
+# Analyze outputs
+def analyze():
+    # read data from error file
+    filename = 'bin/carbuncle-diff.dat'
+    all_data = athena_read.error_dat(filename)
+    all_data = all_data.reshape(len(_fluxes))  # , -1, all_data.shape[-1])
+    analyze_status = True
+
+    max_ratio = 0.05
+
+    for i, flux in enumerate(_fluxes):
+        data = all_data[i]
+        flux_str = 'With flux "{0:}": '.format(flux)
+
+        if data > max_ratio and flux not in ['hllc', 'roe']:
+            logger.warning(flux_str + "difference in post-shock P/rho^gamma "
+                           + f"in even/odd rows is too large: {data}")
+            analyze_status = False
+
+    return analyze_status

--- a/tst/regression/scripts/tests/mhd/mhd_carbuncle.py
+++ b/tst/regression/scripts/tests/mhd/mhd_carbuncle.py
@@ -1,0 +1,68 @@
+# Regression test based on detection of carbuncle phenomenon (Odd-Even decoupling)
+# MHD Riemann solvers
+#
+
+# Modules
+import logging
+import scripts.utils.athena as athena
+import sys
+import os
+from shutil import move
+sys.path.insert(0, '../../vis/python')
+import athena_read                             # noqa
+athena_read.check_nan_flag = True
+logger = logging.getLogger('athena' + __name__[7:])  # set logger name based on module
+_fluxes = ['hlle', 'roe', 'llf', 'lhlld', 'hlld']
+_exec = os.path.join('bin', 'athena')
+
+
+# Prepare Athena++
+def prepare(**kwargs):
+    logger.debug('Running test ' + __name__)
+    global _fluxes
+    for i in athena.global_config_args:
+        tmp = i.split('=')
+        if tmp[0] == '--flux' and len(tmp) == 2:
+            _fluxes = [tmp[1]]
+    for flux in _fluxes:
+        athena.configure('b',
+            prob='quirk',
+            coord='cartesian',
+            flux=flux, **kwargs)
+        # to save time, reuse compiled .o files for all executables created in this test:
+        athena.make(clean_first=False)
+        move(_exec, _exec + '_' + flux)
+        os.system('cp -r obj obj_' + flux)
+    os.system('rm -rf obj')
+
+
+# Run Athena++
+def run(**kwargs):
+    for flux in _fluxes:
+        move(_exec + '_' + flux, _exec)
+        os.system('mv obj_' + flux + ' obj')
+        athena.run('hydro/athinput.quirk',
+                   arguments=[])
+    return 'skip_lcov'
+
+
+# Analyze outputs
+def analyze():
+    # read data from error file
+    filename = 'bin/carbuncle-diff.dat'
+    all_data = athena_read.error_dat(filename)
+    all_data = all_data.reshape(len(_fluxes))  # , -1, all_data.shape[-1])
+    analyze_status = True
+
+    max_ratio = 0.05
+
+    for i, flux in enumerate(_fluxes):
+        data = all_data[i]
+        flux_str = 'With flux "{0:}": '.format(flux)
+
+        if data > max_ratio and flux not in ['hlld', 'roe']:
+            logger.warning(flux_str + "difference in post-shock P/rho^gamma "
+                           + f"in even/odd rows is too large: {data}")
+            analyze_status = False
+
+    return analyze_status


### PR DESCRIPTION
Short addition to #380. Although after reviewing Quirk (1994), I am not sure this problem generator examines the Carbuncle instability (section 2.4 of that paper), but instead is a test of LHLLC and LHLLD's ability to avoid the Odd-Even decoupling (section 2.6)?

- [x] Add references for the particular shock tube setup L/R states to `quirk.cpp`