### PR TITLE
Fixed typo in gr_torus problem generator

### DIFF
--- a/src/pgen/gr_torus.cpp
+++ b/src/pgen/gr_torus.cpp
@@ -945,7 +945,7 @@ void TransformContravariantFromBoyerLindquist(Real at_bl, Real ar_bl, Real ath_b
     Real *p_a3) {
   if (std::strcmp(COORDINATE_SYSTEM, "kerr-schild") == 0) {
     Real delta = SQR(x1) - 2.0 * m * x1 + SQR(a);
-    *p_a0 = ar_bl + 2.0 * m * x1 / delta * ar_bl;
+    *p_a0 = at_bl + 2.0 * m * x1 / delta * ar_bl;
     *p_a1 = ar_bl;
     *p_a2 = ath_bl;
     *p_a3 = aph_bl + a / delta * ar_bl;


### PR DESCRIPTION
There was a small typo brought to my attention by @pdmullen. The result was initial equilibrium tori had slight inward radial velocities close to the black hole. Other problem generators are unaffected. The bug was introduced in 072634e8.