### PR TITLE
Add trap for MHD with xorder=4,4c selections

### DIFF
--- a/src/reconstruct/reconstruction.cpp
+++ b/src/reconstruct/reconstruction.cpp
@@ -69,7 +69,7 @@ Reconstruction::Reconstruction(MeshBlock *pmb, ParameterInput *pin) :
     if (MAGNETIC_FIELDS_ENABLED) {
       std::stringstream msg;
       msg << "### FATAL ERROR in Reconstruction constructor" << std::endl
-          << "xorder=" << input_recon << " should not be used with MHD"<< std::endl;
+          << "xorder=" << input_recon << " should not be used with MHD"<< std::endl
           << "4th-order constrained transport algorithm is not yet merged" << std::endl;
       ATHENA_ERROR(msg);
     }

--- a/src/reconstruct/reconstruction.cpp
+++ b/src/reconstruct/reconstruction.cpp
@@ -66,6 +66,13 @@ Reconstruction::Reconstruction(MeshBlock *pmb, ParameterInput *pin) :
     xorder = 4;
     if (input_recon == "4c")
       characteristic_projection = true;
+    if (MAGNETIC_FIELDS_ENABLED) {
+      std::stringstream msg;
+      msg << "### FATAL ERROR in Reconstruction constructor" << std::endl
+          << "xorder=" << input_recon << " should not be used with MHD"<< std::endl;
+          << "4th-order constrained transport algorithm is not yet merged" << std::endl;
+      ATHENA_ERROR(msg);
+    }
   } else {
     std::stringstream msg;
     msg << "### FATAL ERROR in Reconstruction constructor" << std::endl


### PR DESCRIPTION
Adding an error trap following Shinsuke Takasao's report that using the 4th order algorithm for hydro and the second order CT algorithm with RK4 + xorder=4 was only zeroth order, and RK4 + xorder = 4c was first order.
 