### PR TITLE
fix dependency of passive scalar boundary communication

### DIFF
--- a/src/task_list/time_integrator.cpp
+++ b/src/task_list/time_integrator.cpp
@@ -972,9 +972,9 @@ TimeIntegratorTaskList::TimeIntegratorTaskList(ParameterInput *pin, Mesh *pm) {
         AddTask(RECV_SCLR,NONE);
         AddTask(SETB_SCLR,(RECV_SCLR|CALC_HYDORB));
       } else {
-        AddTask(SEND_SCLR,INT_SCLR);
+        AddTask(SEND_SCLR,SRCTERM_HYD);
         AddTask(RECV_SCLR,NONE);
-        AddTask(SETB_SCLR,(RECV_SCLR|INT_SCLR));
+        AddTask(SETB_SCLR,(RECV_SCLR|SRCTERM_HYD));
       }
       if (SHEAR_PERIODIC) {
         AddTask(SEND_SCLRSH,SETB_SCLR);


### PR DESCRIPTION
In AddSourceTermsHydro, it is supposed to impose source functions not only on hydro variables but also on passive scalars. If we change passive scalars in AddSourceTermsHydro, SEND_SCLR and SETB_SCLR need to wait for the execution of SRCTERM_HYD rather than INT_SCLR. This PR fixes the dependencies. 
The name of AddSourceTermsHydro is confusing. I think that we should make a new function as AddSourceTermsScalars or rename the function. 