### PR TITLE
Fixed passive scalar + AMR bug

### DIFF
--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1431,8 +1431,13 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin) {
         if (MAGNETIC_FIELDS_ENABLED)
           pmb->pfield->fbvar.SendBoundaryBuffers();
         // and (conserved variable) passive scalar masses:
-        if (NSCALARS > 0)
+        if (NSCALARS > 0) {
+          pmb->pscalars->sbvar.var_cc = &(pmb->pscalars->s);
+          if (pmb->pmy_mesh->multilevel) {
+            pmb->pscalars->sbvar.coarse_buf = &(pmb->pscalars->coarse_s_);
+          }
           pmb->pscalars->sbvar.SendBoundaryBuffers();
+        }
       }
 
       // wait to receive conserved variables
@@ -1470,6 +1475,9 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin) {
           pmb->phydro->hbvar.SendBoundaryBuffers();
           if (NSCALARS > 0) {
             pmb->pscalars->sbvar.var_cc = &(pmb->pscalars->r);
+            if (pmb->pmy_mesh->multilevel) {
+              pmb->pscalars->sbvar.coarse_buf = &(pmb->pscalars->coarse_r_);
+            }
             pmb->pscalars->sbvar.SendBoundaryBuffers();
           }
         }
@@ -1488,6 +1496,9 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin) {
                                                HydroBoundaryQuantity::cons);
           if (NSCALARS > 0) {
             pmb->pscalars->sbvar.var_cc = &(pmb->pscalars->s);
+            if (pmb->pmy_mesh->multilevel) {
+              pmb->pscalars->sbvar.coarse_buf = &(pmb->pscalars->coarse_s_);
+            }
           }
         }
       } // multilevel
@@ -1558,8 +1569,12 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin) {
           //! * add MHD loop limit calculation for 4th order W(U)
           // Apply physical boundaries prior to 4th order W(U)
           ph->hbvar.SwapHydroQuantity(ph->w, HydroBoundaryQuantity::prim);
-          if (NSCALARS > 0)
+          if (NSCALARS > 0) {
             ps->sbvar.var_cc = &(ps->r);
+            if (pmb->pmy_mesh->multilevel) {
+              ps->sbvar.coarse_buf = &(ps->coarse_r_);
+            }
+          }
           pbval->ApplyPhysicalBoundaries(time, 0.0, pbval->bvars_main_int);
           // Perform 4th order W(U)
           pmb->peos->ConservedToPrimitiveCellAverage(ph->u, ph->w1, pf->b,
@@ -1576,8 +1591,12 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin) {
         // Swap Hydro and (possibly) passive scalar quantities in BoundaryVariable
         // interface from conserved to primitive formulations:
         ph->hbvar.SwapHydroQuantity(ph->w, HydroBoundaryQuantity::prim);
-        if (NSCALARS > 0)
+        if (NSCALARS > 0) {
           ps->sbvar.var_cc = &(ps->r);
+          if (pmb->pmy_mesh->multilevel) {
+            ps->sbvar.coarse_buf = &(ps->coarse_r_);
+          }
+        }
 
         pbval->ApplyPhysicalBoundaries(time, 0.0, pbval->bvars_main_int);
       }
@@ -1827,8 +1846,13 @@ void Mesh::CorrectMidpointInitialCondition() {
     if (MAGNETIC_FIELDS_ENABLED)
       pmb->pfield->fbvar.SendBoundaryBuffers();
     // and (conserved variable) passive scalar masses:
-    if (NSCALARS > 0)
+    if (NSCALARS > 0) {
+      pmb->pscalars->sbvar.var_cc = &(pmb->pscalars->s);
+      if (pmb->pmy_mesh->multilevel) {
+        pmb->pscalars->sbvar.coarse_buf = &(pmb->pscalars->coarse_s_);
+      }
       pmb->pscalars->sbvar.SendBoundaryBuffers();
+    }
   }
 
   // wait to receive conserved variables
@@ -1840,8 +1864,13 @@ void Mesh::CorrectMidpointInitialCondition() {
     pmb->phydro->hbvar.ReceiveAndSetBoundariesWithWait();
     if (MAGNETIC_FIELDS_ENABLED)
       pmb->pfield->fbvar.ReceiveAndSetBoundariesWithWait();
-    if (NSCALARS > 0)
+    if (NSCALARS > 0) {
+      pmb->pscalars->sbvar.var_cc = &(pmb->pscalars->s);
+      if (pmb->pmy_mesh->multilevel) {
+        pmb->pscalars->sbvar.coarse_buf = &(pmb->pscalars->coarse_s_);
+      }
       pmb->pscalars->sbvar.ReceiveAndSetBoundariesWithWait();
+    }
     if (shear_periodic && orbital_advection==0) {
       pmb->phydro->hbvar.AddHydroShearForInit();
     }

--- a/src/task_list/sts_task_list.cpp
+++ b/src/task_list/sts_task_list.cpp
@@ -926,6 +926,9 @@ TaskStatus SuperTimeStepTaskList::Primitives_STS(MeshBlock *pmb, int stage) {
       }
       if (do_sts_scalar) {
         pmb->pscalars->sbvar.var_cc = &(pmb->pscalars->r);
+        if (pmb->pmy_mesh->multilevel) {
+          pmb->pscalars->sbvar.coarse_buf = &(pmb->pscalars->coarse_r_);
+        }
       }
       Real time = pmb->pmy_mesh->time;
       if (pmb->pmy_mesh->sts_loc == TaskType::op_split_after) time += pmb->pmy_mesh->dt;
@@ -957,6 +960,9 @@ TaskStatus SuperTimeStepTaskList::PhysicalBoundary_STS(MeshBlock *pmb, int stage
     }
     if (do_sts_scalar) {
       pmb->pscalars->sbvar.var_cc = &(pmb->pscalars->r);
+      if (pmb->pmy_mesh->multilevel) {
+        pmb->pscalars->sbvar.coarse_buf = &(pmb->pscalars->coarse_r_);
+      }
     }
     Real time = pmb->pmy_mesh->time;
     if (pmb->pmy_mesh->sts_loc == TaskType::op_split_after) time += pmb->pmy_mesh->dt;


### PR DESCRIPTION
I noticed something wrong with the passive scalars near refinement boundaries in an AMR calculation. After digging through the code, I realized the scalars were not perfectly paralleling the hydro quantities with regard to primitive vs. conserved coarse buffers. In particular, calls to `HydroBoundaryVariable::SwapHydroQuantity` were followed by the appropriate setting of `var_cc` in the scalars' `CellCenteredBoundaryVariable`, but the subsequent setting of `coarse_buf` done by `HydroBoundaryVariable::SelectCoarseBuffer` was omitted. This occurs 7 times in `mesh.cpp`, 4 times in `time_integrator.cpp`, and 2 times in `sts_task_list.cpp`.

This pull request adds in the missing logic in all 13 cases. I don't know if this is strictly necessary in all cases, but it doesn't seem like this can harm anything. I am particularly uncertain about STS, since I never use it.

This problem is hard to find in existing test problems. Partly, this may be because the effects of bad ghost cells may be hidden by flux corrections and time evolution. It may also not show up in problems where the conserved density is 1, since the primitive and conserved scalars are the same in that case. It may well affect SMR calculations, but I can't be certain I've seen that occur.

Below is an example problem before and after this update. The hydro variables always look good, but the passive scalars show clear grid artifacts in the unfixed version.

![amr_scalar_comparison](https://user-images.githubusercontent.com/2496675/170843329-8f9e6f2f-cc53-4e4f-9e8e-609504dec296.png)

- [x] Code follows style guide.
- [x] Documentation updated (N/A).
- [ ] Test coverage: I could not find a simple test that illustrated the problem (I only saw it with a 3D AMR multigrid calculation with at least 512 8^3 blocks).
- [ ] Optional: someone can comment on whether all the changes here are necessary.
- [ ] Optional: one could achieve the same effect by making a new `ScalarBoundaryVariable` derived from `CellCenteredBoundaryVariable` with analogous `SwapScalarQuantity` and `SelectCoarseBuffer` functions, more closely paralleling hydro.