### PR TITLE
Apply output time cadence changes even if no input file is provided during restarts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,9 +226,10 @@ int main(int argc, char *argv[]) {
     if (res_flag == 1) {
       restartfile.Open(restart_filename, IOWrapper::FileMode::read);
       pinput->LoadFromFile(restartfile);
-      // If both -r and -i are specified, make sure next_time gets corrected.
+      // make sure next_time gets corrected in case -i input file or cmdline args change
+      // the output next_time, dt, etc.
       // This needs to be corrected on the restart file because we need the old dt.
-      if (iarg_flag == 1) pinput->RollbackNextTime();
+      pinput->RollbackNextTime();
       // leave the restart file open for later use
     }
     if (iarg_flag == 1) {
@@ -295,8 +296,9 @@ int main(int argc, char *argv[]) {
 #endif // ENABLE_EXCEPTIONS
 
   // With current mesh time possibly read from restart file, correct next_time for outputs
-  if (iarg_flag == 1 && res_flag == 1) {
-    // if both -r and -i are specified, ensure that next_time  >= mesh_time - dt
+  if (res_flag == 1) {
+    // ensure that next_time  >= mesh_time - dt, in case input file or command line
+    // overrides it
     pinput->ForwardNextTime(pmesh->time);
   }
 

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -776,10 +776,13 @@ void OutputType::ClearOutputData() {
 //! \brief scans through singly linked list of OutputTypes and makes any outputs needed.
 
 void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, bool wtflag) {
+  // wtflag = only true for making final outputs due to signal or wall-time/cycle/time
+  // limit. Used by restart file output to change suffix to .final
   bool first=true;
   OutputType* ptype = pfirst_type_;
   while (ptype != nullptr) {
-    if ((pm->time == pm->start_time)
+    if (((pm->time == pm->start_time) // output initial conditions, unless next_time set
+         && (ptype->output_params.next_time <= pm->start_time ))
       || (ptype->output_params.dt > 0.0 && pm->time >= ptype->output_params.next_time)
       || (ptype->output_params.dcycle > 0 && pm->ncycle%ptype->output_params.dcycle == 0)
       || (pm->time >= pm->tlim)

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -31,7 +31,8 @@
 
 
 //----------------------------------------------------------------------------------------
-//! \fn void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
+//! \fn void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin,
+//                                          bool force_write)
 //! \brief Cycles over all MeshBlocks and writes data to a single restart file.
 
 void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool force_write) {
@@ -46,9 +47,10 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool force_wr
 
   fname.assign(output_params.file_basename);
   fname.append(".");
-  // add file number to name, unless write is forced by terminate signal, in which case
-  // replace number in the name by the string "final".  This keeps the restart file
-  // numbers consistent with output.dt when a job is restarted many times.
+  // add file number to name, unless write is forced by signal or main integration loop,
+  // (wall-time / cycle / time limit) in which case replace number in the name by the
+  // string "final".  This keeps the restart file numbers consistent with output.dt when a
+  // job is restarted many times.
   if (!force_write)
     fname.append(number);
   else


### PR DESCRIPTION
Makes command line changes equivalent to input file changes. Closes #451. Can you check @EdwinChan ? I just removed the `if (iarg_flag == 1)` check for the `Forward/RollbackNextTime()` calls in `main.cpp`, which I am pretty sure is safe in all cases but not 100% positive. 

Also closes #310, by skipping the initial condition output if `next_time > start_time`. This was one of two suggested changes; see discussion in #311. The alternative is to stop overriding `next_time` when the IC is outputted, in other words "keep `next_time` after the initial output."
- [ ] Document this change


---

#451 had many other comments and suggestions, which should be opened as separate issues if we want to pursue any of them:
- [ ] Expose `outputN/file_number` as a user-modifiable options, like `outputN/next_time`:
```
./outputs/outputs.cpp:137:      op.next_time = pin->GetOrAddReal(op.block_name,"next_time", pm->time);
```
- [ ] Give the user the ability to overwrite `mesh->time` (I suppose this only matters for restarts, since you can change `time/start_time` for fresh simulations)
- [ ] Policy change about `next_time < pm->time` behavior when `next_time` is changed via input file and/or command line during restart. I regard this as an invalid/ill-defined choice that the user has no reason to assume will result in a particular behavior , so I think the current implementation is fine. Currently we use `ForwardNextTime()` to set "the next output after the restart happens at `next_time_new = next_time + n * dt` so that `next_time_new >= pm->time` for the smallest such non-negative integer `n`"

The suggestion is that "the output should happen as soon as possible ..., because that would give us an easy way to make a debug dump right at the point of restart", i.e. `next_time_new = pm->time` like an initial condition output for the restarted simulation, which does seem useful. 

Regardless of the choice, we should explicitly document it in the Wiki if it isnt already documented. 
