### PR TITLE
Fix bug specifying uov output

### DIFF
--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -678,14 +678,17 @@ void OutputType::LoadOutputData(MeshBlock *pmb) {
     }
   } // endif (MAGNETIC_FIELDS_ENABLED)
 
+  bool output_all_uov = ContainVariable(output_params.variable, "uov")
+                        || ContainVariable(output_params.variable, "user_out_var");
   for (int n = 0; n < pmb->nuser_out_var; ++n) {
     char abbr_name[16], full_name[32];
     std::snprintf(abbr_name, sizeof(abbr_name), "uov%d", n);
     std::snprintf(full_name, sizeof(full_name), "user_out_var%d", n);
-    if ((pmb->user_out_var_names_[n].length() != 0
+    if (output_all_uov ||
+        (pmb->user_out_var_names_[n].length() != 0
          && ContainVariable(output_params.variable, pmb->user_out_var_names_[n]))
         || ContainVariable(output_params.variable, abbr_name)
-        || ContainVariable(output_params.variable, abbr_name)) {
+        || ContainVariable(output_params.variable, full_name)) {
       pod = new OutputData;
       pod->type = "SCALARS";
       if (pmb->user_out_var_names_[n].length() != 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #436 

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on my machine with problem `linear_wave` configured as followed:
`python configure.py --prob=linear_wave --cxx=clang++ --cflag='-arch arm64' -debug -hdf5`
Edited `athinput.linear_wave1d`, added hdf5 output and `,uov` to variable.
Code runs without producing error and the uov is output as intended.

