### PR TITLE
Passive scalar dependent EOS

### DIFF
--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -46,6 +46,9 @@
 #include <mpi.h>
 #endif
 
+// empty array to pass in place of scalars when NSCALARS=0
+static AthenaArray<Real> empty;
+
 //----------------------------------------------------------------------------------------
 //! \brief BoundaryValues constructor
 //!        (the first object constructed inside the MeshBlock() constructor)
@@ -488,8 +491,10 @@ void BoundaryValues::ApplyPhysicalBoundaries(const Real time, const Real dt,
                                               pmb->is-NGHOST, pmb->is-1,
                                               bjs, bje, bks, bke);
     }
-    pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u, pco,
-                                    pmb->is-NGHOST, pmb->is-1, bjs, bje, bks, bke);
+    pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u,
+                                    (NSCALARS) ? ps->r : empty,
+                                    (NSCALARS) ? ps->s : empty,
+                                    pco, pmb->is-NGHOST, pmb->is-1, bjs, bje, bks, bke);
     if (NSCALARS > 0) {
       pmb->peos->PassiveScalarPrimitiveToConserved(
           ps->r, ph->u, ps->s, pco, pmb->is-NGHOST, pmb->is-1, bjs, bje, bks, bke);
@@ -508,8 +513,10 @@ void BoundaryValues::ApplyPhysicalBoundaries(const Real time, const Real dt,
                                               pmb->ie+1, pmb->ie+NGHOST,
                                               bjs, bje, bks, bke);
     }
-    pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u, pco,
-                                    pmb->ie+1, pmb->ie+NGHOST, bjs, bje, bks, bke);
+    pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u,
+                                    (NSCALARS) ? ps->r : empty,
+                                    (NSCALARS) ? ps->s : empty,
+                                    pco, pmb->ie+1, pmb->ie+NGHOST, bjs, bje, bks, bke);
     if (NSCALARS > 0) {
       pmb->peos->PassiveScalarPrimitiveToConserved(
           ps->r, ph->u, ps->s, pco, pmb->ie+1, pmb->ie+NGHOST, bjs, bje, bks, bke);
@@ -529,8 +536,10 @@ void BoundaryValues::ApplyPhysicalBoundaries(const Real time, const Real dt,
                                                 bis, bie, pmb->js-NGHOST, pmb->js-1,
                                                 bks, bke);
       }
-      pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u, pco,
-                                      bis, bie, pmb->js-NGHOST, pmb->js-1, bks, bke);
+      pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u,
+                                     (NSCALARS) ? ps->r : empty,
+                                     (NSCALARS) ? ps->s : empty,
+                                     pco, bis, bie, pmb->js-NGHOST, pmb->js-1, bks, bke);
       if (NSCALARS > 0) {
         pmb->peos->PassiveScalarPrimitiveToConserved(
             ps->r, ph->u, ps->s, pco, bis, bie, pmb->js-NGHOST, pmb->js-1, bks, bke);
@@ -549,8 +558,10 @@ void BoundaryValues::ApplyPhysicalBoundaries(const Real time, const Real dt,
                                                 bis, bie, pmb->je+1, pmb->je+NGHOST,
                                                 bks, bke);
       }
-      pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u, pco,
-                                      bis, bie, pmb->je+1, pmb->je+NGHOST, bks, bke);
+      pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u,
+                                     (NSCALARS) ? ps->r : empty,
+                                     (NSCALARS) ? ps->s : empty,
+                                     pco, bis, bie, pmb->je+1, pmb->je+NGHOST, bks, bke);
       if (NSCALARS > 0) {
         pmb->peos->PassiveScalarPrimitiveToConserved(
             ps->r, ph->u, ps->s, pco, bis, bie, pmb->je+1, pmb->je+NGHOST, bks, bke);
@@ -574,8 +585,10 @@ void BoundaryValues::ApplyPhysicalBoundaries(const Real time, const Real dt,
                                                 bis, bie, bjs, bje,
                                                 pmb->ks-NGHOST, pmb->ks-1);
       }
-      pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u, pco,
-                                      bis, bie, bjs, bje, pmb->ks-NGHOST, pmb->ks-1);
+      pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u,
+                                     (NSCALARS) ? ps->r : empty,
+                                     (NSCALARS) ? ps->s : empty,
+                                     pco, bis, bie, bjs, bje, pmb->ks-NGHOST, pmb->ks-1);
       if (NSCALARS > 0) {
         pmb->peos->PassiveScalarPrimitiveToConserved(
             ps->r, ph->u, ps->s, pco, bis, bie, bjs, bje, pmb->ks-NGHOST, pmb->ks-1);
@@ -594,8 +607,10 @@ void BoundaryValues::ApplyPhysicalBoundaries(const Real time, const Real dt,
                                                 bis, bie, bjs, bje,
                                                 pmb->ke+1, pmb->ke+NGHOST);
       }
-      pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u, pco,
-                                      bis, bie, bjs, bje, pmb->ke+1, pmb->ke+NGHOST);
+      pmb->peos->PrimitiveToConserved(ph->w, pf->bcc, ph->u,
+                                     (NSCALARS) ? ps->r : empty,
+                                     (NSCALARS) ? ps->s : empty,
+                                     pco, bis, bie, bjs, bje, pmb->ke+1, pmb->ke+NGHOST);
       if (NSCALARS > 0) {
         pmb->peos->PassiveScalarPrimitiveToConserved(
             ps->r, ph->u, ps->s, pco, bis, bie, bjs, bje, pmb->ke+1, pmb->ke+NGHOST);

--- a/src/eos/adiabatic_hydro.cpp
+++ b/src/eos/adiabatic_hydro.cpp
@@ -38,7 +38,8 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 
 void EquationOfState::ConservedToPrimitive(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &b,
-    AthenaArray<Real> &prim, AthenaArray<Real> &bcc,
+    AthenaArray<Real> &prim, AthenaArray<Real> &bcc, AthenaArray<Real> &s,
+    const AthenaArray<Real> &r_old, AthenaArray<Real> &r,
     Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku) {
   Real gm1 = GetGamma() - 1.0;
 
@@ -88,7 +89,8 @@ void EquationOfState::ConservedToPrimitive(
 
 void EquationOfState::PrimitiveToConserved(
     const AthenaArray<Real> &prim, const AthenaArray<Real> &bc,
-    AthenaArray<Real> &cons, Coordinates *pco,
+    AthenaArray<Real> &cons, const AthenaArray<Real> &r,
+    AthenaArray<Real> &s, Coordinates *pco,
     int il, int iu, int jl, int ju, int kl, int ku) {
   Real igm1 = 1.0/(GetGamma() - 1.0);
   for (int k=kl; k<=ku; ++k) {

--- a/src/eos/adiabatic_hydro_gr.cpp
+++ b/src/eos/adiabatic_hydro_gr.cpp
@@ -68,14 +68,18 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 //----------------------------------------------------------------------------------------
 //! \fn void EquationOfState::ConservedToPrimitive(
 //!   AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
-//!   AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, Coordinates *pco, int il, int iu,
-//!   int jl, int ju, int kl, int ku)
+//!   AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, AthenaArray<Real> &s,
+//!   const AthenaArray<Real> &r_old, AthenaArray<Real> &r, Coordinates *pco,
+//!   int il, int iu, int jl, int ju, int kl, int ku)
 //! \brief Variable inverter
 //!
 //! Inputs:
 //!  - cons: conserved quantities
 //!  - prim_old: primitive quantities from previous half timestep
 //!  - bb: face-centered magnetic field (not used)
+//!  - s: conserved scalars
+//!  - r_old: old primitive scalars
+//!  - r: primitive scalars
 //!  - pco: pointer to Coordinates
 //!  - il, iu, jl, ju, kl, ku: index bounds of region to be updated
 //! Outputs:
@@ -87,8 +91,9 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 
 void EquationOfState::ConservedToPrimitive(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
-    AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, Coordinates *pco, int il, int iu,
-    int jl, int ju, int kl, int ku) {
+    AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, AthenaArray<Real> &s,
+    const AthenaArray<Real> &r_old, AthenaArray<Real> &r, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
   // Parameters
   const Real mm_sq_ee_sq_max = 1.0 - 1.0e-12;  // max. of squared momentum over energy
 
@@ -247,26 +252,28 @@ void EquationOfState::ConservedToPrimitive(
 
 //----------------------------------------------------------------------------------------
 //! \fn void EquationOfState::PrimitiveToConserved(
-//!    const AthenaArray<Real> &prim,
-//!    const AthenaArray<Real> &bb_cc, AthenaArray<Real> &cons, Coordinates *pco,
-//!    int il, int iu, int jl, int ju, int kl, int ku)
+//!    const AthenaArray<Real> &prim, const AthenaArray<Real> &bb_cc,
+//!    AthenaArray<Real> &cons, const AthenaArray<Real> &r, AthenaArray<Real> &s,
+//!    Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku)
 //! \brief Function for converting all primitives to conserved variables
 //!
 //! Inputs:
 //!  - prim: primitives
 //!  - bb_cc: cell-centered magnetic field (unused)
+//!  - r: primitive scalars
 //!  - pco: pointer to Coordinates
 //!  - il,iu,jl,ju,kl,ku: index bounds of region to be updated
 //! Outputs:
 //!  - cons: conserved variables
+//!  - s: conserved scalars (unused)
 //! Notes:
 //!  - Single-cell function exists for other purposes; call made to that function rather
 //!       than having duplicate code.
 
 void EquationOfState::PrimitiveToConserved(
-    const AthenaArray<Real> &prim,
-    const AthenaArray<Real> &bb_cc, AthenaArray<Real> &cons, Coordinates *pco,
-    int il, int iu, int jl, int ju, int kl, int ku) {
+    const AthenaArray<Real> &prim, const AthenaArray<Real> &bb_cc,
+    AthenaArray<Real> &cons, const AthenaArray<Real> &r, AthenaArray<Real> &s,
+    Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku) {
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
       pco->CellMetric(k, j, il, iu, g_, g_inv_);

--- a/src/eos/adiabatic_hydro_sr.cpp
+++ b/src/eos/adiabatic_hydro_sr.cpp
@@ -50,24 +50,34 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 }
 
 //----------------------------------------------------------------------------------------
-// Variable inverter
-// Inputs:
-//   cons: conserved quantities
-//   prim_old: primitive quantities from previous half timestep (not used)
-//   bb: face-centered magnetic field (not used)
-//   pco: pointer to Coordinates
-//   il, iu, jl, ju, kl, ku: index bounds of region to be updated
-// Outputs:
-//   prim: primitives
-//   bb_cc: cell-centered magnetic field (not set)
-// Notes:
-//   More complex version with magnetic fields found in adiabatic_mhd_sr.cpp.
-//   More complex version for GR found in adiabatic_hydro_gr.cpp.
+//! \fn void EquationOfState::ConservedToPrimitive(
+//!   AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
+//!   AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, AthenaArray<Real> &s,
+//!   const AthenaArray<Real> &r_old, AthenaArray<Real> &r, Coordinates *pco,
+//!   int il, int iu, int jl, int ju, int kl, int ku)
+//! \brief Variable inverter
+//!
+//! Inputs:
+//!  - cons: conserved quantities
+//!  - prim_old: primitive quantities from previous half timestep
+//!  - bb: face-centered magnetic field (not used)
+//!  - s: conserved scalars
+//!  - r_old: old primitive scalars
+//!  - r: primitive scalars
+//!  - pco: pointer to Coordinates
+//!  - il, iu, jl, ju, kl, ku: index bounds of region to be updated
+//! Outputs:
+//!  - prim: primitives
+//!  - bb_cc: cell-centered magnetic field (not set)
+//! Notes:
+//!   More complex version with magnetic fields found in adiabatic_mhd_sr.cpp.
+//!   More complex version for GR found in adiabatic_hydro_gr.cpp.
 
 void EquationOfState::ConservedToPrimitive(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
-    AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, Coordinates *pco, int il, int iu,
-    int jl, int ju, int kl, int ku) {
+    AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, AthenaArray<Real> &s,
+    const AthenaArray<Real> &r_old, AthenaArray<Real> &r, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
   // Parameters
   const Real mm_sq_ee_sq_max = 1.0 - 1.0e-12;  // max. of squared momentum over energy
 
@@ -219,19 +229,26 @@ void EquationOfState::ConservedToPrimitive(
 }
 
 //----------------------------------------------------------------------------------------
-// Function for converting all primitives to conserved variables
-// Inputs:
-//   prim: primitives
-//   bb_cc: cell-centered magnetic field (unused)
-//   pco: pointer to Coordinates
-//   il,iu,jl,ju,kl,ku: index bounds of region to be updated
-// Outputs:
-//   cons: conserved variables
+//! \fn void EquationOfState::PrimitiveToConserved(
+//!    const AthenaArray<Real> &prim, const AthenaArray<Real> &bb_cc,
+//!    AthenaArray<Real> &cons, const AthenaArray<Real> &r, AthenaArray<Real> &s,
+//!    Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku)
+//! \brief Function for converting all primitives to conserved variables
+//!
+//! Inputs:
+//!  - prim: primitives
+//!  - bb_cc: cell-centered magnetic field (unused)
+//!  - r: primitive scalars
+//!  - pco: pointer to Coordinates
+//!  - il,iu,jl,ju,kl,ku: index bounds of region to be updated
+//! Outputs:
+//!  - cons: conserved variables
+//!  - s: conserved scalars (unused)
 
 void EquationOfState::PrimitiveToConserved(
     const AthenaArray<Real> &prim, const AthenaArray<Real> &bb_cc,
-    AthenaArray<Real> &cons, Coordinates *pco,
-    int il, int iu, int jl, int ju, int kl, int ku) {
+    AthenaArray<Real> &cons, const AthenaArray<Real> &r, AthenaArray<Real> &s,
+    Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku) {
   // Calculate reduced ratio of specific heats
   Real gamma_prime = gamma_/(gamma_-1.0);
 

--- a/src/eos/adiabatic_mhd.cpp
+++ b/src/eos/adiabatic_mhd.cpp
@@ -40,7 +40,8 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 
 void EquationOfState::ConservedToPrimitive(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &b,
-    AthenaArray<Real> &prim, AthenaArray<Real> &bcc,
+    AthenaArray<Real> &prim, AthenaArray<Real> &bcc, AthenaArray<Real> &s,
+    const AthenaArray<Real> &r_old, AthenaArray<Real> &r,
     Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku) {
   Real gm1 = GetGamma() - 1.0;
 
@@ -98,7 +99,8 @@ void EquationOfState::ConservedToPrimitive(
 
 void EquationOfState::PrimitiveToConserved(
     const AthenaArray<Real> &prim, const AthenaArray<Real> &bc,
-    AthenaArray<Real> &cons, Coordinates *pco,
+    AthenaArray<Real> &cons, const AthenaArray<Real> &r,
+    AthenaArray<Real> &s, Coordinates *pco,
     int il, int iu, int jl, int ju, int kl, int ku) {
   Real igm1 = 1.0/(GetGamma() - 1.0);
 

--- a/src/eos/adiabatic_mhd_gr.cpp
+++ b/src/eos/adiabatic_mhd_gr.cpp
@@ -70,24 +70,34 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 }
 
 //----------------------------------------------------------------------------------------
-// Variable inverter
-// Inputs:
-//   cons: conserved quantities
-//   prim_old: primitive quantities from previous half timestep
-//   bb: face-centered magnetic field
-//   pco: pointer to Coordinates
-//   il, iu, jl, ju, kl, ku: index bounds of region to be updated
-// Outputs:
-//   prim: primitives
-//   bb_cc: cell-centered magnetic field
-// Notes:
-//   Simpler version without magnetic fields found in adiabatic_hydro_gr.cpp.
-//   Simpler version for SR found in adiabatic_mhd_sr.cpp.
+//! \fn void EquationOfState::ConservedToPrimitive(
+//!   AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
+//!   AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, AthenaArray<Real> &s,
+//!   const AthenaArray<Real> &r_old, AthenaArray<Real> &r, Coordinates *pco,
+//!   int il, int iu, int jl, int ju, int kl, int ku)
+//! \brief Variable inverter
+//!
+//! Inputs:
+//!  - cons: conserved quantities
+//!  - prim_old: primitive quantities from previous half timestep
+//!  - bb: face-centered magnetic field (not used)
+//!  - s: conserved scalars
+//!  - r_old: old primitive scalars
+//!  - r: primitive scalars
+//!  - pco: pointer to Coordinates
+//!  - il, iu, jl, ju, kl, ku: index bounds of region to be updated
+//! Outputs:
+//!  - prim: primitives
+//!  - bb_cc: cell-centered magnetic field (not set)
+//! Notes:
+//!   Simpler version without magnetic fields found in adiabatic_hydro_gr.cpp.
+//!   Simpler version for SR found in adiabatic_mhd_sr.cpp.
 
 void EquationOfState::ConservedToPrimitive(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
-    AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, Coordinates *pco, int il, int iu,
-    int jl, int ju, int kl, int ku) {
+    AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, AthenaArray<Real> &s,
+    const AthenaArray<Real> &r_old, AthenaArray<Real> &r, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
   // Parameters
   const Real mm_sq_ee_sq_max = 1.0 - 1.0e-12;  // max. of squared momentum over energy
 
@@ -280,22 +290,26 @@ void EquationOfState::ConservedToPrimitive(
 }
 
 //----------------------------------------------------------------------------------------
-// Function for converting all primitives to conserved variables
-// Inputs:
-//   prim: primitives
-//   bb_cc: cell-centered magnetic field
-//   pco: pointer to Coordinates
-//   il,iu,jl,ju,kl,ku: index bounds of region to be updated
-// Outputs:
-//   cons: conserved variables
-// Notes:
-//   Single-cell function exists for other purposes; call made to that function rather
-//       than having duplicate code.
+//! \fn void EquationOfState::PrimitiveToConserved(
+//!    const AthenaArray<Real> &prim, const AthenaArray<Real> &bb_cc,
+//!    AthenaArray<Real> &cons, const AthenaArray<Real> &r, AthenaArray<Real> &s,
+//!    Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku)
+//! \brief Function for converting all primitives to conserved variables
+//!
+//! Inputs:
+//!  - prim: primitives
+//!  - bb_cc: cell-centered magnetic field (unused)
+//!  - r: primitive scalars
+//!  - pco: pointer to Coordinates
+//!  - il,iu,jl,ju,kl,ku: index bounds of region to be updated
+//! Outputs:
+//!  - cons: conserved variables
+//!  - s: conserved scalars (unused)
 
 void EquationOfState::PrimitiveToConserved(
-    const AthenaArray<Real> &prim,
-    const AthenaArray<Real> &bb_cc, AthenaArray<Real> &cons, Coordinates *pco,
-    int il, int iu, int jl, int ju, int kl, int ku) {
+    const AthenaArray<Real> &prim, const AthenaArray<Real> &bb_cc,
+    AthenaArray<Real> &cons, const AthenaArray<Real> &r, AthenaArray<Real> &s,
+    Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku) {
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
       pco->CellMetric(k, j, il, iu, g_, g_inv_);

--- a/src/eos/adiabatic_mhd_sr.cpp
+++ b/src/eos/adiabatic_mhd_sr.cpp
@@ -55,24 +55,34 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 }
 
 //----------------------------------------------------------------------------------------
-// Variable inverter
-// Inputs:
-//   cons: conserved quantities
-//   prim_old: primitive quantities from previous half timestep
-//   bb: face-centered magnetic field
-//   pco: pointer to Coordinates
-//   il, iu, jl, ju, kl, ku: index bounds of region to be updated
-// Outputs:
-//   prim: primitives
-//   bb_cc: cell-centered magnetic field
-// Notes:
-//   Simpler version without magnetic fields found in adiabatic_hydro_sr.cpp.
-//   More complex version for GR found in adiabatic_mhd_gr.cpp.
+//! \fn void EquationOfState::ConservedToPrimitive(
+//!   AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
+//!   AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, AthenaArray<Real> &s,
+//!   const AthenaArray<Real> &r_old, AthenaArray<Real> &r, Coordinates *pco,
+//!   int il, int iu, int jl, int ju, int kl, int ku)
+//! \brief Variable inverter
+//!
+//! Inputs:
+//!  - cons: conserved quantities
+//!  - prim_old: primitive quantities from previous half timestep
+//!  - bb: face-centered magnetic field
+//!  - s: conserved scalars
+//!  - r_old: old primitive scalars
+//!  - r: primitive scalars
+//!  - pco: pointer to Coordinates
+//!  - il, iu, jl, ju, kl, ku: index bounds of region to be updated
+//! Outputs:
+//!  - prim: primitives
+//!  - bb_cc: cell-centered magnetic field
+//! Notes:
+//!   Simpler version without magnetic fields found in adiabatic_hydro_sr.cpp.
+//!   More complex version for GR found in adiabatic_mhd_gr.cpp.
 
 void EquationOfState::ConservedToPrimitive(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &bb,
-    AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, Coordinates *pco, int il, int iu,
-    int jl, int ju, int kl, int ku) {
+    AthenaArray<Real> &prim, AthenaArray<Real> &bb_cc, AthenaArray<Real> &s,
+    const AthenaArray<Real> &r_old, AthenaArray<Real> &r, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
   // Parameters
   const Real mm_sq_ee_sq_max = 1.0 - 1.0e-12;  // max. of squared momentum over energy
 
@@ -272,19 +282,26 @@ void EquationOfState::ConservedToPrimitive(
 }
 
 //----------------------------------------------------------------------------------------
-// Function for converting all primitives to conserved variables
-// Inputs:
-//   prim: 3D array of primitives
-//   bc: 3D array of cell-centered magnetic fields
-//   pco: pointer to Coordinates
-//   il,iu,jl,ju,kl,ku: index bounds of region to be updated
-// Outputs:
-//   cons: 3D array of conserved variables
+//! \fn void EquationOfState::PrimitiveToConserved(
+//!    const AthenaArray<Real> &prim, const AthenaArray<Real> &bb_cc,
+//!    AthenaArray<Real> &cons, const AthenaArray<Real> &r, AthenaArray<Real> &s,
+//!    Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku)
+//! \brief Function for converting all primitives to conserved variables
+//!
+//! Inputs:
+//!  - prim: primitives
+//!  - bc: cell-centered magnetic field
+//!  - r: primitive scalars
+//!  - pco: pointer to Coordinates
+//!  - il,iu,jl,ju,kl,ku: index bounds of region to be updated
+//! Outputs:
+//!  - cons: conserved variables
+//!  - s: conserved scalars (unused)
 
 void EquationOfState::PrimitiveToConserved(
     const AthenaArray<Real> &prim, const AthenaArray<Real> &bc,
-    AthenaArray<Real> &cons, Coordinates *pco,
-    int il, int iu, int jl, int ju, int kl, int ku) {
+    AthenaArray<Real> &cons, const AthenaArray<Real> &r, AthenaArray<Real> &s,
+    Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku) {
   // Calculate reduced ratio of specific heats
   Real gamma_adi_red = gamma_/(gamma_-1.0);
 

--- a/src/eos/eos.hpp
+++ b/src/eos/eos.hpp
@@ -153,9 +153,9 @@ class EquationOfState {
 #endif  // !MAGNETIC_FIELDS_ENABLED (GR)
 #endif  // #else (#if !RELATIVISTIC_DYNAMICS, #elif !GENERAL_RELATIVITY)
 
-  Real PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]);
-  Real EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]);
-  Real AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS]);
+  Real PresFromRhoEg(Real rho, Real egas, Real* s);
+  Real EgasFromRhoP(Real rho, Real pres, Real* r);
+  Real AsqFromRhoP(Real rho, Real pres, const Real* r);
   // overload eos calls without tracers for backward compatibility
   Real PresFromRhoEg(Real rho, Real egas);
   Real EgasFromRhoP(Real rho, Real pres);

--- a/src/eos/eos.hpp
+++ b/src/eos/eos.hpp
@@ -43,6 +43,10 @@ class EquationOfState {
                             AthenaArray<Real> &cons, const AthenaArray<Real> &r,
                             AthenaArray<Real> &s, Coordinates *pco,
                             int il, int iu, int jl, int ju, int kl, int ku);
+  // overload eos calls without tracers for backward compatibility with pgens
+  void PrimitiveToConserved(const AthenaArray<Real> &prim, const AthenaArray<Real> &bc,
+                            AthenaArray<Real> &cons, Coordinates *pco,
+                            int il, int iu, int jl, int ju, int kl, int ku);
   void ConservedToPrimitiveCellAverage(
       AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &b,
       AthenaArray<Real> &prim, AthenaArray<Real> &bcc,
@@ -156,7 +160,7 @@ class EquationOfState {
   Real PresFromRhoEg(Real rho, Real egas, Real* s);
   Real EgasFromRhoP(Real rho, Real pres, Real* r);
   Real AsqFromRhoP(Real rho, Real pres, const Real* r);
-  // overload eos calls without tracers for backward compatibility
+  // overload eos calls without tracers for backward compatibility with pgens
   Real PresFromRhoEg(Real rho, Real egas);
   Real EgasFromRhoP(Real rho, Real pres);
   Real AsqFromRhoP(Real rho, Real pres);

--- a/src/eos/eos_high_order.cpp
+++ b/src/eos/eos_high_order.cpp
@@ -30,6 +30,7 @@
 void EquationOfState::ConservedToPrimitiveCellAverage(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &b,
     AthenaArray<Real> &prim, AthenaArray<Real> &bcc,
+    AthenaArray<Real> &s, const AthenaArray<Real> &r_old, AthenaArray<Real> &r,
     Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku) {
   MeshBlock *pmb = pmy_block_;
   Hydro *ph = pmb->phydro;
@@ -67,7 +68,8 @@ void EquationOfState::ConservedToPrimitiveCellAverage(
   pco->Laplacian(prim, laplacian_cc, il, iu, jl, ju, kl, ku, nl, nu);
 
   // Convert cell-centered conserved values to cell-centered primitive values
-  ConservedToPrimitive(u_cc, prim_old, b, w_cc, bcc, pco, il, iu,
+  // MSBC: TODO: move PasiveScalarPrimitiveCellAverage here (need s_cc here)
+  ConservedToPrimitive(u_cc, prim_old, b, w_cc, bcc, s, r_old, r, pco, il, iu,
                        jl, ju, kl, ku);
 
   for (int n=nl; n<=nu; ++n) {

--- a/src/eos/general/eos_table.cpp
+++ b/src/eos/general/eos_table.cpp
@@ -41,23 +41,23 @@ inline Real GetEosData(EosTable *ptable, int kOut, Real var, Real rho) {
 } // namespace
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS])
+//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real* s)
 //! \brief Return interpolated gas pressure
-Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]) {
+Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real* s) {
   return GetEosData(ptable, 0, egas, rho) * egas;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS])
+//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real* r)
 //! \brief Return interpolated internal energy density
-Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
+Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real* r) {
   return GetEosData(ptable, 1, pres, rho) * pres;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS])
+//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres, const Real* r)
 //! \brief Return interpolated adiabatic sound speed squared
-Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
+Real EquationOfState::AsqFromRhoP(Real rho, Real pres, const Real* r) {
   return GetEosData(ptable, 2, pres, rho) * pres / rho;
 }
 

--- a/src/eos/general/eos_table.cpp
+++ b/src/eos/general/eos_table.cpp
@@ -41,23 +41,23 @@ inline Real GetEosData(EosTable *ptable, int kOut, Real var, Real rho) {
 } // namespace
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas)
+//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS])
 //! \brief Return interpolated gas pressure
-Real EquationOfState::PresFromRhoEg(Real rho, Real egas) {
+Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]) {
   return GetEosData(ptable, 0, egas, rho) * egas;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres)
+//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS])
 //! \brief Return interpolated internal energy density
-Real EquationOfState::EgasFromRhoP(Real rho, Real pres) {
+Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
   return GetEosData(ptable, 1, pres, rho) * pres;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres)
+//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS])
 //! \brief Return interpolated adiabatic sound speed squared
-Real EquationOfState::AsqFromRhoP(Real rho, Real pres) {
+Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
   return GetEosData(ptable, 2, pres, rho) * pres / rho;
 }
 

--- a/src/eos/general/general_hydro.cpp
+++ b/src/eos/general/general_hydro.cpp
@@ -170,6 +170,21 @@ void EquationOfState::PrimitiveToConserved(
   return;
 }
 
+// overload eos calls without tracers for backward compatibility with pgens
+void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
+    const AthenaArray<Real> &bc, AthenaArray<Real> &cons, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
+  if (NSCALARS > 0) {
+    std::stringstream msg;
+    msg << "### FATAL ERROR in EquationOfState::PrimitiveToConserved" << std::endl
+        << "When NSCALARS>0, scalars must be passed to this function." << std::endl;
+    ATHENA_ERROR(msg);
+    return;
+  }
+  AthenaArray<Real> empty;
+  PrimitiveToConserved(prim, bc, cons, empty, empty, pco, il, iu, jl, ju, kl, ku);
+}
+
 //----------------------------------------------------------------------------------------
 //! \fn Real EquationOfState::SoundSpeed(Real prim[NHYDRO])
 //! \brief returns adiabatic sound speed given vector of primitive variables

--- a/src/eos/general/general_hydro.cpp
+++ b/src/eos/general/general_hydro.cpp
@@ -123,8 +123,8 @@ void EquationOfState::ConservedToPrimitive(
 
 //----------------------------------------------------------------------------------------
 //! \fn void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
-//!           const AthenaArray<Real> &bc, AthenaArray<Real> &cons, const AthenaArray<Real> &r,
-//!           AthenaArray<Real> &s, Coordinates *pco,
+//!           const AthenaArray<Real> &bc, AthenaArray<Real> &cons,
+//!           const AthenaArray<Real> &r,AthenaArray<Real> &s, Coordinates *pco,
 //!           int il, int iu, int jl, int ju, int kl, int ku);
 //! \brief Converts primitive variables into conservative variables
 
@@ -162,7 +162,7 @@ void EquationOfState::PrimitiveToConserved(
           r_cell[n] = r(n,k,j,i);
         }
         // cellwise conversion
-        u_e = EgasFromRhoP(u_d, w_p, r_cell) + 0.5*w_d*(SQR(w_vx) + SQR(w_vy) + SQR(w_vz));
+        u_e = EgasFromRhoP(u_d, w_p, r_cell) + 0.5*w_d*(SQR(w_vx)+SQR(w_vy)+SQR(w_vz));
       }
     }
   }

--- a/src/eos/general/general_mhd.cpp
+++ b/src/eos/general/general_mhd.cpp
@@ -184,6 +184,21 @@ void EquationOfState::PrimitiveToConserved(
   return;
 }
 
+// overload eos calls without tracers for backward compatibility with pgens
+void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
+    const AthenaArray<Real> &bc, AthenaArray<Real> &cons, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
+  if (NSCALARS > 0) {
+    std::stringstream msg;
+    msg << "### FATAL ERROR in EquationOfState::PrimitiveToConserved" << std::endl
+        << "When NSCALARS>0, scalars must be passed to this function." << std::endl;
+    ATHENA_ERROR(msg);
+    return;
+  }
+  AthenaArray<Real> empty;
+  PrimitiveToConserved(prim, bc, cons, empty, empty, pco, il, iu, jl, ju, kl, ku);
+}
+
 //----------------------------------------------------------------------------------------
 //! \fn Real EquationOfState::SoundSpeed(Real prim[NHYDRO])
 //! \brief returns adiabatic sound speed given vector of primitive variables

--- a/src/eos/general/general_mhd.cpp
+++ b/src/eos/general/general_mhd.cpp
@@ -131,8 +131,8 @@ void EquationOfState::ConservedToPrimitive(
 
 //----------------------------------------------------------------------------------------
 //! \fn void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
-//!           const AthenaArray<Real> &bc, AthenaArray<Real> &cons, const AthenaArray<Real> &r,
-//!           AthenaArray<Real> &s, Coordinates *pco,
+//!           const AthenaArray<Real> &bc, AthenaArray<Real> &cons,
+//!           const AthenaArray<Real> &r, AthenaArray<Real> &s, Coordinates *pco,
 //!           int il, int iu, int jl, int ju, int kl, int ku);
 //! \brief Converts primitive variables into conservative variables
 

--- a/src/eos/general/hydrogen.cpp
+++ b/src/eos/general/hydrogen.cpp
@@ -133,9 +133,9 @@ Real invert(Real(*f) (Real, Real), Real rho, Real sol, Real Ta, Real Tb) {
 } // namespace
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas)
+//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS])
 //! \brief Return gas pressure
-Real EquationOfState::PresFromRhoEg(Real rho, Real egas) {
+Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]) {
   rho *= rho_unit_;
   egas *= egas_unit_;
   Real es = egas / rho;
@@ -145,9 +145,9 @@ Real EquationOfState::PresFromRhoEg(Real rho, Real egas) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres)
+//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS])
 //! \brief Return internal energy density
-Real EquationOfState::EgasFromRhoP(Real rho, Real pres) {
+Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
   rho *= rho_unit_;
   pres *= egas_unit_;
   Real ps = pres / rho;
@@ -156,9 +156,9 @@ Real EquationOfState::EgasFromRhoP(Real rho, Real pres) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres)
+//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS])
 //! \brief Return adiabatic sound speed squared
-Real EquationOfState::AsqFromRhoP(Real rho, Real pres) {
+Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
   rho *= rho_unit_;
   pres *= egas_unit_;
   Real ps = pres / rho;

--- a/src/eos/general/hydrogen.cpp
+++ b/src/eos/general/hydrogen.cpp
@@ -133,9 +133,9 @@ Real invert(Real(*f) (Real, Real), Real rho, Real sol, Real Ta, Real Tb) {
 } // namespace
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS])
+//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real* s)
 //! \brief Return gas pressure
-Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]) {
+Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real* s) {
   rho *= rho_unit_;
   egas *= egas_unit_;
   Real es = egas / rho;
@@ -145,9 +145,9 @@ Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS])
+//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real* r)
 //! \brief Return internal energy density
-Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
+Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real* r) {
   rho *= rho_unit_;
   pres *= egas_unit_;
   Real ps = pres / rho;
@@ -156,9 +156,9 @@ Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS])
+//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres, const Real* r)
 //! \brief Return adiabatic sound speed squared
-Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
+Real EquationOfState::AsqFromRhoP(Real rho, Real pres, const Real* r) {
   rho *= rho_unit_;
   pres *= egas_unit_;
   Real ps = pres / rho;

--- a/src/eos/general/ideal.cpp
+++ b/src/eos/general/ideal.cpp
@@ -15,23 +15,23 @@
 #include "../eos.hpp"
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS])
+//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real* s)
 //! \brief Return gas pressure
-Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]) {
+Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real* s) {
   return (gamma_ - 1.) * egas;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS])
+//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real* r)
 //! \brief Return internal energy density
-Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
+Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real* r) {
   return pres / (gamma_ - 1.);
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS])
+//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres, const Real* r)
 //! \brief Return adiabatic sound speed squared
-Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
+Real EquationOfState::AsqFromRhoP(Real rho, Real pres, const Real* r) {
   return gamma_ * pres / rho;
 }
 

--- a/src/eos/general/ideal.cpp
+++ b/src/eos/general/ideal.cpp
@@ -15,23 +15,23 @@
 #include "../eos.hpp"
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas)
+//! \fn Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS])
 //! \brief Return gas pressure
-Real EquationOfState::PresFromRhoEg(Real rho, Real egas) {
+Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]) {
   return (gamma_ - 1.) * egas;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres)
+//! \fn Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS])
 //! \brief Return internal energy density
-Real EquationOfState::EgasFromRhoP(Real rho, Real pres) {
+Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
   return pres / (gamma_ - 1.);
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres)
+//! \fn Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS])
 //! \brief Return adiabatic sound speed squared
-Real EquationOfState::AsqFromRhoP(Real rho, Real pres) {
+Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
   return gamma_ * pres / rho;
 }
 

--- a/src/eos/general/noop.cpp
+++ b/src/eos/general/noop.cpp
@@ -51,6 +51,12 @@ Real EquationOfState::EgasFromRhoP(Real rho, Real pres) {
 Real EquationOfState::AsqFromRhoP(Real rho, Real pres) {
   return AsqFromRhoP(rho, pres, nullptr);
 }
+void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
+    const AthenaArray<Real> &bc, AthenaArray<Real> &cons, Coordinates *pco,
+    int il, int iu, int jl, int ju, int kl, int ku) {
+  AthenaArray<Real> empty;
+  PrimitiveToConserved(prim, bc, cons, empty, empty, pco, il, iu, jl, ju, kl, ku);
+}
 
 //----------------------------------------------------------------------------------------
 //! \fn void EquationOfState::InitEosConstants(ParameterInput* pin)

--- a/src/eos/general/noop.cpp
+++ b/src/eos/general/noop.cpp
@@ -19,26 +19,37 @@
 // Athena++ headers
 #include "../eos.hpp"
 
-Real EquationOfState::PresFromRhoEg(Real rho, Real egas) {
+Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]) {
   std::stringstream msg;
   msg << "### FATAL ERROR in EquationOfState::PresFromRhoEg" << std::endl
       << "Function should not be called with current configuration." << std::endl;
   ATHENA_ERROR(msg);
   return -1.0;
 }
-Real EquationOfState::EgasFromRhoP(Real rho, Real pres) {
+Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
   std::stringstream msg;
   msg << "### FATAL ERROR in EquationOfState::EgasFromRhoP" << std::endl
       << "Function should not be called with current configuration." << std::endl;
   ATHENA_ERROR(msg);
   return -1.0;
 }
-Real EquationOfState::AsqFromRhoP(Real rho, Real pres) {
+Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
   std::stringstream msg;
   msg << "### FATAL ERROR in EquationOfState::AsqFromRhoP" << std::endl
       << "Function should not be called with current configuration." << std::endl;
   ATHENA_ERROR(msg);
   return -1.0;
+}
+
+// overload eos calls without tracers for backward compatibility
+Real EquationOfState::PresFromRhoEg(Real rho, Real egas) {
+  return PresFromRhoEg(rho, egas, nullptr);
+}
+Real EquationOfState::EgasFromRhoP(Real rho, Real pres) {
+  return EgasFromRhoP(rho, pres, nullptr);
+}
+Real EquationOfState::AsqFromRhoP(Real rho, Real pres) {
+  return AsqFromRhoP(rho, pres, nullptr);
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/eos/general/noop.cpp
+++ b/src/eos/general/noop.cpp
@@ -19,21 +19,21 @@
 // Athena++ headers
 #include "../eos.hpp"
 
-Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real s[NSCALARS]) {
+Real EquationOfState::PresFromRhoEg(Real rho, Real egas, Real* s) {
   std::stringstream msg;
   msg << "### FATAL ERROR in EquationOfState::PresFromRhoEg" << std::endl
       << "Function should not be called with current configuration." << std::endl;
   ATHENA_ERROR(msg);
   return -1.0;
 }
-Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
+Real EquationOfState::EgasFromRhoP(Real rho, Real pres, Real* r) {
   std::stringstream msg;
   msg << "### FATAL ERROR in EquationOfState::EgasFromRhoP" << std::endl
       << "Function should not be called with current configuration." << std::endl;
   ATHENA_ERROR(msg);
   return -1.0;
 }
-Real EquationOfState::AsqFromRhoP(Real rho, Real pres, Real r[NSCALARS]) {
+Real EquationOfState::AsqFromRhoP(Real rho, Real pres, const Real* r) {
   std::stringstream msg;
   msg << "### FATAL ERROR in EquationOfState::AsqFromRhoP" << std::endl
       << "Function should not be called with current configuration." << std::endl;

--- a/src/eos/isothermal_hydro.cpp
+++ b/src/eos/isothermal_hydro.cpp
@@ -30,12 +30,15 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 
 //----------------------------------------------------------------------------------------
 //! \fn void EquationOfState::ConservedToPrimitive(AthenaArray<Real> &cons,
-//!           const AthenaArray<Real> &prim_old, const FaceField &b,
-//!           AthenaArray<Real> &prim, AthenaArray<Real> &bcc, Coordinates *pco,
-//!           int il, int iu, int jl, int ju, int kl, int ku)
+//!          const AthenaArray<Real> &prim_old, const FaceField &b,
+//!          AthenaArray<Real> &prim, AthenaArray<Real> &bcc, Coordinates *pco,
+//!          int il, int iu, int jl, int ju, int kl, int ku)
+//! \brief Converts conserved into primitive variables in adiabatic hydro.
+
 void EquationOfState::ConservedToPrimitive(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &b,
-    AthenaArray<Real> &prim, AthenaArray<Real> &bcc,
+    AthenaArray<Real> &prim, AthenaArray<Real> &bcc, AthenaArray<Real> &s,
+    const AthenaArray<Real> &r_old, AthenaArray<Real> &r,
     Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku) {
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -68,13 +71,14 @@ void EquationOfState::ConservedToPrimitive(
 
 //----------------------------------------------------------------------------------------
 //! \fn void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
-//!           const AthenaArray<Real> &bc, AthenaArray<Real> &cons, Coordinates *pco,
-//!           int il, int iu, int jl, int ju, int kl, int ku);
+//!          const AthenaArray<Real> &bc, AthenaArray<Real> &cons, Coordinates *pco,
+//!          int il, int iu, int jl, int ju, int kl, int ku);
 //! \brief Converts primitive variables into conservative variables
 
 void EquationOfState::PrimitiveToConserved(
     const AthenaArray<Real> &prim, const AthenaArray<Real> &bc,
-    AthenaArray<Real> &cons, Coordinates *pco,
+    AthenaArray<Real> &cons, const AthenaArray<Real> &r,
+    AthenaArray<Real> &s, Coordinates *pco,
     int il, int iu, int jl, int ju, int kl, int ku) {
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {

--- a/src/eos/isothermal_mhd.cpp
+++ b/src/eos/isothermal_mhd.cpp
@@ -31,15 +31,15 @@ EquationOfState::EquationOfState(MeshBlock *pmb, ParameterInput *pin) :
 
 //----------------------------------------------------------------------------------------
 //! \fn void EquationOfState::ConservedToPrimitive(AthenaArray<Real> &cons,
-//!    const AthenaArray<Real> &prim_old, const FaceField &b,
-//!    AthenaArray<Real> &prim, AthenaArray<Real> &bcc, Coordinates *pco,
-//!    int il, int iu, int jl, int ju, int kl, int ku);
-//! \brief For the Hydro, converts conserved into primitive variables in adiabatic MHD.
-//!  For the Field, computes cell-centered from face-centered magnetic field.
+//!          const AthenaArray<Real> &prim_old, const FaceField &b,
+//!          AthenaArray<Real> &prim, AthenaArray<Real> &bcc, Coordinates *pco,
+//!          int il, int iu, int jl, int ju, int kl, int ku)
+//! \brief Converts conserved into primitive variables in adiabatic hydro.
 
 void EquationOfState::ConservedToPrimitive(
     AthenaArray<Real> &cons, const AthenaArray<Real> &prim_old, const FaceField &b,
-    AthenaArray<Real> &prim, AthenaArray<Real> &bcc,
+    AthenaArray<Real> &prim, AthenaArray<Real> &bcc, AthenaArray<Real> &s,
+    const AthenaArray<Real> &r_old, AthenaArray<Real> &r,
     Coordinates *pco, int il, int iu, int jl, int ju, int kl, int ku) {
   pmy_block_->pfield->CalculateCellCenteredField(b,bcc,pco,il,iu,jl,ju,kl,ku);
 
@@ -74,14 +74,14 @@ void EquationOfState::ConservedToPrimitive(
 
 //----------------------------------------------------------------------------------------
 //! \fn void EquationOfState::PrimitiveToConserved(const AthenaArray<Real> &prim,
-//!           const AthenaArray<Real> &bc, AthenaArray<Real> &cons, Coordinates *pco,
-//!           int il, int iu, int jl, int ju, int kl, int ku);
+//!          const AthenaArray<Real> &bc, AthenaArray<Real> &cons, Coordinates *pco,
+//!          int il, int iu, int jl, int ju, int kl, int ku);
 //! \brief Converts primitive variables into conservative variables
-//!        Note that this function assumes cell-centered fields are already calculated
 
 void EquationOfState::PrimitiveToConserved(
     const AthenaArray<Real> &prim, const AthenaArray<Real> &bc,
-    AthenaArray<Real> &cons, Coordinates *pco,
+    AthenaArray<Real> &cons, const AthenaArray<Real> &r,
+    AthenaArray<Real> &s, Coordinates *pco,
     int il, int iu, int jl, int ju, int kl, int ku) {
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {

--- a/src/hydro/calculate_fluxes.cpp
+++ b/src/hydro/calculate_fluxes.cpp
@@ -34,11 +34,22 @@
 //! \brief Calculate Hydrodynamic Fluxes using the Riemann solver
 
 void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
-                            AthenaArray<Real> &bcc, const int order) {
+                            AthenaArray<Real> &bcc, AthenaArray<Real> &r,
+                            const int order) {
   MeshBlock *pmb = pmy_block;
   int is = pmb->is; int js = pmb->js; int ks = pmb->ks;
   int ie = pmb->ie; int je = pmb->je; int ke = pmb->ke;
   int il, iu, jl, ju, kl, ku;
+
+  // scalars
+  PassiveScalars *ps = pmb->pscalars;
+  AthenaArray<Real> &rl_ = ps->rl_;
+  AthenaArray<Real> &rr_ = ps->rr_;
+  AthenaArray<Real> &rlb_ = ps->rlb_;
+  AthenaArray<Real> &rl3d_ = ps->rl3d_;
+  AthenaArray<Real> &rr3d_ = ps->rr3d_;
+  AthenaArray<Real> &s_flux_fc = ps->scr1_nkji_;
+  AthenaArray<Real> &s_laplacian_all_fc = ps->scr2_nkji_;
 
   // b,bcc are passed as fn parameters becausse clients may want to pass different bcc1,
   // b1, b2, etc., but the remaining members of the Field class are accessed directly via
@@ -62,6 +73,8 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
   // i-direction
 
   AthenaArray<Real> &x1flux = flux[X1DIR];
+  AthenaArray<Real> &s_x1flux = ps->s_flux[X1DIR];
+
   // set the loop limits
   jl = js, ju = je, kl = ks, ku = ke;
   if (MAGNETIC_FIELDS_ENABLED || order == 4) {
@@ -78,19 +91,30 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
       // reconstruct L/R states
       if (order == 1) {
         pmb->precon->DonorCellX1(k, j, is-1, ie+1, w, bcc, wl_, wr_);
+        pmb->precon->DonorCellX1(k, j, is-1, ie+1, r, rl_, rr_);
       } else if (order == 2) {
         pmb->precon->PiecewiseLinearX1(k, j, is-1, ie+1, w, bcc, wl_, wr_);
+        pmb->precon->PiecewiseLinearX1(k, j, is-1, ie+1, r, rl_, rr_);
       } else {
         pmb->precon->PiecewiseParabolicX1(k, j, is-1, ie+1, w, bcc, wl_, wr_);
+        pmb->precon->PiecewiseParabolicX1(k, j, is-1, ie+1, r, rl_, rr_);
+        for (int n=0; n<NSCALARS; ++n) {
+#pragma omp simd
+          for (int i=is; i<=ie+1; ++i) {
+            pmb->peos->ApplyPassiveScalarFloors(rl_, n, k, j, i);
+            pmb->peos->ApplyPassiveScalarFloors(rr_, n, k, j, i);
+          }
+        }
       }
 
       pmb->pcoord->CenterWidth1(k, j, is, ie+1, dxw_);
 #if !MAGNETIC_FIELDS_ENABLED  // Hydro:
-      RiemannSolver(k, j, is, ie+1, IVX, wl_, wr_, x1flux, dxw_);
+      RiemannSolver(k, j, is, ie+1, IVX, wl_, wr_, x1flux, dxw_, rl_, rr_, s_x1flux);
 #else  // MHD:
       // x1flux(IBY) = (v1*b2 - v2*b1) = -EMFZ
       // x1flux(IBZ) = (v1*b3 - v3*b1) =  EMFY
-      RiemannSolver(k, j, is, ie+1, IVX, b1, wl_, wr_, x1flux, e3x1, e2x1, w_x1f, dxw_);
+      RiemannSolver(k, j, is, ie+1, IVX, b1, wl_, wr_, x1flux, e3x1, e2x1, w_x1f, dxw_,
+                    rl_, rr_, s1x1flux);
 #endif
 
       if (order == 4) {
@@ -98,6 +122,12 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
           for (int i=is; i<=ie+1; i++) {
             wl3d_(n,k,j,i) = wl_(n,i);
             wr3d_(n,k,j,i) = wr_(n,i);
+          }
+        }
+        for (int n=0; n<NSCALARS; n++) {
+          for (int i=is; i<=ie+1; i++) {
+            rl3d_(n,k,j,i) = rl_(n,i);
+            rr3d_(n,k,j,i) = rr_(n,i);
           }
         }
       }
@@ -112,6 +142,8 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
 
     // construct Laplacian from x1flux
     pmb->pcoord->LaplacianX1All(x1flux, laplacian_all_fc, 0, NHYDRO-1,
+                                kl, ku, jl, ju, is, ie+1);
+    pmb->pcoord->LaplacianX1All(x1flux, s_laplacian_all_fc, 0, NSCALARS-1,
                                 kl, ku, jl, ju, is, ie+1);
 
     for (int k=kl; k<=ku; ++k) {
@@ -131,26 +163,39 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
           pmb->peos->ApplyPrimitiveFloors(wl_, k, j, i);
           pmb->peos->ApplyPrimitiveFloors(wr_, k, j, i);
         }
+        // repeat for scalars
+        for (int n=0; n<NSCALARS; ++n) {
+          pmb->pcoord->LaplacianX1(rl3d_, ps->laplacian_l_fc_, n, k, j, is, ie+1);
+          pmb->pcoord->LaplacianX1(rr3d_, ps->laplacian_r_fc_, n, k, j, is, ie+1);
+#pragma omp simd
+          for (int i=is; i<=ie+1; ++i) {
+            rl_(n,i) = rl3d_(n,k,j,i) - C*ps->laplacian_l_fc_(i);
+            rr_(n,i) = rr3d_(n,k,j,i) - C*ps->laplacian_r_fc_(i);
+            pmb->peos->ApplyPassiveScalarFloors(rl_, n, k, j, i);
+            pmb->peos->ApplyPassiveScalarFloors(rr_, n, k, j, i);
+          }
+        }
 
         // Compute x1 interface fluxes from face-centered primitive variables
         // TODO(felker): check that e3x1,e2x1 arguments added in late 2017 work here
         pmb->pcoord->CenterWidth1(k, j, is, ie+1, dxw_);
 #if !MAGNETIC_FIELDS_ENABLED  // Hydro:
-        RiemannSolver(k, j, is, ie+1, IVX, wl_, wr_, flux_fc, dxw_);
+        RiemannSolver(k, j, is, ie+1, IVX, wl_, wr_, flux_fc, dxw_, rl_, rr_, s_flux_fc);
 #else  // MHD:
         RiemannSolver(k, j, is, ie+1, IVX, b1, wl_, wr_, flux_fc, e3x1, e2x1,
-                      w_x1f, dxw_);
+                      w_x1f, dxw_, rl_, rr_, s_flux_fc);
 #endif
         // Apply Laplacian of second-order accurate face-averaged flux on x1 faces
         for (int n=0; n<NHYDRO; ++n) {
 #pragma omp simd
           for (int i=is; i<=ie+1; i++) {
             x1flux(n,k,j,i) = flux_fc(n,k,j,i) + C*laplacian_all_fc(n,k,j,i);
-            // TODO(felker): replace this loop-based deep copy with memcpy, or alternative
-            if (n == IDN && NSCALARS > 0) {
-              pmb->pscalars->mass_flux_fc[X1DIR](k,j,i) = flux_fc(n,k,j,i);
-            }
           }
+        }
+        for (int n=0; n<NSCALARS; ++n) {
+#pragma omp simd
+          for (int i=is; i<=ie+1; i++)
+            s_x1flux(n,k,j,i) = s_flux_fc(n,k,j,i) + C*s_laplacian_all_fc(n,k,j,i);
         }
       }
     }
@@ -163,6 +208,7 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
 
   if (pmb->pmy_mesh->f2) {
     AthenaArray<Real> &x2flux = flux[X2DIR];
+    AthenaArray<Real> &s_x2flux = ps->s_flux[X2DIR];
     // set the loop limits
     il = is-1, iu = ie+1, kl = ks, ku = ke;
     if (MAGNETIC_FIELDS_ENABLED || order == 4) {
@@ -176,28 +222,49 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
       // reconstruct the first row
       if (order == 1) {
         pmb->precon->DonorCellX2(k, js-1, il, iu, w, bcc, wl_, wr_);
+        pmb->precon->DonorCellX2(k, js-1, il, iu, r, rl_, rr_);
       } else if (order == 2) {
         pmb->precon->PiecewiseLinearX2(k, js-1, il, iu, w, bcc, wl_, wr_);
+        pmb->precon->PiecewiseLinearX2(k, js-1, il, iu, r, rl_, rr_);
       } else {
         pmb->precon->PiecewiseParabolicX2(k, js-1, il, iu, w, bcc, wl_, wr_);
+        pmb->precon->PiecewiseParabolicX2(k, js-1, il, iu, r, rl_, rr_);
+        for (int n=0; n<NSCALARS; ++n) {
+#pragma omp simd
+          for (int i=il; i<=iu; ++i) {
+            pmb->peos->ApplyPassiveScalarFloors(rl_, n, k, js-1, i);
+            //pmb->peos->ApplyPassiveScalarFloors(rr_, n, k, j, i);
+          }
+        }
       }
       for (int j=js; j<=je+1; ++j) {
         // reconstruct L/R states at j
         if (order == 1) {
           pmb->precon->DonorCellX2(k, j, il, iu, w, bcc, wlb_, wr_);
+          pmb->precon->DonorCellX2(k, j, il, iu, r, rlb_, rr_);
         } else if (order == 2) {
           pmb->precon->PiecewiseLinearX2(k, j, il, iu, w, bcc, wlb_, wr_);
+          pmb->precon->PiecewiseLinearX2(k, j, il, iu, r, rlb_, rr_);
         } else {
           pmb->precon->PiecewiseParabolicX2(k, j, il, iu, w, bcc, wlb_, wr_);
+          pmb->precon->PiecewiseParabolicX2(k, j, il, iu, r, rlb_, rr_);
+          for (int n=0; n<NSCALARS; ++n) {
+#pragma omp simd
+            for (int i=il; i<=iu; ++i) {
+              pmb->peos->ApplyPassiveScalarFloors(rlb_, n, k, j, i);
+              pmb->peos->ApplyPassiveScalarFloors(rr_, n, k, j, i);
+            }
+          }
         }
 
         pmb->pcoord->CenterWidth2(k, j, il, iu, dxw_);
 #if !MAGNETIC_FIELDS_ENABLED  // Hydro:
-        RiemannSolver(k, j, il, iu, IVY, wl_, wr_, x2flux, dxw_);
+        RiemannSolver(k, j, il, iu, IVY, wl_, wr_, x2flux, dxw_, rl_, rr_, s_x2flux);
 #else  // MHD:
         // flx(IBY) = (v2*b3 - v3*b2) = -EMFX
         // flx(IBZ) = (v2*b1 - v1*b2) =  EMFZ
-        RiemannSolver(k, j, il, iu, IVY, b2, wl_, wr_, x2flux, e1x2, e3x2, w_x2f, dxw_);
+        RiemannSolver(k, j, il, iu, IVY, b2, wl_, wr_, x2flux, e1x2, e3x2, w_x2f, dxw_,
+                      rl_, rr_, s_x2flux);
 #endif
 
         if (order == 4) {
@@ -207,10 +274,17 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
               wr3d_(n,k,j,i) = wr_(n,i);
             }
           }
+          for (int n=0; n<NSCALARS; n++) {
+            for (int i=il; i<=iu; i++) {
+              rl3d_(n,k,j,i) = rl_(n,i);
+              rr3d_(n,k,j,i) = rr_(n,i);
+            }
+          }
         }
 
         // swap the arrays for the next step
         wl_.SwapAthenaArray(wlb_);
+        rl_.SwapAthenaArray(rlb_);
       }
     }
     if (order == 4) {
@@ -221,6 +295,8 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
 
       // construct Laplacian from x2flux
       pmb->pcoord->LaplacianX2All(x2flux, laplacian_all_fc, 0, NHYDRO-1,
+                                  kl, ku, js, je+1, il, iu);
+      pmb->pcoord->LaplacianX2All(s_x2flux, s_laplacian_all_fc, 0, NSCALARS-1,
                                   kl, ku, js, je+1, il, iu);
 
       // Approximate x2 face-centered primitive Riemann states
@@ -241,15 +317,26 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
             pmb->peos->ApplyPrimitiveFloors(wl_, k, j, i);
             pmb->peos->ApplyPrimitiveFloors(wr_, k, j, i);
           }
+          for (int n=0; n<NSCALARS; ++n) {
+            pmb->pcoord->LaplacianX2(rl3d_, ps->laplacian_l_fc_, n, k, j, il, iu);
+            pmb->pcoord->LaplacianX2(rr3d_, ps->laplacian_r_fc_, n, k, j, il, iu);
+#pragma omp simd
+            for (int i=il; i<=iu; ++i) {
+              rl_(n,i) = rl3d_(n,k,j,i) - C*ps->laplacian_l_fc_(i);
+              rr_(n,i) = rr3d_(n,k,j,i) - C*ps->laplacian_r_fc_(i);
+              pmb->peos->ApplyPassiveScalarFloors(rl_, n, k, j, i);
+              pmb->peos->ApplyPassiveScalarFloors(rr_, n, k, j, i);
+            }
+          }
 
           // Compute x2 interface fluxes from face-centered primitive variables
           // TODO(felker): check that e1x2,e3x2 arguments added in late 2017 work here
           pmb->pcoord->CenterWidth2(k, j, il, iu, dxw_);
 #if !MAGNETIC_FIELDS_ENABLED  // Hydro:
-          RiemannSolver(k, j, il, iu, IVY, wl_, wr_, flux_fc, dxw_);
+          RiemannSolver(k, j, il, iu, IVY, wl_, wr_, flux_fc, dxw_, rl_, rr_, s_flux_fc);
 #else  // MHD:
           RiemannSolver(k, j, il, iu, IVY, b2, wl_, wr_, flux_fc, e1x2, e3x2,
-                        w_x2f, dxw_);
+                        w_x2f, dxw_, rl_, rr_, s_flux_fc);
 #endif
 
           // Apply Laplacian of second-order accurate face-averaged flux on x1 faces
@@ -257,11 +344,13 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
 #pragma omp simd
             for (int i=il; i<=iu; i++) {
               x2flux(n,k,j,i) = flux_fc(n,k,j,i) + C*laplacian_all_fc(n,k,j,i);
-              if (n == IDN && NSCALARS > 0) {
-                pmb->pscalars->mass_flux_fc[X2DIR](k,j,i) = flux_fc(n,k,j,i);
-              }
             }
           }
+          for (int n=0; n<NSCALARS; ++n) {
+#pragma omp simd
+            for (int i=il; i<=iu; i++)
+              s_x2flux(n,k,j,i) = s_flux_fc(n,k,j,i) + C*laplacian_all_fc(n,k,j,i);
+            }
         }
       }
     } // end if (order == 4)
@@ -272,6 +361,7 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
 
   if (pmb->pmy_mesh->f3) {
     AthenaArray<Real> &x3flux = flux[X3DIR];
+    AthenaArray<Real> &s_x3flux = ps->s_flux[X3DIR];
     // set the loop limits
     il = is, iu = ie, jl = js, ju = je;
     if (MAGNETIC_FIELDS_ENABLED || order == 4) {
@@ -282,28 +372,49 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
       // reconstruct the first row
       if (order == 1) {
         pmb->precon->DonorCellX3(ks-1, j, il, iu, w, bcc, wl_, wr_);
+        pmb->precon->DonorCellX3(ks-1, j, il, iu, r, rl_, rr_);
       } else if (order == 2) {
         pmb->precon->PiecewiseLinearX3(ks-1, j, il, iu, w, bcc, wl_, wr_);
+        pmb->precon->PiecewiseLinearX3(ks-1, j, il, iu, r, rl_, rr_);
       } else {
         pmb->precon->PiecewiseParabolicX3(ks-1, j, il, iu, w, bcc, wl_, wr_);
+        pmb->precon->PiecewiseParabolicX3(ks-1, j, il, iu, r, rl_, rr_);
+        for (int n=0; n<NSCALARS; ++n) {
+#pragma omp simd
+          for (int i=il; i<=iu; ++i) {
+            pmb->peos->ApplyPassiveScalarFloors(rl_, n, ks-1, j, i);
+            //pmb->peos->ApplyPassiveScalarFloors(rr_, n, k, j, i);
+          }
+        }
       }
       for (int k=ks; k<=ke+1; ++k) {
         // reconstruct L/R states at k
         if (order == 1) {
           pmb->precon->DonorCellX3(k, j, il, iu, w, bcc, wlb_, wr_);
+          pmb->precon->DonorCellX3(k, j, il, iu, r, rlb_, rr_);
         } else if (order == 2) {
           pmb->precon->PiecewiseLinearX3(k, j, il, iu, w, bcc, wlb_, wr_);
+          pmb->precon->PiecewiseLinearX3(k, j, il, iu, r, rlb_, rr_);
         } else {
           pmb->precon->PiecewiseParabolicX3(k, j, il, iu, w, bcc, wlb_, wr_);
+          pmb->precon->PiecewiseParabolicX3(k, j, il, iu, r, rlb_, rr_);
+          for (int n=0; n<NSCALARS; ++n) {
+#pragma omp simd
+            for (int i=il; i<=iu; ++i) {
+              pmb->peos->ApplyPassiveScalarFloors(rlb_, n, k, j, i);
+              pmb->peos->ApplyPassiveScalarFloors(rr_, n, k, j, i);
+            }
+          }
         }
 
         pmb->pcoord->CenterWidth3(k, j, il, iu, dxw_);
 #if !MAGNETIC_FIELDS_ENABLED  // Hydro:
-        RiemannSolver(k, j, il, iu, IVZ, wl_, wr_, x3flux, dxw_);
+        RiemannSolver(k, j, il, iu, IVZ, wl_, wr_, x3flux, dxw_, rl_, rr_, s_x3flux);
 #else  // MHD:
         // flx(IBY) = (v3*b1 - v1*b3) = -EMFY
         // flx(IBZ) = (v3*b2 - v2*b3) =  EMFX
-        RiemannSolver(k, j, il, iu, IVZ, b3, wl_, wr_, x3flux, e2x3, e1x3, w_x3f, dxw_);
+        RiemannSolver(k, j, il, iu, IVZ, b3, wl_, wr_, x3flux, e2x3, e1x3, w_x3f, dxw_,
+                      rl_, rr_, s_x3flux);
 #endif
         if (order == 4) {
           for (int n=0; n<NWAVE; n++) {
@@ -312,10 +423,17 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
               wr3d_(n,k,j,i) = wr_(n,i);
             }
           }
+          for (int n=0; n<NSCALARS; n++) {
+            for (int i=il; i<=iu; i++) {
+              rl3d_(n,k,j,i) = rl_(n,i);
+              rr3d_(n,k,j,i) = rr_(n,i);
+            }
+          }
         }
 
         // swap the arrays for the next step
         wl_.SwapAthenaArray(wlb_);
+        rl_.SwapAthenaArray(rlb_);
       }
     }
     if (order == 4) {
@@ -326,6 +444,8 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
 
       // construct Laplacian from x3flux
       pmb->pcoord->LaplacianX3All(x3flux, laplacian_all_fc, 0, NHYDRO-1,
+                                  ks, ke+1, jl, ju, il, iu);
+      pmb->pcoord->LaplacianX3All(s_x3flux, s_laplacian_all_fc, 0, NSCALARS-1,
                                   ks, ke+1, jl, ju, il, iu);
 
       // Approximate x3 face-centered primitive Riemann states
@@ -346,25 +466,38 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
             pmb->peos->ApplyPrimitiveFloors(wl_, k, j, i);
             pmb->peos->ApplyPrimitiveFloors(wr_, k, j, i);
           }
+          for (int n=0; n<NSCALARS; ++n) {
+            pmb->pcoord->LaplacianX3(rl3d_, laplacian_l_fc_, n, k, j, il, iu);
+            pmb->pcoord->LaplacianX3(rr3d_, laplacian_r_fc_, n, k, j, il, iu);
+#pragma omp simd
+            for (int i=il; i<=iu; ++i) {
+              rl_(n,i) = rl3d_(n,k,j,i) - C*laplacian_l_fc_(i);
+              rr_(n,i) = rr3d_(n,k,j,i) - C*laplacian_r_fc_(i);
+              pmb->peos->ApplyPassiveScalarFloors(rl_, n, k, j, i);
+              pmb->peos->ApplyPassiveScalarFloors(rr_, n, k, j, i);
+            }
+          }
 
           // Compute x3 interface fluxes from face-centered primitive variables
           // TODO(felker): check that e2x3,e1x3 arguments added in late 2017 work here
           pmb->pcoord->CenterWidth3(k, j, il, iu, dxw_);
 #if !MAGNETIC_FIELDS_ENABLED  // Hydro:
-          RiemannSolver(k, j, il, iu, IVZ, wl_, wr_, flux_fc, dxw_);
+          RiemannSolver(k, j, il, iu, IVZ, wl_, wr_, flux_fc, dxw_, rl_, rr_, s_flux_fc);
 #else  // MHD:
           RiemannSolver(k, j, il, iu, IVZ, b3, wl_, wr_, flux_fc, e2x3, e1x3,
-                        w_x3f, dxw_);
+                        w_x3f, dxw_, rl_, rr_, s_flux_fc);
 #endif
           // Apply Laplacian of second-order accurate face-averaged flux on x3 faces
           for (int n=0; n<NHYDRO; ++n) {
 #pragma omp simd
             for (int i=il; i<=iu; i++) {
               x3flux(n,k,j,i) = flux_fc(n,k,j,i) + C*laplacian_all_fc(n,k,j,i);
-              if (n == IDN && NSCALARS > 0) {
-                pmb->pscalars->mass_flux_fc[X3DIR](k,j,i) = flux_fc(n,k,j,i);
-              }
             }
+          }
+          for (int n=0; n<NSCALARS; ++n) {
+#pragma omp simd
+            for (int i=il; i<=iu; i++)
+              s_x3flux(n,k,j,i) = s_flux_fc(n,k,j,i) + C*s_laplacian_all_fc(n,k,j,i);
           }
         }
       }
@@ -373,6 +506,7 @@ void Hydro::CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
 
   if (!STS_ENABLED)
     AddDiffusionFluxes();
+    ps->AddDiffusionFluxes();
 
   return;
 }

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -69,22 +69,24 @@ class Hydro {
                              AthenaArray<Real> &u_out,
                              AthenaArray<Real> &fl_div_out,
                              std::vector<int> idx_subset);
-  void CalculateFluxes(AthenaArray<Real> &w, FaceField &b,
-                       AthenaArray<Real> &bcc, const int order);
+  void CalculateFluxes(AthenaArray<Real> &w, FaceField &b, AthenaArray<Real> &bcc,
+                       AthenaArray<Real> &r, const int order);
   void CalculateFluxes_STS();
 #if !MAGNETIC_FIELDS_ENABLED  // Hydro:
   void RiemannSolver(
       const int k, const int j, const int il, const int iu,
       const int ivx,
       AthenaArray<Real> &wl, AthenaArray<Real> &wr, AthenaArray<Real> &flx,
-      const AthenaArray<Real> &dxw);
+      const AthenaArray<Real> &dxw, AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+      AthenaArray<Real> &sflx);
 #else  // MHD:
   void RiemannSolver(
       const int k, const int j, const int il, const int iu,
       const int ivx, const AthenaArray<Real> &bx,
       AthenaArray<Real> &wl, AthenaArray<Real> &wr, AthenaArray<Real> &flx,
       AthenaArray<Real> &ey, AthenaArray<Real> &ez,
-      AthenaArray<Real> &wct, const AthenaArray<Real> &dxw);
+      AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+      AthenaArray<Real> &rl, AthenaArray<Real> &rr, AthenaArray<Real> &sflx);
 #endif
   void CalculateVelocityDifferences(const int k, const int j, const int il, const int iu,
     const int ivx, AthenaArray<Real> &dvn, AthenaArray<Real> &dvt);

--- a/src/hydro/rsolvers/hydro/hllc_rel.cpp
+++ b/src/hydro/rsolvers/hydro/hllc_rel.cpp
@@ -18,6 +18,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 namespace {

--- a/src/hydro/rsolvers/hydro/hllc_rel.cpp
+++ b/src/hydro/rsolvers/hydro/hllc_rel.cpp
@@ -38,7 +38,9 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 //! \fn void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 //!                           const int ivx,
 //!                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw)
+//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+//!                           const AthenaArray<Real> &rl, const AthenaArray<Real> &rl,
+//!                           const AthenaArray<Real> &sflx)
 //! \brief Riemann solver
 //!
 //! Inputs:
@@ -59,11 +61,18 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx,
                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   if (GENERAL_RELATIVITY && ivx == IVY && pmy_block->pcoord->IsPole(j)) {
     HLLENonTransforming(pmy_block, k, j, il, iu, g_, gi_, prim_l, prim_r, flux);
   } else {
     HLLCTransforming(pmy_block, k, j, il, iu, ivx, g_, gi_, prim_l, prim_r, cons_, flux);
+  }
+  if (NSCALARS) {
+    AthenaArray<Real> mflux;
+    mflux.InitWithShallowSlice(flux, 4, IDN, 1);
+    pmy_block->pscalars->ComputeUpwindFlux(k, j, il, iu, rl, rr, mflux, sflx);
   }
   return;
 }

--- a/src/hydro/rsolvers/hydro/hlle.cpp
+++ b/src/hydro/rsolvers/hydro/hlle.cpp
@@ -43,6 +43,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
   Real wli[(NHYDRO+NSCALARS*GENERAL_EOS)],wri[(NHYDRO+NSCALARS*GENERAL_EOS)];
+  Real wroe[(NHYDRO)];
   Real fl[(NHYDRO)],fr[(NHYDRO)],flxi[(NHYDRO)];
   Real iso_cs = pmy_block->peos->GetIsoSoundSpeed();
   Real gamma;

--- a/src/hydro/rsolvers/hydro/hlle_rel.cpp
+++ b/src/hydro/rsolvers/hydro/hlle_rel.cpp
@@ -18,6 +18,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 namespace {

--- a/src/hydro/rsolvers/hydro/hlle_rel.cpp
+++ b/src/hydro/rsolvers/hydro/hlle_rel.cpp
@@ -38,7 +38,9 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 //! \fn void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 //!                           const int ivx,
 //!                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw)
+//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+//!                           const AthenaArray<Real> &rl, const AthenaArray<Real> &rl,
+//!                           const AthenaArray<Real> &sflx)
 //! \brief Riemann solver
 //!
 //! Inputs:
@@ -58,11 +60,18 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx,
                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   if (GENERAL_RELATIVITY && ivx == IVY && pmy_block->pcoord->IsPole(j)) {
     HLLENonTransforming(pmy_block, k, j, il, iu, g_, gi_, prim_l, prim_r, flux);
   } else {
     HLLETransforming(pmy_block, k, j, il, iu, ivx, g_, gi_, prim_l, prim_r, cons_, flux);
+  }
+  if (NSCALARS) {
+    AthenaArray<Real> mflux;
+    mflux.InitWithShallowSlice(flux, 4, IDN, 1);
+    pmy_block->pscalars->ComputeUpwindFlux(k, j, il, iu, rl, rr, mflux, sflx);
   }
   return;
 }

--- a/src/hydro/rsolvers/hydro/hlle_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/hydro/hlle_rel_no_transform.cpp
@@ -24,7 +24,9 @@
 //! \fn void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 //!                           const int ivx,
 //!                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw)
+//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+//!                           const AthenaArray<Real> &rl, const AthenaArray<Real> &rl,
+//!                           const AthenaArray<Real> &sflx)
 //! \brief Riemann solver
 //!
 //! Inputs:
@@ -42,7 +44,9 @@
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx,
                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   // Calculate cyclic permutations of indices
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
@@ -209,6 +213,11 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     for (int n = 0; n < NHYDRO; ++n) {
       flux(n,k,j,i) = flux_interface[n];
     }
+  }
+  if (NSCALARS) {
+    AthenaArray<Real> mflux;
+    mflux.InitWithShallowSlice(flux, 4, IDN, 1);
+    pmy_block->pscalars->ComputeUpwindFlux(k, j, il, iu, rl, rr, mflux, sflx);
   }
   return;
 }

--- a/src/hydro/rsolvers/hydro/hlle_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/hydro/hlle_rel_no_transform.cpp
@@ -18,6 +18,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 //----------------------------------------------------------------------------------------

--- a/src/hydro/rsolvers/hydro/lhllc.cpp
+++ b/src/hydro/rsolvers/hydro/lhllc.cpp
@@ -26,10 +26,11 @@
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx, AthenaArray<Real> &wl,
                           AthenaArray<Real> &wr, AthenaArray<Real> &flx,
-                          const AthenaArray<Real> &dxw) {
+                          const AthenaArray<Real> &dxw, AthenaArray<Real> &rl,
+                          AthenaArray<Real> &rr, AthenaArray<Real> &sflx) {
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
-  Real wli[(NHYDRO)],wri[(NHYDRO)];
+  Real wli[(NHYDRO+NSCALARS*GENERAL_EOS)],wri[(NHYDRO+NSCALARS*GENERAL_EOS)];
   Real flxi[(NHYDRO)],fl[(NHYDRO)],fr[(NHYDRO)];
   Real gamma;
   if (GENERAL_EOS) {
@@ -58,6 +59,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     wri[IVZ]=wr(ivz,i);
     wri[IPR]=wr(IPR,i);
 
+    if (GENERAL_EOS) {
+      for (int n=0; n<NSCALARS; ++n) {
+        wli[NHYDRO+n]=rl(n,i);
+        wri[NHYDRO+n]=rr(n,i);
+      }
+    }
+
     //--- Step 2.  Compute middle state estimates with PVRS (Toro 10.5.2)
 
     Real al, ar, el, er;
@@ -66,8 +74,10 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     Real vsql = SQR(wli[IVX]) + SQR(wli[IVY]) + SQR(wli[IVZ]);
     Real vsqr = SQR(wri[IVX]) + SQR(wri[IVY]) + SQR(wri[IVZ]);
     if (GENERAL_EOS) {
-      el = pmy_block->peos->EgasFromRhoP(wli[IDN], wli[IPR]) + 0.5*wli[IDN]*vsql;
-      er = pmy_block->peos->EgasFromRhoP(wri[IDN], wri[IPR]) + 0.5*wri[IDN]*vsqr;
+      el = pmy_block->peos->EgasFromRhoP(wli[IDN], wli[IPR], wli + NHYDRO) +
+           0.5*wli[IDN]*vsql;
+      er = pmy_block->peos->EgasFromRhoP(wri[IDN], wri[IPR], wri + NHYDRO) +
+           0.5*wri[IDN]*vsqr;
     } else {
       el = wli[IPR]*igm1 + 0.5*wli[IDN]*vsql;
       er = wri[IPR]*igm1 + 0.5*wri[IDN]*vsqr;
@@ -83,8 +93,8 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
     Real ql, qr;
     if (GENERAL_EOS) {
-      Real gl = pmy_block->peos->AsqFromRhoP(rhol, pmid) * rhol / pmid;
-      Real gr = pmy_block->peos->AsqFromRhoP(rhor, pmid) * rhor / pmid;
+      Real gl = pmy_block->peos->AsqFromRhoP(rhol, pmid, wli + NHYDRO) * rhol / pmid;
+      Real gr = pmy_block->peos->AsqFromRhoP(rhor, pmid, wri + NHYDRO) * rhor / pmid;
       ql = (pmid <= wli[IPR]) ? 1.0 :
            std::sqrt(1.0 + (gl + 1) / (2 * gl) * (pmid / wli[IPR]-1.0));
       qr = (pmid <= wri[IPR]) ? 1.0 :
@@ -177,6 +187,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     flx(ivy,k,j,i) = flxi[IVY];
     flx(ivz,k,j,i) = flxi[IVZ];
     flx(IEN,k,j,i) = flxi[IEN];
+
+    for (int n=0; n<NSCALARS; n++) {
+      if (flx(IDN,k,j,i) >= 0.0)
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rl(n,i);
+      else
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rr(n,i);
+    }
   }
   return;
 }

--- a/src/hydro/rsolvers/hydro/llf.cpp
+++ b/src/hydro/rsolvers/hydro/llf.cpp
@@ -39,6 +39,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
   Real wli[(NHYDRO+NSCALARS*GENERAL_EOS)],wri[(NHYDRO+NSCALARS*GENERAL_EOS)];
+  Real du[(NHYDRO)];
   Real fl[(NHYDRO)],fr[(NHYDRO)],flxi[(NHYDRO)];
   Real gm1 = pmy_block->peos->GetGamma() - 1.0;
   Real iso_cs = pmy_block->peos->GetIsoSoundSpeed();

--- a/src/hydro/rsolvers/hydro/llf.cpp
+++ b/src/hydro/rsolvers/hydro/llf.cpp
@@ -32,12 +32,13 @@
 //! \brief The LLF Riemann solver for hydrodynamics (both adiabatic and isothermal)
 
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
-                          const int ivx,
-                          AthenaArray<Real> &wl, AthenaArray<Real> &wr,
-                          AthenaArray<Real> &flx, const AthenaArray<Real> &dxw) {
+                          const int ivx, AthenaArray<Real> &wl,
+                          AthenaArray<Real> &wr, AthenaArray<Real> &flx,
+                          const AthenaArray<Real> &dxw, AthenaArray<Real> &rl,
+                          AthenaArray<Real> &rr, AthenaArray<Real> &sflx) {
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
-  Real wli[(NHYDRO)],wri[(NHYDRO)],du[(NHYDRO)];
+  Real wli[(NHYDRO+NSCALARS*GENERAL_EOS)],wri[(NHYDRO+NSCALARS*GENERAL_EOS)];
   Real fl[(NHYDRO)],fr[(NHYDRO)],flxi[(NHYDRO)];
   Real gm1 = pmy_block->peos->GetGamma() - 1.0;
   Real iso_cs = pmy_block->peos->GetIsoSoundSpeed();
@@ -56,6 +57,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     wri[IVY]=wr(ivy,i);
     wri[IVZ]=wr(ivz,i);
     if (NON_BAROTROPIC_EOS) wri[IPR]=wr(IPR,i);
+
+    if (GENERAL_EOS) {
+      for (int n=0; n<NSCALARS; ++n) {
+        wli[NHYDRO+n]=rl(n,i);
+        wri[NHYDRO+n]=rr(n,i);
+      }
+    }
 
     //--- Step 2.  Compute wave speeds in L,R states (see Toro eq. 10.43)
 
@@ -118,6 +126,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     flx(ivy,k,j,i) = flxi[IVY];
     flx(ivz,k,j,i) = flxi[IVZ];
     if (NON_BAROTROPIC_EOS) flx(IEN,k,j,i) = flxi[IEN];
+
+    for (int n=0; n<NSCALARS; n++) {
+      if (flx(IDN,k,j,i) >= 0.0)
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rl(n,i);
+      else
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rr(n,i);
+    }
   }
   return;
 }

--- a/src/hydro/rsolvers/hydro/llf_rel.cpp
+++ b/src/hydro/rsolvers/hydro/llf_rel.cpp
@@ -18,6 +18,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 namespace {

--- a/src/hydro/rsolvers/hydro/llf_rel.cpp
+++ b/src/hydro/rsolvers/hydro/llf_rel.cpp
@@ -38,7 +38,9 @@ void LLFNonTransforming(MeshBlock *pmb, const int k, const int j,
 //! \fn void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 //!                           const int ivx,
 //!                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw)
+//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+//!                           const AthenaArray<Real> &rl, const AthenaArray<Real> &rl,
+//!                           const AthenaArray<Real> &sflx)
 //! \brief Riemann solver
 //!
 //! Inputs:
@@ -56,11 +58,18 @@ void LLFNonTransforming(MeshBlock *pmb, const int k, const int j,
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx,
                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   if (GENERAL_RELATIVITY && ivx == IVY && pmy_block->pcoord->IsPole(j)) {
     LLFNonTransforming(pmy_block, k, j, il, iu, g_, gi_, prim_l, prim_r, flux);
   } else {
     LLFTransforming(pmy_block, k, j, il, iu, ivx, g_, gi_, prim_l, prim_r, cons_, flux);
+  }
+  if (NSCALARS) {
+    AthenaArray<Real> mflux;
+    mflux.InitWithShallowSlice(flux, 4, IDN, 1);
+    pmy_block->pscalars->ComputeUpwindFlux(k, j, il, iu, rl, rr, mflux, sflx);
   }
   return;
 }

--- a/src/hydro/rsolvers/hydro/llf_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/hydro/llf_rel_no_transform.cpp
@@ -19,6 +19,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 //----------------------------------------------------------------------------------------

--- a/src/hydro/rsolvers/hydro/llf_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/hydro/llf_rel_no_transform.cpp
@@ -25,7 +25,9 @@
 //! \fn void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 //!                           const int ivx,
 //!                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw)
+//!                           AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+//!                           const AthenaArray<Real> &rl, const AthenaArray<Real> &rl,
+//!                           const AthenaArray<Real> &sflx)
 //! \brief Riemann solver
 //!
 //! Inputs:
@@ -43,7 +45,9 @@
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx,
                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
-                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &flux, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   // Calculate cyclic permutations of indices
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
@@ -195,6 +199,11 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
       flux(n,k,j,i) =
           0.5 * (flux_l[n] + flux_r[n] - lambda * (cons_r[n] - cons_l[n]));
     }
+  }
+  if (NSCALARS) {
+    AthenaArray<Real> mflux;
+    mflux.InitWithShallowSlice(flux, 4, IDN, 1);
+    pmy_block->pscalars->ComputeUpwindFlux(k, j, il, iu, rl, rr, mflux, sflx);
   }
   return;
 }

--- a/src/hydro/rsolvers/hydro/roe.cpp
+++ b/src/hydro/rsolvers/hydro/roe.cpp
@@ -47,6 +47,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
   Real wli[(NHYDRO+NSCALARS*GENERAL_EOS)],wri[(NHYDRO+NSCALARS*GENERAL_EOS)];
+  Real wroe[(NHYDRO)];
   Real flxi[(NHYDRO)],fl[(NHYDRO)],fr[(NHYDRO)];
   gm1 = pmy_block->peos->GetGamma() - 1.0;
   iso_cs = pmy_block->peos->GetIsoSoundSpeed();

--- a/src/hydro/rsolvers/mhd/hlld.cpp
+++ b/src/hydro/rsolvers/mhd/hlld.cpp
@@ -40,12 +40,15 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           AthenaArray<Real> &wl, AthenaArray<Real> &wr,
                           AthenaArray<Real> &flx,
                           AthenaArray<Real> &ey, AthenaArray<Real> &ez,
-                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
-  Real flxi[(NWAVE)];             // temporary variable to store flux
-  Real wli[(NWAVE)],wri[(NWAVE)]; // L/R states, primitive variables (input)
-  Real spd[5];                    // signal speeds, left to right
+  Real flxi[(NWAVE)];  // temporary variable to store flux
+  // L/R states, primitive variables (input)
+  Real wli[(NWAVE+NSCALARS*GENERAL_EOS)],wri[(NWAVE+NSCALARS*GENERAL_EOS)];
+  Real spd[5];         // signal speeds, left to right
 
   Real igm1;
   EquationOfState *peos = pmy_block->peos;
@@ -76,6 +79,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     wri[IBY]=wr(IBY,i);
     wri[IBZ]=wr(IBZ,i);
 
+    if (GENERAL_EOS) {
+      for (int n=0; n<NSCALARS; ++n) {
+        wli[NHYDRO+n]=rl(n,i);
+        wri[NHYDRO+n]=rr(n,i);
+      }
+    }
+
     Real bxi = bx(k,j,i);
 
     // Compute L/R states for selected conserved variables
@@ -91,7 +101,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     ul.my = wli[IVY]*ul.d;
     ul.mz = wli[IVZ]*ul.d;
     if (GENERAL_EOS) {
-      ul.e  = peos->EgasFromRhoP(ul.d, wli[IPR]) + kel + pbl;
+      ul.e  = peos->EgasFromRhoP(ul.d, wli[IPR], wli + NSCALARS) + kel + pbl;
     } else {
       ul.e  = wli[IPR]*igm1 + kel + pbl;
     }
@@ -103,7 +113,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     ur.my = wri[IVY]*ur.d;
     ur.mz = wri[IVZ]*ur.d;
     if (GENERAL_EOS) {
-      ur.e  = peos->EgasFromRhoP(ur.d, wri[IPR]) + ker + pbr;
+      ur.e  = peos->EgasFromRhoP(ur.d, wri[IPR], wri + NSCALARS) + ker + pbr;
     } else {
       ur.e  = wri[IPR]*igm1 + ker + pbr;
     }
@@ -377,6 +387,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     ez(k,j,i) =  flxi[IBZ];
 
     wct(k,j,i) = GetWeightForCT(flxi[IDN], wli[IDN], wri[IDN], dxw(i), dt);
+
+    for (int n=0; n<NSCALARS; n++) {
+      if (flx(IDN,k,j,i) >= 0.0)
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rl(n,i);
+      else
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rr(n,i);
+    }
   }
   return;
 }

--- a/src/hydro/rsolvers/mhd/hlld_rel.cpp
+++ b/src/hydro/rsolvers/mhd/hlld_rel.cpp
@@ -18,6 +18,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 namespace {

--- a/src/hydro/rsolvers/mhd/hlld_rel.cpp
+++ b/src/hydro/rsolvers/mhd/hlld_rel.cpp
@@ -46,31 +46,42 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 } // namespace
 
 //----------------------------------------------------------------------------------------
-// Riemann solver
-// Inputs:
-//   k,j: x3- and x2-indices
-//   il,iu: lower and upper x1-indices
-//   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
-//   bb: 3D array of normal magnetic fields
-//   prim_l,prim_r: 1D arrays of left and right primitive states
-//   dxw: 1D array of mesh spacing in the x-direction
-// Outputs:
-//   flux: 3D array of hydrodynamical fluxes across interfaces
-//   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
-//   wct: 3D array of weighting factors for CT
-// Notes:
-//   prim_l, prim_r overwritten
-//   tries to implement HLLD algorithm from Mignone, Ugliano, & Bodo 2009, MNRAS 393
-//       1141 (MUB)
-//   otherwise implements HLLE algorithm similar to that of fluxcalc() in step_ch.c in
-//       Harm
+//! \fn void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
+//!                               const int ivx, const AthenaArray<Real> &bb,
+//!                               AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
+//!                               AthenaArray<Real> &flux,
+//!                               AthenaArray<Real> &ey, AthenaArray<Real> &ez,
+//!                               AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+//!                               AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+//!                               AthenaArray<Real> &sflx) {
+//! \brief Riemann solver
+//!
+//! Inputs:
+//!   k,j: x3- and x2-indices
+//!   il,iu: lower and upper x1-indices
+//!   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
+//!   bb: 3D array of normal magnetic fields
+//!   prim_l,prim_r: 1D arrays of left and right primitive states
+//!   dxw: 1D array of mesh spacing in the x-direction
+//! Outputs:
+//!   flux: 3D array of hydrodynamical fluxes across interfaces
+//!   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
+//!   wct: 3D array of weighting factors for CT
+//! Notes:
+//!   prim_l, prim_r overwritten
+//!   tries to implement HLLD algorithm from Mignone, Ugliano, & Bodo 2009, MNRAS 393
+//!       1141 (MUB)
+//!   otherwise implements HLLE algorithm similar to that of fluxcalc() in step_ch.c in
+//!       Harm
 
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx, const AthenaArray<Real> &bb,
                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
                           AthenaArray<Real> &flux,
                           AthenaArray<Real> &ey, AthenaArray<Real> &ez,
-                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   Real dt = pmy_block->pmy_mesh->dt;
   if (GENERAL_RELATIVITY && ivx == IVY && pmy_block->pcoord->IsPole(j)) {
     HLLENonTransforming(pmy_block, k, j, il, iu, bb, g_, gi_, prim_l, prim_r, flux, ey,
@@ -85,6 +96,11 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   for(int i=il; i<=iu; ++i) {
     wct(k,j,i) = GetWeightForCT(flux(IDN,k,j,i), prim_l(IDN,i), prim_r(IDN,i), dxw(i),
                                 dt);
+  }
+  if (NSCALARS) {
+    AthenaArray<Real> mflux;
+    mflux.InitWithShallowSlice(flux, 4, IDN, 1);
+    pmy_block->pscalars->ComputeUpwindFlux(k, j, il, iu, rl, rr, mflux, sflx);
   }
   return;
 }

--- a/src/hydro/rsolvers/mhd/hlle_mhd.cpp
+++ b/src/hydro/rsolvers/mhd/hlle_mhd.cpp
@@ -27,10 +27,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           AthenaArray<Real> &wl, AthenaArray<Real> &wr,
                           AthenaArray<Real> &flx,
                           AthenaArray<Real> &ey, AthenaArray<Real> &ez,
-                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
-  Real wli[(NWAVE)], wri[(NWAVE)], wroe[(NWAVE)];
+  Real wli[(NWAVE+NSCALARS*GENERAL_EOS)],wri[(NWAVE+NSCALARS*GENERAL_EOS)];
+  Real wroe[(NWAVE)];
   Real fl[(NWAVE)],fr[(NWAVE)],flxi[(NWAVE)];
 
   Real gm1 = pmy_block->peos->GetGamma() - 1.0;
@@ -56,6 +59,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     if (NON_BAROTROPIC_EOS) wri[IPR]=wr(IPR,i);
     wri[IBY]=wr(IBY,i);
     wri[IBZ]=wr(IBZ,i);
+
+    if (GENERAL_EOS) {
+      for (int n=0; n<NSCALARS; ++n) {
+        wli[NHYDRO+n]=rl(n,i);
+        wri[NHYDRO+n]=rr(n,i);
+      }
+    }
 
     Real bxi = bx(k,j,i);
 
@@ -177,6 +187,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     ez(k,j,i) =  flxi[IBZ];
 
     wct(k,j,i)=GetWeightForCT(flxi[IDN], wli[IDN], wri[IDN], dxw(i), dt);
+
+    for (int n=0; n<NSCALARS; n++) {
+      if (flx(IDN,k,j,i) >= 0.0)
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rl(n,i);
+      else
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rr(n,i);
+    }
   }
   return;
 }

--- a/src/hydro/rsolvers/mhd/hlle_mhd_rel.cpp
+++ b/src/hydro/rsolvers/mhd/hlle_mhd_rel.cpp
@@ -38,30 +38,40 @@ void HLLENonTransforming(MeshBlock *pmb, const int k, const int j,
 } // namespace
 
 //----------------------------------------------------------------------------------------
-// Riemann solver
-// Inputs:
-//   k,j: x3- and x2-indices
-//   il,iu: lower and upper x1-indices
-//   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
-//   bb: 3D array of normal magnetic fields
-//   prim_l,prim_r: 1D arrays of left and right primitive states
-//   dxw: 1D array of mesh spacing in the x-direction
-// Outputs:
-//   flux: 3D array of hydrodynamical fluxes across interfaces
-//   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
-//   wct: 3D array of weighting factors for CT
-// Notes:
-//   prim_l, prim_r overwritten
-//   tries to implement HLLE algorithm from Mignone & Bodo 2005, MNRAS 364 126 (MB2005)
-//   otherwise implements HLLE algorithm similar to that of fluxcalc() in step_ch.c in
-//       Harm
+//! \fn void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
+//!                               const int ivx, const AthenaArray<Real> &bb,
+//!                               AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
+//!                               AthenaArray<Real> &flux,
+//!                               AthenaArray<Real> &ey, AthenaArray<Real> &ez,
+//!                               AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+//!                               AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+//!                               AthenaArray<Real> &sflx) {
+//! \brief Riemann solver
+//! Inputs:
+//!   k,j: x3- and x2-indices
+//!   il,iu: lower and upper x1-indices
+//!   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
+//!   bb: 3D array of normal magnetic fields
+//!   prim_l,prim_r: 1D arrays of left and right primitive states
+//!   dxw: 1D array of mesh spacing in the x-direction
+//! Outputs:
+//!   flux: 3D array of hydrodynamical fluxes across interfaces
+//!   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
+//!   wct: 3D array of weighting factors for CT
+//! Notes:
+//!   prim_l, prim_r overwritten
+//!   tries to implement HLLE algorithm from Mignone & Bodo 2005, MNRAS 364 126 (MB2005)
+//!   otherwise implements HLLE algorithm similar to that of fluxcalc() in step_ch.c in
+//!       Harm
 
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx, const AthenaArray<Real> &bb,
                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
                           AthenaArray<Real> &flux,
                           AthenaArray<Real> &ey, AthenaArray<Real> &ez,
-                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   Real dt = pmy_block->pmy_mesh->dt;
   if (GENERAL_RELATIVITY && ivx == IVY && pmy_block->pcoord->IsPole(j)) {
     HLLENonTransforming(pmy_block, k, j, il, iu, bb, g_, gi_, prim_l, prim_r, flux, ey,
@@ -74,6 +84,11 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   for(int i=il; i<=iu; ++i) {
     wct(k,j,i) = GetWeightForCT(flux(IDN,k,j,i), prim_l(IDN,i), prim_r(IDN,i), dxw(i),
                                 dt);
+  }
+  if (NSCALARS) {
+    AthenaArray<Real> mflux;
+    mflux.InitWithShallowSlice(flux, 4, IDN, 1);
+    pmy_block->pscalars->ComputeUpwindFlux(k, j, il, iu, rl, rr, mflux, sflx);
   }
   return;
 }

--- a/src/hydro/rsolvers/mhd/hlle_mhd_rel.cpp
+++ b/src/hydro/rsolvers/mhd/hlle_mhd_rel.cpp
@@ -18,6 +18,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 namespace {

--- a/src/hydro/rsolvers/mhd/hlle_mhd_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/mhd/hlle_mhd_rel_no_transform.cpp
@@ -18,6 +18,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 //----------------------------------------------------------------------------------------

--- a/src/hydro/rsolvers/mhd/llf_mhd_rel.cpp
+++ b/src/hydro/rsolvers/mhd/llf_mhd_rel.cpp
@@ -18,6 +18,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 namespace {

--- a/src/hydro/rsolvers/mhd/llf_mhd_rel.cpp
+++ b/src/hydro/rsolvers/mhd/llf_mhd_rel.cpp
@@ -38,28 +38,39 @@ void LLFNonTransforming(MeshBlock *pmb, const int k, const int j,
 } // namespace
 
 //----------------------------------------------------------------------------------------
-// Riemann solver
-// Inputs:
-//   k,j: x3- and x2-indices
-//   il,iu: lower and upper x1-indices
-//   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
-//   bb: 3D array of normal magnetic fields
-//   prim_l,prim_r: 1D arrays of left and right primitive states
-//   dxw: 1D array of mesh spacing in the x-direction
-// Outputs:
-//   flux: 3D array of hydrodynamical fluxes across interfaces
-//   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
-//   wct: 3D array of weighting factors for CT
-// Notes:
-//   prim_l, prim_r overwritten
-//   implements LLF algorithm similar to that of fluxcalc() in step_ch.c in Harm
+//! \fn void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
+//!                               const int ivx, const AthenaArray<Real> &bb,
+//!                               AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
+//!                               AthenaArray<Real> &flux,
+//!                               AthenaArray<Real> &ey, AthenaArray<Real> &ez,
+//!                               AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+//!                               AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+//!                               AthenaArray<Real> &sflx) {
+//! \brief Riemann solver
+//!
+//! Inputs:
+//!   k,j: x3- and x2-indices
+//!   il,iu: lower and upper x1-indices
+//!   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
+//!   bb: 3D array of normal magnetic fields
+//!   prim_l,prim_r: 1D arrays of left and right primitive states
+//!   dxw: 1D array of mesh spacing in the x-direction
+//! Outputs:
+//!   flux: 3D array of hydrodynamical fluxes across interfaces
+//!   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
+//!   wct: 3D array of weighting factors for CT
+//! Notes:
+//!   prim_l, prim_r overwritten
+//!   implements LLF algorithm similar to that of fluxcalc() in step_ch.c in Harm
 
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx, const AthenaArray<Real> &bb,
                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
                           AthenaArray<Real> &flux,
                           AthenaArray<Real> &ey, AthenaArray<Real> &ez,
-                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   Real dt = pmy_block->pmy_mesh->dt;
   if (GENERAL_RELATIVITY && ivx == IVY && pmy_block->pcoord->IsPole(j)) {
     LLFNonTransforming(pmy_block, k, j, il, iu, bb, g_, gi_, prim_l, prim_r, flux,
@@ -72,6 +83,11 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   for(int i=il; i<=iu; ++i) {
     wct(k,j,i) = GetWeightForCT(flux(IDN,k,j,i), prim_l(IDN,i), prim_r(IDN,i), dxw(i),
                                 dt);
+  }
+  if (NSCALARS) {
+    AthenaArray<Real> mflux;
+    mflux.InitWithShallowSlice(flux, 4, IDN, 1);
+    pmy_block->pscalars->ComputeUpwindFlux(k, j, il, iu, rl, rr, mflux, sflx);
   }
   return;
 }

--- a/src/hydro/rsolvers/mhd/llf_mhd_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/mhd/llf_mhd_rel_no_transform.cpp
@@ -18,6 +18,7 @@
 #include "../../../coordinates/coordinates.hpp"  // Coordinates
 #include "../../../eos/eos.hpp"                  // EquationOfState
 #include "../../../mesh/mesh.hpp"                // MeshBlock
+#include "../../../scalars/scalars.hpp"          // PassiveScalars
 #include "../../hydro.hpp"
 
 //----------------------------------------------------------------------------------------

--- a/src/hydro/rsolvers/mhd/llf_mhd_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/mhd/llf_mhd_rel_no_transform.cpp
@@ -21,25 +21,36 @@
 #include "../../hydro.hpp"
 
 //----------------------------------------------------------------------------------------
-// Riemann solver
-// Inputs:
-//   k,j: x3- and x2-indices
-//   il,iu: lower and upper x1-indices
-//   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
-//   bb: 3D array of normal magnetic fields
-//   prim_l,prim_r: 1D arrays of left and right primitive states
-//   dxw: 1D array of mesh spacing in the x-direction
-// Outputs:
-//   flux: 3D array of hydrodynamical fluxes across interfaces
-//   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
-//   wct: 3D array of weighting factors for CT
+//! \fn void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
+//!                               const int ivx, const AthenaArray<Real> &bb,
+//!                               AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
+//!                               AthenaArray<Real> &flux,
+//!                               AthenaArray<Real> &ey, AthenaArray<Real> &ez,
+//!                               AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+//!                               AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+//!                               AthenaArray<Real> &sflx) {
+//! \brief Riemann solver
+//!
+//! Inputs:
+//!   k,j: x3- and x2-indices
+//!   il,iu: lower and upper x1-indices
+//!   ivx: type of interface (IVX for x1, IVY for x2, IVZ for x3)
+//!   bb: 3D array of normal magnetic fields
+//!   prim_l,prim_r: 1D arrays of left and right primitive states
+//!   dxw: 1D array of mesh spacing in the x-direction
+//! Outputs:
+//!   flux: 3D array of hydrodynamical fluxes across interfaces
+//!   ey,ez: 3D arrays of magnetic fluxes (electric fields) across interfaces
+//!   wct: 3D array of weighting factors for CT
 
 void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           const int ivx, const AthenaArray<Real> &bb,
                           AthenaArray<Real> &prim_l, AthenaArray<Real> &prim_r,
                           AthenaArray<Real> &flux,
                           AthenaArray<Real> &ey, AthenaArray<Real> &ez,
-                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   // Calculate cyclic permutations of indices
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
@@ -285,6 +296,11 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
 
     wct(k,j,i) =
         GetWeightForCT(flux(IDN,k,j,i), prim_l(IDN,i), prim_r(IDN,i), dxw(i), dt);
+  }
+  if (NSCALARS) {
+    AthenaArray<Real> mflux;
+    mflux.InitWithShallowSlice(flux, 4, IDN, 1);
+    pmy_block->pscalars->ComputeUpwindFlux(k, j, il, iu, rl, rr, mflux, sflx);
   }
 
   return;

--- a/src/hydro/rsolvers/mhd/roe_mhd.cpp
+++ b/src/hydro/rsolvers/mhd/roe_mhd.cpp
@@ -45,10 +45,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
                           AthenaArray<Real> &wl, AthenaArray<Real> &wr,
                           AthenaArray<Real> &flx,
                           AthenaArray<Real> &ey, AthenaArray<Real> &ez,
-                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw) {
+                          AthenaArray<Real> &wct, const AthenaArray<Real> &dxw,
+                          AthenaArray<Real> &rl, AthenaArray<Real> &rr,
+                          AthenaArray<Real> &sflx) {
   int ivy = IVX + ((ivx-IVX)+1)%3;
   int ivz = IVX + ((ivx-IVX)+2)%3;
-  Real wli[(NWAVE)],wri[(NWAVE)],wroe[(NWAVE)];
+  Real wli[(NWAVE+NSCALARS*GENERAL_EOS)],wri[(NWAVE+NSCALARS*GENERAL_EOS)];
+  Real wroe[(NWAVE)];
   Real flxi[(NWAVE)],fl[(NWAVE)],fr[(NWAVE)];
 
   gm1 = pmy_block->peos->GetGamma() - 1.0;
@@ -75,6 +78,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     if (NON_BAROTROPIC_EOS) wri[IPR]=wr(IPR,i);
     wri[IBY]=wr(IBY,i);
     wri[IBZ]=wr(IBZ,i);
+
+    if (GENERAL_EOS) {
+      for (int n=0; n<NSCALARS; ++n) {
+        wli[NHYDRO+n]=rl(n,i);
+        wri[NHYDRO+n]=rr(n,i);
+      }
+    }
 
     Real bxi = bx(k,j,i);
 
@@ -208,6 +218,13 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     ez(k,j,i) =  flxi[IBZ];
 
     wct(k,j,i)=GetWeightForCT(flxi[IDN], wli[IDN], wri[IDN], dxw(i), dt);
+
+    for (int n=0; n<NSCALARS; n++) {
+      if (flx(IDN,k,j,i) >= 0.0)
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rl(n,i);
+      else
+        sflx(n,k,j,i) = flx(IDN,k,j,i) * rr(n,i);
+    }
   }
 
   return;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -57,6 +57,9 @@
 #include <mpi.h>
 #endif
 
+// empty array to pass in place of scalars when NSCALARS=0
+static AthenaArray<Real> empty;
+
 //----------------------------------------------------------------------------------------
 //! Mesh constructor, builds mesh at start of calculation using parameters in input file
 
@@ -1533,8 +1536,14 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin) {
           if (pbval->nblevel[0][1][1] != -1) kl -= NGHOST;
           if (pbval->nblevel[2][1][1] != -1) ku += NGHOST;
         }
+        // MSBC: scalars are passed to EOS functions. If there are no scalars, pass any
+        // array.
         pmb->peos->ConservedToPrimitive(ph->u, ph->w1, pf->b,
-                                        ph->w, pf->bcc, pmb->pcoord,
+                                        ph->w, pf->bcc,
+                                        (NSCALARS) ? ps->s : empty,
+                                        (NSCALARS) ? ps->r : empty,
+                                        (NSCALARS) ? ps->r : empty,
+                                        pmb->pcoord,
                                         il, iu, jl, ju, kl, ku);
         if (NSCALARS > 0) {
           // r1/r_old for GR is currently unused:
@@ -1563,7 +1572,11 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin) {
           pbval->ApplyPhysicalBoundaries(time, 0.0, pbval->bvars_main_int);
           // Perform 4th order W(U)
           pmb->peos->ConservedToPrimitiveCellAverage(ph->u, ph->w1, pf->b,
-                                                     ph->w, pf->bcc, pmb->pcoord,
+                                                     ph->w, pf->bcc,
+                                                     (NSCALARS) ? ps->s : empty,
+                                                     (NSCALARS) ? ps->r : empty,
+                                                     (NSCALARS) ? ps->r : empty,
+                                                     pmb->pcoord,
                                                      il, iu, jl, ju, kl, ku);
           if (NSCALARS > 0) {
             pmb->peos->PassiveScalarConservedToPrimitiveCellAverage(

--- a/src/pgen/eos_test.cpp
+++ b/src/pgen/eos_test.cpp
@@ -126,8 +126,9 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
       std::cout << "Density, internal energy: " << rho << ", " << egas << '\n';
       u(IDN,0,0,0) = rho;
       u(IEN,0,0,0) = egas;
-      peos->ConservedToPrimitive(u, zeros, f, w, zeros, pcoord, 0, 0, 0, 0, 0, 0);
-      peos->PrimitiveToConserved(w, zeros, u, pcoord, 0, 0, 0, 0, 0, 0);
+      peos->ConservedToPrimitive(u, zeros, f, w, zeros, zeros, zeros, zeros, pcoord,
+                                 0, 0, 0, 0, 0, 0);
+      peos->PrimitiveToConserved(w, zeros, u, zeros, zeros, pcoord, 0, 0, 0, 0, 0, 0);
       p = w(IPR,0,0,0);
       w2[IPR]=p;
       w2[IDN]=rho;

--- a/src/pgen/gr_shock_tube.cpp
+++ b/src/pgen/gr_shock_tube.cpp
@@ -226,7 +226,8 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
       }
     }
   }
-  peos->PrimitiveToConserved(phydro->w, bb, phydro->u, pcoord, is, ie, js, je, ks, ke);
+  peos->PrimitiveToConserved(phydro->w, bb, phydro->u, pscalars->r, pscalars->s, pcoord,
+      is, ie, js, je, ks, ke);
   peos->PassiveScalarPrimitiveToConserved(pscalars->r, phydro->u, pscalars->s, pcoord, is,
       ie, js, je, ks, ke);
 

--- a/src/scalars/scalars.hpp
+++ b/src/scalars/scalars.hpp
@@ -19,6 +19,7 @@
 
 class MeshBlock;
 class ParameterInput;
+class Hydro;
 
 //! \class PassiveScalars
 //! \brief
@@ -106,5 +107,6 @@ class PassiveScalars {
   void AddDiffusionFluxes();
   // TODO(felker): dedpulicate these arrays and the same named ones in HydroDiffusion
   AthenaArray<Real> dx1_, dx2_, dx3_;
+  friend class Hydro;
 };
 #endif // SCALARS_SCALARS_HPP_

--- a/src/task_list/sts_task_list.cpp
+++ b/src/task_list/sts_task_list.cpp
@@ -39,6 +39,9 @@
 #include "../scalars/scalars.hpp"
 #include "task_list.hpp"
 
+// empty array to pass in place of scalars when NSCALARS=0
+static AthenaArray<Real> empty;
+
 //----------------------------------------------------------------------------------------
 //! SuperTimeStepTaskList constructor
 
@@ -896,7 +899,11 @@ TaskStatus SuperTimeStepTaskList::Primitives_STS(MeshBlock *pmb, int stage) {
     //! which is not yet compatible with STS, thus making this a safe choice.
     if (do_sts_hydro || do_sts_field) {
       pmb->peos->ConservedToPrimitive(ph->u, ph->w, pf->b,
-                                      ph->w, pf->bcc, pmb->pcoord,
+                                      ph->w, pf->bcc,
+                                      (NSCALARS) ? ps->coarse_s_ : empty,
+                                      (NSCALARS) ? ps->coarse_r_ : empty,
+                                      (NSCALARS) ? ps->coarse_r_ : empty,
+                                      pmb->pcoord,
                                       il, iu, jl, ju, kl, ku);
       if (pmb->porb->orbital_advection_defined) {
         pmb->porb->ResetOrbitalSystemConversionFlag();
@@ -933,7 +940,11 @@ TaskStatus SuperTimeStepTaskList::Primitives_STS(MeshBlock *pmb, int stage) {
       // Perform 4th order W(U)
       if (do_sts_hydro || do_sts_field) {
         pmb->peos->ConservedToPrimitiveCellAverage(ph->u, ph->w, pf->b,
-                                                   ph->w, pf->bcc, pmb->pcoord,
+                                                   ph->w, pf->bcc,
+                                                   (NSCALARS) ? ps->coarse_s_ : empty,
+                                                   (NSCALARS) ? ps->coarse_r_ : empty,
+                                                   (NSCALARS) ? ps->coarse_r_ : empty,
+                                                   pmb->pcoord,
                                                    il, iu, jl, ju, kl, ku);
       }
       if (do_sts_scalar) {

--- a/src/task_list/task_list.hpp
+++ b/src/task_list/task_list.hpp
@@ -188,7 +188,7 @@ class TimeIntegratorTaskList : public TaskList {
   TaskStatus NewBlockTimeStep(MeshBlock *pmb, int stage);
   TaskStatus CheckRefinement(MeshBlock *pmb, int stage);
 
-  TaskStatus CalculateScalarFlux(MeshBlock *pmb, int stage);
+  // TaskStatus CalculateScalarFlux(MeshBlock *pmb, int stage);
   TaskStatus SendScalarFlux(MeshBlock *pmb, int stage);
   TaskStatus ReceiveScalarFlux(MeshBlock *pmb, int stage);
   TaskStatus IntegrateScalars(MeshBlock *pmb, int stage);

--- a/tst/regression/scripts/tests/grav/unstable_jeans_3d_mg.py
+++ b/tst/regression/scripts/tests/grav/unstable_jeans_3d_mg.py
@@ -15,12 +15,29 @@ athena_read.check_nan_flag = True
 logger = logging.getLogger('athena' + __name__[7:])  # set logger name based on module
 
 
+def kludge_grav_mg():
+    with open('../../src/defs.hpp', 'a') as f:
+        f.write('#undef SELF_GRAVITY_ENABLED\n')
+        f.write('#define SELF_GRAVITY_ENABLED 2\n')
+
+
+def grav_mg_available():
+    with open('../../configure.py', 'r') as f:
+        for line in f:
+            if 'if args[\'grav\'] == "mg":' in line:
+                return True
+
+
 # Prepare Athena++
 def prepare(**kwargs):
+    mg_avail = grav_mg_available()
+    mg = 'mg' if mg_avail else 'none'
     logger.debug('Running test ' + __name__)
     athena.configure(prob='jeans',
-                     grav='mg',
+                     grav=mg,
                      **kwargs)
+    if not mg_avail:
+        kludge_grav_mg()
     athena.make()
 
 

--- a/tst/regression/scripts/tests/mhd/mhd_carbuncle.py
+++ b/tst/regression/scripts/tests/mhd/mhd_carbuncle.py
@@ -26,9 +26,9 @@ def prepare(**kwargs):
             _fluxes = [tmp[1]]
     for flux in _fluxes:
         athena.configure('b',
-            prob='quirk',
-            coord='cartesian',
-            flux=flux, **kwargs)
+                         prob='quirk',
+                         coord='cartesian',
+                         flux=flux, **kwargs)
         # to save time, reuse compiled .o files for all executables created in this test:
         athena.make(clean_first=False)
         move(_exec, _exec + '_' + flux)

--- a/vis/python/plot_slice.py
+++ b/vis/python/plot_slice.py
@@ -75,9 +75,11 @@ def main(**kwargs):
     # Read data
     if quantities[0] == 'Levels':
         data = athena_read.athdf(kwargs['data_file'], quantities=quantities[1:],
-                                 level=level, return_levels=True, num_ghost=kwargs['num_ghost'])
+                                 level=level, return_levels=True,
+                                 num_ghost=kwargs['num_ghost'])
     else:
-        data = athena_read.athdf(kwargs['data_file'], quantities=quantities, level=level, num_ghost=kwargs['num_ghost'])
+        data = athena_read.athdf(kwargs['data_file'], quantities=quantities, level=level,
+                                 num_ghost=kwargs['num_ghost'])
 
     # Check that coordinates work with user choices
     coordinates = data['Coordinates'].decode('ascii', 'replace')
@@ -218,7 +220,7 @@ def main(**kwargs):
     # Make plot
     # should make the size editable?
     fig = plt.figure(1, figsize=(12, 12))
-    ax = fig.add_subplot(1,1,1,projection=projection_type)
+    ax = fig.add_subplot(1, 1, 1, projection=projection_type)
     if projection_type == 'polar':
         # switch axis for radial and azimuthal
         im = ax.pcolormesh(y_grid, x_grid, vals, cmap=kwargs['colormap'], norm=norm)
@@ -235,10 +237,10 @@ def main(**kwargs):
         if projection_type == 'polar':
             # switch axis for radial and azimuthal and Transpose
             ax.streamplot(y_stream.T, x_stream.T, vals_y.T, vals_x.T,
-                        density=kwargs['stream_density'], color='k')
+                          density=kwargs['stream_density'], color='k')
         else:
             ax.streamplot(x_stream, y_stream, vals_x, vals_y,
-                        density=kwargs['stream_density'], color='k')
+                          density=kwargs['stream_density'], color='k')
 
     if projection_type == 'polar':
         ax.set_rmin(x_min)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add support for equations of state that depend on passive scalars. Closes #359 

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To enable support for equations of state that depend on passive scalars, the passive scalars must be passed to (nearly) all EOS calls. The main difficulty here is that EOS calls are made inside the Riemann solver. This requires that the face centered values of the scalar primitive values must also be passed to the Riemann solver. Which, in turn, requires that the scalars be interpolated to the face centers at the same time as the hydro variables. Thus `PasiveScalars::CalculateFluxes` was essentially merged into `Hydro::CalculateFluxes` (I have left `PasiveScalars::CalculateFluxes` in the code even-though it is unused). Otherwise I've done my best to keep the scalars as separated from hydro as I can. Although, I think we should combine the hydro and scalar `ConservedToPrimitive` and `PrimitiveToConserved` functions as they are always called together (outside of pgens and if `NSCALARS>0`). If your EOS needs to do an inversion (e.g. find Temperature) it would be useful to store this in the passive scalars to estimate the solution for the next EOS inversion.

Currently 4th-order is not properly supported for an EOS which depends on passive scalars. In `EquationOfState::ConservedToPrimitiveCellAverage` there is one call to ConservedToPrimitive that uses the 4th-order cell-centered values, but I am currently only passing it the cell-averaged scalars. The only way I see of fixing that is to merge `PasiveScalarPrimitiveCellAverage` into `ConservedToPrimitiveCellAverage` so that the 4th-order cell-centered scalars are accessible at this stage. However, I didn't want to make this change without approval from @felker.

You may want to categorize major vs. minor changes and list them:
1. Change nearly all EOS function and Riemann solver signatures to include passive scalars, enabling scalar dependent EOS.
2. Merged `PasiveScalars::CalculateFluxes` into `Hydro::CalculateFluxes`
3. The Riemann solvers are now responsible for computing the scalar fluxes
4. Removed `CalculateScalarFlux` from task list as it is now part of hydro fluxes (dependancies updated)

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All current tests past using `--cxx=clang++-apple` on my MacBook Pro (with Apple Arm64 CPU).

...

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->

- [ ] Add EOS module that depends on passive scalars
- [ ] Add corresponding shock tube tests for regression testing
- [ ] Double check passive scalar fluxes are properly updated for SR/GR
- [ ] Make sure doxygen comments are updated
- [ ] Fix 4th-order
- [ ] Cleanup now unused scalar code (and `mass_flux_fc`)
- [ ] Maybe find a cleaner way of passing empty scalar arrays when `NSCALARS` is zero
