### PR TITLE
Rename Source Functions

### DIFF
--- a/src/eos/adiabatic_hydro.cpp
+++ b/src/eos/adiabatic_hydro.cpp
@@ -93,7 +93,7 @@ void EquationOfState::PrimitiveToConserved(
   Real igm1 = 1.0/(GetGamma() - 1.0);
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
-      #pragma omp simd
+#pragma omp simd
       for (int i=il; i<=iu; ++i) {
         Real& u_d  = cons(IDN,k,j,i);
         Real& u_m1 = cons(IM1,k,j,i);

--- a/src/hydro/srcterms/hydro_srcterms.cpp
+++ b/src/hydro/srcterms/hydro_srcterms.cpp
@@ -113,14 +113,15 @@ HydroSourceTerms::HydroSourceTerms(Hydro *phyd, ParameterInput *pin) {
 //----------------------------------------------------------------------------------------
 //! \fn void HydroSourceTerms::AddHydroSourceTerms
 //! \brief Adds source terms to conserved variables
+//! This function is not only for hydro variables but also for passive scalars.
 
-void HydroSourceTerms::AddHydroSourceTerms(const Real time, const Real dt,
-                                           const AthenaArray<Real> *flux,
-                                           const AthenaArray<Real> &prim,
-                                           const AthenaArray<Real> &prim_scalar,
-                                           const AthenaArray<Real> &bcc,
-                                           AthenaArray<Real> &cons,
-                                           AthenaArray<Real> &cons_scalar) {
+void HydroSourceTerms::AddSourceTerms(const Real time, const Real dt,
+                                      const AthenaArray<Real> *flux,
+                                      const AthenaArray<Real> &prim,
+                                      const AthenaArray<Real> &prim_scalar,
+                                      const AthenaArray<Real> &bcc,
+                                      AthenaArray<Real> &cons,
+                                      AthenaArray<Real> &cons_scalar) {
   MeshBlock *pmb = pmy_hydro_->pmy_block;
 
   // accleration due to point mass (MUST BE AT ORIGIN)

--- a/src/hydro/srcterms/hydro_srcterms.hpp
+++ b/src/hydro/srcterms/hydro_srcterms.hpp
@@ -39,11 +39,11 @@ class HydroSourceTerms {
   bool hydro_sourceterms_defined;
 
   // functions
-  void AddHydroSourceTerms(const Real time, const Real dt, const AthenaArray<Real> *flx,
-                           const AthenaArray<Real> &prim,
-                           const AthenaArray<Real> &prim_scalar,
-                           const AthenaArray<Real> &b, AthenaArray<Real> &cons,
-                           AthenaArray<Real> &cons_scalar);
+  void AddSourceTerms(const Real time, const Real dt, const AthenaArray<Real> *flx,
+                      const AthenaArray<Real> &prim,
+                      const AthenaArray<Real> &prim_scalar,
+                      const AthenaArray<Real> &b, AthenaArray<Real> &cons,
+                      AthenaArray<Real> &cons_scalar);
   void PointMass(const Real dt, const AthenaArray<Real> *flx,const AthenaArray<Real> &p,
                  AthenaArray<Real> &c);
   void ConstantAcceleration(const Real dt, const AthenaArray<Real> *flx,

--- a/src/task_list/task_list.hpp
+++ b/src/task_list/task_list.hpp
@@ -157,7 +157,7 @@ class TimeIntegratorTaskList : public TaskList {
   TaskStatus IntegrateHydro(MeshBlock *pmb, int stage);
   TaskStatus IntegrateField(MeshBlock *pmb, int stage);
 
-  TaskStatus AddSourceTerm(MeshBlock *pmb, int stage);
+  TaskStatus AddSourceTerms(MeshBlock *pmb, int stage);
 
   TaskStatus DiffuseHydro(MeshBlock *pmb, int stage);
   TaskStatus DiffuseField(MeshBlock *pmb, int stage);

--- a/src/task_list/task_list.hpp
+++ b/src/task_list/task_list.hpp
@@ -157,7 +157,7 @@ class TimeIntegratorTaskList : public TaskList {
   TaskStatus IntegrateHydro(MeshBlock *pmb, int stage);
   TaskStatus IntegrateField(MeshBlock *pmb, int stage);
 
-  TaskStatus AddSourceTermsHydro(MeshBlock *pmb, int stage);
+  TaskStatus AddSourceTerm(MeshBlock *pmb, int stage);
 
   TaskStatus DiffuseHydro(MeshBlock *pmb, int stage);
   TaskStatus DiffuseField(MeshBlock *pmb, int stage);
@@ -285,7 +285,7 @@ const TaskID RECV_FLDFLX(11);
 // const TaskID RECV_RADFLX(12);
 // const TaskID RECV_CHMFLX(13);
 
-const TaskID SRCTERM_HYD(14);
+const TaskID SRC_TERM(14);
 // const TaskID SRCTERM_FLD(15);
 // const TaskID SRCTERM_RAD(16);
 // const TaskID SRCTERM_CHM(17);

--- a/src/task_list/time_integrator.cpp
+++ b/src/task_list/time_integrator.cpp
@@ -1115,7 +1115,7 @@ void TimeIntegratorTaskList::AddTask(const TaskID& id, const TaskID& dep) {
   //!   VerbObject() since "HydroFluxCalculate()" doesn't sound quite right.
   //! - There are exceptions to the "verb+object" convention in some TASK_NAMES and
   //!   TaskFunc, e.g. NEW_DT + NewBlockTimeStep() and AMR_FLAG + CheckRefinement(),
-  //!   SRC_TERM and SourceTerm(), USERWORK, PHY_BVAL, PROLONG, CONS2PRIM,
+  //!   SRC_TERM and SourceTerms(), USERWORK, PHY_BVAL, PROLONG, CONS2PRIM,
   //!   ... Although, AMR_FLAG = "flag blocks for AMR" should be FLAG_AMR in VERB_OBJECT
   using namespace HydroIntegratorTaskNames; // NOLINT (build/namespace)
   if (id == CLEAR_ALLBND) {
@@ -1166,7 +1166,7 @@ void TimeIntegratorTaskList::AddTask(const TaskID& id, const TaskID& dep) {
   } else if (id == SRC_TERM) {
     task_list_[ntasks].TaskFunc=
         static_cast<TaskStatus (TaskList::*)(MeshBlock*,int)>
-        (&TimeIntegratorTaskList::AddSourceTerm);
+        (&TimeIntegratorTaskList::AddSourceTerms);
     task_list_[ntasks].lb_time = true;
   } else if (id == SEND_HYD) {
     task_list_[ntasks].TaskFunc=
@@ -1652,7 +1652,7 @@ TaskStatus TimeIntegratorTaskList::IntegrateField(MeshBlock *pmb, int stage) {
 //----------------------------------------------------------------------------------------
 //! Functions to add source terms
 
-TaskStatus TimeIntegratorTaskList::AddSourceTerm(MeshBlock *pmb, int stage) {
+TaskStatus TimeIntegratorTaskList::AddSourceTerms(MeshBlock *pmb, int stage) {
   Hydro *ph = pmb->phydro;
   Field *pf = pmb->pfield;
   PassiveScalars *ps = pmb->pscalars;

--- a/src/task_list/time_integrator.cpp
+++ b/src/task_list/time_integrator.cpp
@@ -930,21 +930,21 @@ TimeIntegratorTaskList::TimeIntegratorTaskList(ParameterInput *pin, Mesh *pm) {
       AddTask(INT_HYD, CALC_HYDFLX);
     }
     if (NSCALARS > 0) {
-      AddTask(SRCTERM_HYD,(INT_HYD|INT_SCLR));
+      AddTask(SRC_TERM,(INT_HYD|INT_SCLR));
     } else {
-      AddTask(SRCTERM_HYD,INT_HYD);
+      AddTask(SRC_TERM,INT_HYD);
     }
     if (ORBITAL_ADVECTION) {
-      AddTask(SEND_HYDORB,SRCTERM_HYD);
+      AddTask(SEND_HYDORB,SRC_TERM);
       AddTask(RECV_HYDORB,NONE);
       AddTask(CALC_HYDORB,(SEND_HYDORB|RECV_HYDORB));
       AddTask(SEND_HYD,CALC_HYDORB);
       AddTask(RECV_HYD,NONE);
       AddTask(SETB_HYD,(RECV_HYD|CALC_HYDORB));
     } else {
-      AddTask(SEND_HYD,SRCTERM_HYD);
+      AddTask(SEND_HYD,SRC_TERM);
       AddTask(RECV_HYD,NONE);
-      AddTask(SETB_HYD,(RECV_HYD|SRCTERM_HYD));
+      AddTask(SETB_HYD,(RECV_HYD|SRC_TERM));
     }
 
     if (SHEAR_PERIODIC) {
@@ -966,15 +966,14 @@ TimeIntegratorTaskList::TimeIntegratorTaskList(ParameterInput *pin, Mesh *pm) {
       } else {
         AddTask(INT_SCLR,CALC_SCLRFLX);
       }
-      // there is no SRCTERM_SCLR task
       if (ORBITAL_ADVECTION) {
         AddTask(SEND_SCLR,CALC_HYDORB);
         AddTask(RECV_SCLR,NONE);
         AddTask(SETB_SCLR,(RECV_SCLR|CALC_HYDORB));
       } else {
-        AddTask(SEND_SCLR,SRCTERM_HYD);
+        AddTask(SEND_SCLR,SRC_TERM);
         AddTask(RECV_SCLR,NONE);
-        AddTask(SETB_SCLR,(RECV_SCLR|SRCTERM_HYD));
+        AddTask(SETB_SCLR,(RECV_SCLR|SRC_TERM));
       }
       if (SHEAR_PERIODIC) {
         AddTask(SEND_SCLRSH,SETB_SCLR);
@@ -1116,7 +1115,7 @@ void TimeIntegratorTaskList::AddTask(const TaskID& id, const TaskID& dep) {
   //!   VerbObject() since "HydroFluxCalculate()" doesn't sound quite right.
   //! - There are exceptions to the "verb+object" convention in some TASK_NAMES and
   //!   TaskFunc, e.g. NEW_DT + NewBlockTimeStep() and AMR_FLAG + CheckRefinement(),
-  //!   SRCTERM_HYD and HydroSourceTerms(), USERWORK, PHY_BVAL, PROLONG, CONS2PRIM,
+  //!   SRC_TERM and SourceTerm(), USERWORK, PHY_BVAL, PROLONG, CONS2PRIM,
   //!   ... Although, AMR_FLAG = "flag blocks for AMR" should be FLAG_AMR in VERB_OBJECT
   using namespace HydroIntegratorTaskNames; // NOLINT (build/namespace)
   if (id == CLEAR_ALLBND) {
@@ -1164,10 +1163,10 @@ void TimeIntegratorTaskList::AddTask(const TaskID& id, const TaskID& dep) {
         static_cast<TaskStatus (TaskList::*)(MeshBlock*,int)>
         (&TimeIntegratorTaskList::IntegrateField);
     task_list_[ntasks].lb_time = true;
-  } else if (id == SRCTERM_HYD) {
+  } else if (id == SRC_TERM) {
     task_list_[ntasks].TaskFunc=
         static_cast<TaskStatus (TaskList::*)(MeshBlock*,int)>
-        (&TimeIntegratorTaskList::AddSourceTermsHydro);
+        (&TimeIntegratorTaskList::AddSourceTerm);
     task_list_[ntasks].lb_time = true;
   } else if (id == SEND_HYD) {
     task_list_[ntasks].TaskFunc=
@@ -1653,7 +1652,7 @@ TaskStatus TimeIntegratorTaskList::IntegrateField(MeshBlock *pmb, int stage) {
 //----------------------------------------------------------------------------------------
 //! Functions to add source terms
 
-TaskStatus TimeIntegratorTaskList::AddSourceTermsHydro(MeshBlock *pmb, int stage) {
+TaskStatus TimeIntegratorTaskList::AddSourceTerm(MeshBlock *pmb, int stage) {
   Hydro *ph = pmb->phydro;
   Field *pf = pmb->pfield;
   PassiveScalars *ps = pmb->pscalars;
@@ -1670,7 +1669,7 @@ TaskStatus TimeIntegratorTaskList::AddSourceTermsHydro(MeshBlock *pmb, int stage
       // Scaled coefficient for RHS update
       Real dt = (stage_wghts[(stage-1)].beta)*(pmb->pmy_mesh->dt);
       // Evaluate the source terms at the time at the beginning of the stage
-      ph->hsrc.AddHydroSourceTerms(t_start_stage, dt, ph->flux, ph->w, ps->r, pf->bcc,
+      ph->hsrc.AddSourceTerms(t_start_stage, dt, ph->flux, ph->w, ps->r, pf->bcc,
                                    ph->u, ps->s);
     }
     return TaskStatus::next;


### PR DESCRIPTION
As discussed in 49d491e1837a578ebf29216c7cdade8e842cb9fc, the name of source functions were misunderstanding. This PR renames the functions as below. 

HydroSourceTerms
`void HydroSourceTerms::AddHydroSourceTerms`
=> `void HydroSourceTerms::AddSourceTerms`
TaskList
`TaskID SRCTERM_HYD`
=> `TaskID SRC_TERM`
`TaskStatus TimeIntegratorTaskList::AddSourceTermsHydro`
=> `TaskStatus TimeIntegratorTaskList::AddSourceTerm`

If I just omit `Hydro` from the names, two functions in HydroSourceTerms and TaskList have the same name. To avoid the duplication, I rename one in singular form and the other in plural form. It could be still confusing, but It would be OK.

This PR has passed the regression tests and meet the Athena++ style. I found that e08dd974808fed05b9d7709f63bedfb42b885224 does not meet the style. I also fixed it.