### PR TITLE
Clarify units in EOS input file

### DIFF
--- a/inputs/mhd/athinput.rj2a
+++ b/inputs/mhd/athinput.rj2a
@@ -48,8 +48,8 @@ ox3_bc      = periodic  # Outer-X3 boundary condition flag
 
 <hydro>
 gamma = 1.666666666667  # gamma = C_p/C_v
-eos_rho_unit    = 1.0   # rho (in sim units) * eos_rho_unit = rho (in table units)
-eos_egas_unit   = 1.0   # similar to eos_rho_unit. Both default to 1.0
+eos_rho_unit  = 1.0     # rho (in sim units) * eos_rho_unit = rho (in table units)
+eos_egas_unit = 1.0     # similar to eos_rho_unit. Both default to 1.0
 
 <problem>
 shock_dir     = 1         # Shock Direction -- (1,2,3) = (x1,x2,x3)


### PR DESCRIPTION
## Description

Clarified `eos_rho_unit` and `eos_egas_unit` in the comments of an example input file.