### PR TITLE
Change SMALL_NUMBER to 10^-4 in the HLLD-series Riemann solvers

### DIFF
--- a/src/hydro/rsolvers/mhd/hlld.cpp
+++ b/src/hydro/rsolvers/mhd/hlld.cpp
@@ -29,8 +29,6 @@ struct Cons1D {
   Real d, mx, my, mz, e, by, bz;
 };
 
-#define SMALL_NUMBER 1.0e-8
-
 //----------------------------------------------------------------------------------------
 //! \fn void Hydro::RiemannSolver
 //! \brief The HLLD Riemann solver for adiabatic MHD
@@ -46,6 +44,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   Real flxi[(NWAVE)];             // temporary variable to store flux
   Real wli[(NWAVE)],wri[(NWAVE)]; // L/R states, primitive variables (input)
   Real spd[5];                    // signal speeds, left to right
+  constexpr Real SMALL_NUMBER = 1.0e-4;
 
   Real igm1;
   EquationOfState *peos = pmy_block->peos;

--- a/src/hydro/rsolvers/mhd/hlld_iso.cpp
+++ b/src/hydro/rsolvers/mhd/hlld_iso.cpp
@@ -28,8 +28,6 @@ struct Cons1D {
   Real d, mx, my, mz, by, bz;
 };
 
-#define SMALL_NUMBER 1.0e-8
-
 //----------------------------------------------------------------------------------------
 //! \fn void Hydro::RiemannSolver
 //! \brief The HLLD Riemann solver for isothermal MHD
@@ -45,6 +43,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   Real flxi[(NWAVE)];             // temporary variable to store flux
   Real wli[(NWAVE)],wri[(NWAVE)]; // L/R states, primitive variables (input)
   Real spd[5];                    // signal speeds, left to right
+  constexpr Real SMALL_NUMBER = 1.0e-4;
 
   Real dfloor = pmy_block->peos->GetDensityFloor();
   Real cs = (pmy_block->peos->GetIsoSoundSpeed());

--- a/src/hydro/rsolvers/mhd/lhlld.cpp
+++ b/src/hydro/rsolvers/mhd/lhlld.cpp
@@ -26,9 +26,6 @@ struct Cons1D {
   Real d, mx, my, mz, e, by, bz;
 };
 
-#define SMALL_NUMBER 1.0e-8
-
-
 //----------------------------------------------------------------------------------------
 //! \fn void Hydro::RiemannSolver
 //! \brief The Low-dissipation HLLD (LHLLD) Riemann solver for adiabatic MHD
@@ -44,6 +41,7 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
   Real flxi[(NWAVE)];             // temporary variable to store flux
   Real wli[(NWAVE)],wri[(NWAVE)]; // L/R states, primitive variables (input)
   Real spd[5];                    // signal speeds, left to right
+  constexpr Real SMALL_NUMBER = 1.0e-4;
 
   Real igm1;
   EquationOfState *peos = pmy_block->peos;


### PR DESCRIPTION
## Prerequisite checklist
- [X] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed. (at least the mhd test sets)

## Description
The SMALL_NUMBER constant was used to detect degeneracy conditions in the HLLD-series Riemann solvers (HLLD, LHLLD, and isothermal HLLD). The previous value 10^-8 was too small and failed in some situations with strong magnetic fields. This PR changes this number to 10^-4, which is more robust.

Note that the number in HLLD and LHLLD are used for comparing variables with the pressure dimension, while in the isothermal HLLD it is for comparing variables with the velocity dimension. Therefore, a different value may be more optimal for the isothermal HLLD solver.

## Testing and validation
![ssi](https://user-images.githubusercontent.com/7672598/194699026-d2d1f66d-e212-4a1c-9ae5-57e99bca3842.png)
A slow-shock with perturbation. The top panel is the original implementation and the bottom is the new one. The unphysical explosions in the original are fixed with this change.
