### PR TITLE
Make turbulent velocity field resolution independent

### DIFF
--- a/src/fft/turbulence.cpp
+++ b/src/fft/turbulence.cpp
@@ -258,27 +258,36 @@ void TurbulenceDriver::PowerSpectrum(std::complex<Real> *amp) {
     for (int gk=0; gk<kNx3; gk++) {
       for (int gj=0; gj<kNx2; gj++) {
         for (int gi=0; gi<kNx1; gi++) {
+          std::int64_t nx = GetKcomp(gi, 0, kNx1);
+          std::int64_t ny = GetKcomp(gj, 0, kNx2);
+          std::int64_t nz = GetKcomp(gk, 0, kNx3);
+          Real nmag = std::sqrt(nx*nx+ny*ny+nz*nz);
           int k = gk - kdisp3;
           int j = gj - kdisp2;
           int i = gi - kdisp1;
-          if ((k >= 0) && (k < knx3) &&
-              (j >= 0) && (j < knx2) &&
-              (i >= 0) && (i < knx1)) {
-            // Box-Muller Method
-            //Real q1 = ran2(&rseed);
-            //Real q2 = ran2(&rseed);
-            //Real A = std::sqrt(-2.0*std::log(q1 + 1.e-20))*std::cos(TWO_PI*q2);
-            //Real ph = ran2(&rseed)*TWO_PI;
-            std::int64_t kidx = pfb->GetIndex(i,j,k,idx);
-            Real A = ndist(rng_generator);
-            Real ph = udist(rng_generator)*TWO_PI;
-            amp[kidx] = A*std::complex<Real>(std::cos(ph), std::sin(ph));
-          } else { // if it is not in FFTBlock, just burn unused random numbers
-            Real A = ndist(rng_generator);
-            Real ph = udist(rng_generator)*TWO_PI;
-            //ran2(&rseed);
-            //ran2(&rseed);
-            //ran2(&rseed);
+          // Draw random number only in the cutoff range.
+          // This ensures the velocity field realization is independent
+          // of the grid resolution.
+          if ((nmag > nlow) && (nmag < nhigh)) {
+            if ((k >= 0) && (k < knx3) &&
+                (j >= 0) && (j < knx2) &&
+                (i >= 0) && (i < knx1)) {
+              // Box-Muller Method
+              //Real q1 = ran2(&rseed);
+              //Real q2 = ran2(&rseed);
+              //Real A = std::sqrt(-2.0*std::log(q1 + 1.e-20))*std::cos(TWO_PI*q2);
+              //Real ph = ran2(&rseed)*TWO_PI;
+              std::int64_t kidx = pfb->GetIndex(i,j,k,idx);
+              Real A = ndist(rng_generator);
+              Real ph = udist(rng_generator)*TWO_PI;
+              amp[kidx] = A*std::complex<Real>(std::cos(ph), std::sin(ph));
+            } else { // if it is not in FFTBlock, just burn unused random numbers
+              Real A = ndist(rng_generator);
+              Real ph = udist(rng_generator)*TWO_PI;
+              //ran2(&rseed);
+              //ran2(&rseed);
+              //ran2(&rseed);
+            }
           }
         }
       }

--- a/src/fft/turbulence.cpp
+++ b/src/fft/turbulence.cpp
@@ -266,17 +266,13 @@ void TurbulenceDriver::PowerSpectrum(std::complex<Real> *amp) {
           int j = gj - kdisp2;
           int i = gi - kdisp1;
           // Draw random number only in the cutoff range.
-          // This ensures the velocity field realization is independent
-          // of the grid resolution.
+          // This ensures that the perturbed velocity field is independent of
+          // the number of cells, which is useful property for resolution study.
+          // Note that this only applies for global_ps_ = true (i.e., rseed >= 0).
           if ((nmag > nlow) && (nmag < nhigh)) {
             if ((k >= 0) && (k < knx3) &&
                 (j >= 0) && (j < knx2) &&
                 (i >= 0) && (i < knx1)) {
-              // Box-Muller Method
-              //Real q1 = ran2(&rseed);
-              //Real q2 = ran2(&rseed);
-              //Real A = std::sqrt(-2.0*std::log(q1 + 1.e-20))*std::cos(TWO_PI*q2);
-              //Real ph = ran2(&rseed)*TWO_PI;
               std::int64_t kidx = pfb->GetIndex(i,j,k,idx);
               Real A = ndist(rng_generator);
               Real ph = udist(rng_generator)*TWO_PI;
@@ -284,9 +280,6 @@ void TurbulenceDriver::PowerSpectrum(std::complex<Real> *amp) {
             } else { // if it is not in FFTBlock, just burn unused random numbers
               Real A = ndist(rng_generator);
               Real ph = udist(rng_generator)*TWO_PI;
-              //ran2(&rseed);
-              //ran2(&rseed);
-              //ran2(&rseed);
             }
           }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When `rseed >= 0`, the turbulent power spectrum is generated with a global random number sequence, such that the perturbed velocity field is independent of the Meshblock configuration. However, current implementation does not give identical perturbation when the total number of cells (i.e., Mesh size) is changed. For example, the below figure plots the velocity perturbations in z=0 plane initialized with `rseed = 0`, using 32^3 (upper panels) and 64^3 (lower panels) Mesh (using `src/pgen/turb.cpp`), showing that the turbulent velocity field is different for different Mesh size.
![original](https://user-images.githubusercontent.com/13713687/195191060-0d20e948-0658-46f4-8d84-945130d5df3f.png)

This can be fixed by drawing random numbers only when the wavenumber is in the range specified by `nlow` and `nhigh`, otherwise the global random number sequence would depend on the maximum possible wavenumber set by the number of cells in each dimension. After applying the current PR, the velocity perturbation using `rseed >= 0` will not depend on the number of cells in the Mesh, as seen in the figure below.
![fixed](https://user-images.githubusercontent.com/13713687/195193284-0849a4ef-8523-4262-b4ac-f45c96ad1045.png)

This feature will be useful to make identical initial conditions for resolution study.
