### PR TITLE
fix a bug in disk.cpp

### DIFF
--- a/src/pgen/disk.cpp
+++ b/src/pgen/disk.cpp
@@ -175,7 +175,7 @@ void GetCylCoord(Coordinates *pco,Real &rad,Real &phi,Real &z,int i,int j,int k)
     z=pco->x3v(k);
   } else if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0) {
     rad=std::abs(pco->x1v(i)*std::sin(pco->x2v(j)));
-    phi=pco->x3v(i);
+    phi=pco->x3v(k);
     z=pco->x1v(i)*std::cos(pco->x2v(j));
   }
   return;


### PR DESCRIPTION
As pointed out in #430, disk.cpp has a bug. 
This PR just modifies the bug, `x3v(i)` -> `x3v(k)`.