### PR TITLE
Corrected density used in relativistic passive scalar prolongation

### DIFF
--- a/src/bvals/bvals_refine.cpp
+++ b/src/bvals/bvals_refine.cpp
@@ -563,7 +563,7 @@ void BoundaryValues::ProlongateGhostCells(const NeighborBlock& nb,
                                   fsi, fei, fsj, fej, fsk, fek);
   if (NSCALARS > 0) {
     PassiveScalars *ps = pmb->pscalars;
-    pmb->peos->PassiveScalarPrimitiveToConserved(ps->r, ph->w, ps->s, pmb->pcoord,
+    pmb->peos->PassiveScalarPrimitiveToConserved(ps->r, ph->u, ps->s, pmb->pcoord,
                                                  fsi, fei, fsj, fej, fsk, fek);
   }
   return;


### PR DESCRIPTION
Tiny change that fixes #419.

This should have only ever affected multidimensional relativistic SMR/AMR calculations, with an error that scales as Lorentz factor. It doesn't even violate conservation. Some passive scalar might have gotten trapped or moved slightly too quickly at a coarse-fine boundary relative to the mass flux.