### PR TITLE
Fixed bug in fixup routine for SRMHD

### DIFF
--- a/src/eos/adiabatic_mhd_sr.cpp
+++ b/src/eos/adiabatic_mhd_sr.cpp
@@ -260,10 +260,10 @@ void EquationOfState::ConservedToPrimitive(
           Real wtot = wgas + b_sq;
           pmag = 0.5 * b_sq;
           cons(IDN,k,j,i) = rho * gamma;
-          cons(IEN,k,j,i) = wgas * SQR(gamma) - SQR(b0) - (pgas + pmag);
-          cons(IM1,k,j,i) = wgas * gamma * u1 - b0 * b1;
-          cons(IM2,k,j,i) = wgas * gamma * u2 - b0 * b2;
-          cons(IM3,k,j,i) = wgas * gamma * u3 - b0 * b3;
+          cons(IEN,k,j,i) = wtot * SQR(gamma) - SQR(b0) - (pgas + pmag);
+          cons(IM1,k,j,i) = wtot * gamma * u1 - b0 * b1;
+          cons(IM2,k,j,i) = wtot * gamma * u2 - b0 * b2;
+          cons(IM3,k,j,i) = wtot * gamma * u3 - b0 * b3;
         }
       }
     }


### PR DESCRIPTION
This is a small fix that only affects SRMHD. There was a bug that occurs only when there is some mild variable inversion failure, with the incorrect conserved <-> primitive relation being applied in the case of nonvanishing magnetic field. This wouldn't be covered by any test problems, since there should never be any variable inversion failures there.