### PR TITLE
Update plotting slices and add polar projection view 

### DIFF
--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -216,7 +216,7 @@ def vtk(filename):
     # Read raw data
     with open(filename, 'rb') as data_file:
         raw_data = data_file.read()
-    raw_data_ascii = raw_data.decode('utf-8', 'replace')
+    raw_data_ascii = raw_data.decode('ascii', 'replace')
 
     # Skip header
     current_index = 0
@@ -365,10 +365,10 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
             data['x3v'] = f['x3v'][:]
 
             # Get metadata describing file layout
-            dataset_names = np.array([x.decode('utf-8', 'replace')
+            dataset_names = np.array([x.decode('ascii', 'replace')
                                       for x in f.attrs['DatasetNames'][:]])
             dataset_sizes = f.attrs['NumVariables'][:]
-            variable_names = np.array([x.decode('utf-8', 'replace')
+            variable_names = np.array([x.decode('ascii', 'replace')
                                        for x in f.attrs['VariableNames'][:]])
 
             # Store cell data
@@ -445,7 +445,7 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                 num_extended_dims += 1
 
         # Set volume function for preset coordinates if needed
-        coord = f.attrs['Coordinates'].decode('utf-8', 'replace')
+        coord = f.attrs['Coordinates'].decode('ascii', 'replace')
         if level < max_level and not subsample and not fast_restrict and vol_func is None:
             x1_rat = f.attrs['RootGridX1'][2]
             x2_rat = f.attrs['RootGridX2'][2]

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -216,7 +216,7 @@ def vtk(filename):
     # Read raw data
     with open(filename, 'rb') as data_file:
         raw_data = data_file.read()
-    raw_data_ascii = raw_data.decode('ascii', 'replace')
+    raw_data_ascii = raw_data.decode('utf-8', 'replace')
 
     # Skip header
     current_index = 0
@@ -365,10 +365,10 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
             data['x3v'] = f['x3v'][:]
 
             # Get metadata describing file layout
-            dataset_names = np.array([x.decode('ascii', 'replace')
+            dataset_names = np.array([x.decode('utf-8', 'replace')
                                       for x in f.attrs['DatasetNames'][:]])
             dataset_sizes = f.attrs['NumVariables'][:]
-            variable_names = np.array([x.decode('ascii', 'replace')
+            variable_names = np.array([x.decode('utf-8', 'replace')
                                        for x in f.attrs['VariableNames'][:]])
 
             # Store cell data
@@ -445,7 +445,7 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                 num_extended_dims += 1
 
         # Set volume function for preset coordinates if needed
-        coord = f.attrs['Coordinates'].decode('ascii', 'replace')
+        coord = f.attrs['Coordinates'].decode('utf-8', 'replace')
         if level < max_level and not subsample and not fast_restrict and vol_func is None:
             x1_rat = f.attrs['RootGridX1'][2]
             x2_rat = f.attrs['RootGridX2'][2]
@@ -556,7 +556,7 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                                       + ' fast restriction to work')
 
         # Create list of all quantities if none given
-        var_quantities = np.array([x.decode('ascii', 'replace')
+        var_quantities = np.array([x.decode('utf-8', 'replace')
                                    for x in f.attrs['VariableNames'][:]])
         coord_quantities = ('x1f', 'x2f', 'x3f', 'x1v', 'x2v', 'x3v')
         attr_quantities = [key for key in f.attrs]
@@ -582,11 +582,11 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
 
         # Get metadata describing file layout
         num_blocks = f.attrs['NumMeshBlocks']
-        dataset_names = np.array([x.decode('ascii', 'replace')
+        dataset_names = np.array([x.decode('utf-8', 'replace')
                                   for x in f.attrs['DatasetNames'][:]])
         dataset_sizes = f.attrs['NumVariables'][:]
         dataset_sizes_cumulative = np.cumsum(dataset_sizes)
-        variable_names = np.array([x.decode('ascii', 'replace')
+        variable_names = np.array([x.decode('utf-8', 'replace')
                                    for x in f.attrs['VariableNames'][:]])
         quantity_datasets = []
         quantity_indices = []

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -556,7 +556,7 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                                       + ' fast restriction to work')
 
         # Create list of all quantities if none given
-        var_quantities = np.array([x.decode('utf-8', 'replace')
+        var_quantities = np.array([x.decode('ascii', 'replace')
                                    for x in f.attrs['VariableNames'][:]])
         coord_quantities = ('x1f', 'x2f', 'x3f', 'x1v', 'x2v', 'x3v')
         attr_quantities = [key for key in f.attrs]
@@ -582,11 +582,11 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
 
         # Get metadata describing file layout
         num_blocks = f.attrs['NumMeshBlocks']
-        dataset_names = np.array([x.decode('utf-8', 'replace')
+        dataset_names = np.array([x.decode('ascii', 'replace')
                                   for x in f.attrs['DatasetNames'][:]])
         dataset_sizes = f.attrs['NumVariables'][:]
         dataset_sizes_cumulative = np.cumsum(dataset_sizes)
-        variable_names = np.array([x.decode('utf-8', 'replace')
+        variable_names = np.array([x.decode('ascii', 'replace')
                                    for x in f.attrs['VariableNames'][:]])
         quantity_datasets = []
         quantity_indices = []

--- a/vis/python/plot_slice.py
+++ b/vis/python/plot_slice.py
@@ -75,15 +75,16 @@ def main(**kwargs):
     # Read data
     if quantities[0] == 'Levels':
         data = athena_read.athdf(kwargs['data_file'], quantities=quantities[1:],
-                                 level=level, return_levels=True)
+                                 level=level, return_levels=True, num_ghost=kwargs['num_ghost'])
     else:
-        data = athena_read.athdf(kwargs['data_file'], quantities=quantities, level=level)
+        data = athena_read.athdf(kwargs['data_file'], quantities=quantities, level=level, num_ghost=kwargs['num_ghost'])
 
     # Check that coordinates work with user choices
-    coordinates = data['Coordinates'].decode('ascii', 'replace')
+    coordinates = data['Coordinates'].decode('utf-8', 'replace')
     ave_or_sum = kwargs['average'] or kwargs['sum'] or kwargs['stream_average']
     warn_projection = False
     warn_vector = False
+    projection_type = None
     if coordinates in ('cartesian', 'minkowski'):
         pass
     elif coordinates == 'cylindrical':
@@ -91,6 +92,9 @@ def main(**kwargs):
             warn_projection = True
         if kwargs['stream'] and kwargs['direction'] in (1, 3):
             warn_vector = True
+        if kwargs['direction'] == 3:
+            # pass
+            projection_type = "polar"
     elif coordinates in ('spherical_polar', 'schwarzschild', 'kerr-schild'):
         if ave_or_sum and kwargs['direction'] in (1, 2):
             warn_projection = True
@@ -106,7 +110,7 @@ def main(**kwargs):
     # Name coordinates
     if coordinates in ('cartesian', 'minkowski'):
         coord_labels = (r'$x$', r'$y$', r'$z$')
-    elif coordinates == 'cartesian':
+    elif coordinates == 'cylindrical':
         coord_labels = (r'$R$', r'$\phi$', r'$z$')
     elif coordinates in ('spherical_polar', 'schwarzschild', 'kerr-schild'):
         coord_labels = (r'$r$', r'$\theta$', r'$\phi$')
@@ -141,6 +145,12 @@ def main(**kwargs):
 
     # Create grids
     x_grid, y_grid = np.meshgrid(xf, yf)
+
+    #because single precision hdf5 writing
+    if ( (np.diff(xv).max() - np.diff(xv).min()) > np.finfo(float).eps ):
+        xv = np.linspace(xv.min(), xv.max(), xv.shape[0])
+    if ( (np.diff(yv).max() - np.diff(yv).min()) > np.finfo(float).eps ):
+        yv = np.linspace(yv.min(), yv.max(), yv.shape[0])
     x_stream, y_stream = np.meshgrid(xv, yv)
 
     # Extract scalar data
@@ -197,22 +207,30 @@ def main(**kwargs):
                 vals_x = vals_x[index, :, :]
                 vals_y = vals_y[index, :, :]
 
-    # Determine colormap norm
-    if kwargs['logc']:
-        norm = colors.LogNorm()
-    else:
-        norm = colors.Normalize()
-
     # Determine plot limits
     x_min = kwargs['x_min'] if kwargs['x_min'] is not None else xf[0]
     x_max = kwargs['x_max'] if kwargs['x_max'] is not None else xf[-1]
     y_min = kwargs['y_min'] if kwargs['y_min'] is not None else yf[0]
     y_max = kwargs['y_max'] if kwargs['y_max'] is not None else yf[-1]
+    v_min = kwargs['vmin'] if kwargs['vmin'] is not None else vals.min()
+    v_max = kwargs['vmax'] if kwargs['vmax'] is not None else vals.max()
+
+    # Determine colormap norm
+    if kwargs['logc']:
+        norm = colors.LogNorm(v_min, v_max)
+    else:
+        norm = colors.Normalize(v_min, v_max)
 
     # Make plot
-    plt.figure()
-    im = plt.pcolormesh(x_grid, y_grid, vals, cmap=kwargs['colormap'],
-                        vmin=kwargs['vmin'], vmax=kwargs['vmax'], norm=norm)
+    # should make the size editable?
+    fig = plt.figure(1, figsize=(12, 12))
+    ax = fig.add_subplot(1,1,1,projection=projection_type)
+    if projection_type == 'polar':
+        # switch axis for radial and azimuthal
+        im = ax.pcolormesh(y_grid, x_grid, vals, cmap=kwargs['colormap'], norm=norm)
+    else:
+        im = ax.pcolormesh(x_grid, y_grid, vals, cmap=kwargs['colormap'], norm=norm)
+
     if kwargs['stream'] is not None:
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -220,19 +238,32 @@ def main(**kwargs):
                 'invalid value encountered in greater_equal',
                 RuntimeWarning,
                 'numpy')
-            plt.streamplot(x_stream, y_stream, vals_x, vals_y,
-                           density=kwargs['stream_density'], color='k')
-    plt.xlim((x_min, x_max))
-    plt.ylim((y_min, y_max))
-    if not kwargs['fill']:
-        plt.gca().set_aspect('equal')
-    plt.xlabel(x_label)
-    plt.ylabel(y_label)
-    plt.colorbar(im)
-    if kwargs['output_file'] == 'show':
-        plt.show()
+        if projection_type == 'polar':
+            # switch axis for radial and azimuthal and Transpose
+            ax.streamplot(y_stream.T, x_stream.T, vals_y.T, vals_x.T,
+                        density=kwargs['stream_density'], color='k')
+        else:
+            ax.streamplot(x_stream, y_stream, vals_x, vals_y,
+                        density=kwargs['stream_density'], color='k')
+
+    if projection_type == 'polar':
+        ax.set_rmin(x_min)
+        ax.set_rmax(x_max)
     else:
-        plt.savefig(kwargs['output_file'], bbox_inches='tight')
+        ax.set_xlim((x_min, x_max))
+        ax.set_ylim((y_min, y_max))
+        ax.set_xlabel(x_label)
+        ax.set_ylabel(y_label)
+
+    fig.colorbar(im)
+
+    if not kwargs['fill']:
+        ax.set_aspect('equal')
+
+    if kwargs['output_file'] == 'show':
+        fig.show()
+    else:
+        fig.savefig(kwargs['output_file'], bbox_inches='tight')
 
 
 # Execute main function
@@ -317,5 +348,9 @@ if __name__ == '__main__':
                         type=float,
                         default=1.0,
                         help='density of stream lines')
+    parser.add_argument('--num_ghost',
+                        type=int,
+                        default=0,
+                        help=('Include number of ghost cells in each direction'))
     args = parser.parse_args()
     main(**vars(args))

--- a/vis/python/plot_slice.py
+++ b/vis/python/plot_slice.py
@@ -80,7 +80,7 @@ def main(**kwargs):
         data = athena_read.athdf(kwargs['data_file'], quantities=quantities, level=level, num_ghost=kwargs['num_ghost'])
 
     # Check that coordinates work with user choices
-    coordinates = data['Coordinates'].decode('utf-8', 'replace')
+    coordinates = data['Coordinates'].decode('ascii', 'replace')
     ave_or_sum = kwargs['average'] or kwargs['sum'] or kwargs['stream_average']
     warn_projection = False
     warn_vector = False
@@ -145,12 +145,6 @@ def main(**kwargs):
 
     # Create grids
     x_grid, y_grid = np.meshgrid(xf, yf)
-
-    #because single precision hdf5 writing
-    if ( (np.diff(xv).max() - np.diff(xv).min()) > np.finfo(float).eps ):
-        xv = np.linspace(xv.min(), xv.max(), xv.shape[0])
-    if ( (np.diff(yv).max() - np.diff(yv).min()) > np.finfo(float).eps ):
-        yv = np.linspace(yv.min(), yv.max(), yv.shape[0])
     x_stream, y_stream = np.meshgrid(xv, yv)
 
     # Extract scalar data

--- a/vis/python/plot_slice.py
+++ b/vis/python/plot_slice.py
@@ -80,7 +80,7 @@ def main(**kwargs):
         data = athena_read.athdf(kwargs['data_file'], quantities=quantities, level=level)
 
     # Check that coordinates work with user choices
-    coordinates = data['Coordinates']
+    coordinates = data['Coordinates'].decode('ascii', 'replace')
     ave_or_sum = kwargs['average'] or kwargs['sum'] or kwargs['stream_average']
     warn_projection = False
     warn_vector = False

--- a/vis/python/plot_spherical.py
+++ b/vis/python/plot_spherical.py
@@ -83,7 +83,7 @@ def main(**kwargs):
                                      level=level)
 
     # Extract basic coordinate information
-    coordinates = data['Coordinates'].decode('utf-8', 'replace')
+    coordinates = data['Coordinates'].decode('ascii', 'replace')
     r = data['x1v']
     theta = data['x2v']
     phi = data['x3v']

--- a/vis/python/plot_spherical.py
+++ b/vis/python/plot_spherical.py
@@ -83,7 +83,7 @@ def main(**kwargs):
                                      level=level)
 
     # Extract basic coordinate information
-    coordinates = data['Coordinates'].decode('ascii', 'replace')
+    coordinates = data['Coordinates'].decode('utf-8', 'replace')
     r = data['x1v']
     theta = data['x2v']
     phi = data['x3v']

--- a/vis/python/plot_spherical.py
+++ b/vis/python/plot_spherical.py
@@ -83,7 +83,7 @@ def main(**kwargs):
                                      level=level)
 
     # Extract basic coordinate information
-    coordinates = data['Coordinates']
+    coordinates = data['Coordinates'].decode('ascii', 'replace')
     r = data['x1v']
     theta = data['x2v']
     phi = data['x3v']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description
- Newer versions of h5py read strings as by strings and require being encoded to enable/disable options, prefer utf-8 over ascii
- Stream plots from single precision data fail without recasting grid limits, so recast cell coordinates into uniform data
- prefer explicit objects over `plt.` usage with figures, axes, etc. 
- plots assume rectangular grid, add polar projection for cylindrical plots
- expose num_ghosts as a parameter
- resolve https://github.com/PrincetonUniversity/athena/issues/393

Commits should have been split up but want to get feedback to determine if these changes are useful upstream

## Testing and validation
Ad hoc testing on current data, appears to work for cylindrical slice 


## To-do
<!-- Describe remaining tasks or open questions related to this PR-->

- [ ] currently the figure size is hard-coded to `(12, 12)`  and could be made a variable with a default
