### PR TITLE
Added "dcycle" option to output data at constant cycle intervals

### DIFF
--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -40,6 +40,7 @@ struct OutputParameters {
   std::string file_type;
   std::string data_format;
   Real next_time, dt;
+  int dcycle;
   int file_number;
   bool output_slicex1, output_slicex2, output_slicex3;
   bool output_sumx1, output_sumx2, output_sumx3;


### PR DESCRIPTION
This PR adds "dcycle" option in the <output> block in input. "dcycle" is an integer number, and the code outputs data at every "dcycle" step. "dt" and "dcycle" are exclusive.

## Prerequisite checklist
- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description
This feature is useful for some problems with drastic change in time scale. A particular example is self-gravitational collapse like star formation.

