### PR TITLE
Fixing the restart error reported in #449

### DIFF
--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -856,25 +856,38 @@ Mesh::Mesh(ParameterInput *pin, IOWrapper& resfile, int mesh_test) :
   //    gflag=2;
 
   // allocate data buffer
+  int nbmin = nblist[0];
+  for (int n = 1; n < Globals::nranks; ++n) {
+    if (nbmin > nblist[n])
+      nbmin = nblist[n];
+  }
   nblocal = nblist[Globals::my_rank];
   gids_ = nslist[Globals::my_rank];
   gide_ = gids_ + nblocal - 1;
-  char *mbdata = new char[datasize*nblocal];
+  char *mbdata = new char[datasize];
   my_blocks.NewAthenaArray(nblocal);
-  // load MeshBlocks (parallel)
-  if (resfile.Read_at_all(mbdata, datasize, nblocal, headeroffset+gids_*datasize) !=
-      static_cast<unsigned int>(nblocal)) {
-    msg << "### FATAL ERROR in Mesh constructor" << std::endl
-        << "The restart file is broken or input parameters are inconsistent."
-        << std::endl;
-    ATHENA_ERROR(msg);
-  }
   for (int i=gids_; i<=gide_; i++) {
+    if (i - gids_ < nbmin) {
+      // load MeshBlock (parallel)
+      if (resfile.Read_at_all(mbdata, datasize, 1, headeroffset+i*datasize) != 1) {
+        msg << "### FATAL ERROR in Mesh constructor" << std::endl
+            << "The restart file is broken or input parameters are inconsistent."
+            << std::endl;
+        ATHENA_ERROR(msg);
+      }
+    } else {
+      // load MeshBlock (serial)
+      if (resfile.Read_at(mbdata, datasize, 1, headeroffset+i*datasize) != 1) {
+        msg << "### FATAL ERROR in Mesh constructor" << std::endl
+            << "The restart file is broken or input parameters are inconsistent."
+            << std::endl;
+        ATHENA_ERROR(msg);
+      }
+    }
     // Match fixed-width integer precision of IOWrapperSizeT datasize
-    std::uint64_t buff_os = datasize * (i-gids_);
     SetBlockSizeAndBoundaries(loclist[i], block_size, block_bcs);
     my_blocks(i-gids_) = new MeshBlock(i, i-gids_, this, pin, loclist[i], block_size,
-                                       block_bcs, costlist[i], mbdata+buff_os, gflag);
+                                       block_bcs, costlist[i], mbdata, gflag);
     my_blocks(i-gids_)->pbval->SearchAndSetNeighbors(tree, ranklist, nslist);
   }
   delete [] mbdata;

--- a/src/outputs/io_wrapper.hpp
+++ b/src/outputs/io_wrapper.hpp
@@ -46,8 +46,10 @@ class IOWrapper {
   std::size_t Read_at_all(void *buf, IOWrapperSizeT size,
                           IOWrapperSizeT count, IOWrapperSizeT offset);
   std::size_t Write(const void *buf, IOWrapperSizeT size, IOWrapperSizeT count);
+  std::size_t Write_at(const void *buf, IOWrapperSizeT size,
+                       IOWrapperSizeT count, IOWrapperSizeT offset);
   std::size_t Write_at_all(const void *buf, IOWrapperSizeT size,
-                           IOWrapperSizeT cnt, IOWrapperSizeT offset);
+                           IOWrapperSizeT count, IOWrapperSizeT offset);
   int Close();
   int Seek(IOWrapperSizeT offset);
   IOWrapperSizeT GetPosition();

--- a/src/outputs/io_wrapper.hpp
+++ b/src/outputs/io_wrapper.hpp
@@ -41,6 +41,8 @@ class IOWrapper {
   int Open(const char* fname, FileMode rw);
   std::size_t Read(void *buf, IOWrapperSizeT size, IOWrapperSizeT count);
   std::size_t Read_all(void *buf, IOWrapperSizeT size, IOWrapperSizeT count);
+  std::size_t Read_at(void *buf, IOWrapperSizeT size,
+                      IOWrapperSizeT count, IOWrapperSizeT offset);
   std::size_t Read_at_all(void *buf, IOWrapperSizeT size,
                           IOWrapperSizeT count, IOWrapperSizeT offset);
   std::size_t Write(const void *buf, IOWrapperSizeT size, IOWrapperSizeT count);

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -85,6 +85,11 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool force_wr
   int nbtotal = pm->nbtotal;
   int myns = pm->nslist[Globals::my_rank];
   int mynb = pm->nblist[Globals::my_rank];
+  int nbmin = pm->nblist[0];
+  for (int n = 1; n < Globals::nranks; ++n) {
+    if (nbmin > pm->nblist[n])
+      nbmin = pm->nblist[n];
+  }
 
   // write the header; this part is serial
   if (Globals::my_rank == 0) {
@@ -121,7 +126,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool force_wr
 
   // allocate memory for the ID list and the data
   char *idlist = new char[listsize*mynb];
-  char *data = new char[mynb*datasize];
+  char *data = new char[datasize];
 
   // Loop over MeshBlocks and pack the meta data
   int os=0;
@@ -143,7 +148,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool force_wr
   // Loop over MeshBlocks and pack the data
   for (int b=0; b<pm->nblocal; ++b) {
     MeshBlock *pmb = pm->my_blocks(b);
-    char *pdata = &(data[pmb->lid*datasize]);
+    char *pdata = data;
 
     // NEW_OUTPUT_TYPES: add output of additional physics to restarts here also update
     // MeshBlock::GetBlockSizeInBytes accordingly and MeshBlock constructor for restarts.
@@ -197,11 +202,15 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool force_wr
                   pmb->ruser_meshblock_data[n].GetSizeInBytes());
       pdata += pmb->ruser_meshblock_data[n].GetSizeInBytes();
     }
+
+    // now write restart data in parallel
+    myoffset = headeroffset + listsize*nbtotal + datasize*(myns+b);
+    if (b < nbmin)
+      resfile.Write_at_all(data, datasize, 1, myoffset);
+    else
+      resfile.Write_at(data, datasize, 1, myoffset);
   }
 
-  // now write restart data in parallel
-  myoffset = headeroffset + listsize*nbtotal + datasize*myns;
-  resfile.Write_at_all(data, datasize, mynb, myoffset);
   resfile.Close();
   delete [] data;
 }


### PR DESCRIPTION
This is a patch to fix the error in restart reported in #449. The original implementation loads all MeshBlocks at once from a restart file. This version reads the data one by one in order to avoid hitting the 2GB limit of MPI_File_read.

## Prerequisite checklist
- [X] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Testing and validation
I tested the code by changing the number of processes and it seems working. However, as I tested only for a few steps and Athena++ does not support bitwise reproducibility anyway, I could not cover sufficient test cases. So I would like to request @Edwinchan and @kahoooo to test it thoroughly.  Also, this version can be slower than the original as it calls MPI_File_read many times.