### PR TITLE
Fixed Typo in Error Messages

### DIFF
--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -499,7 +499,7 @@ bool ParameterInput::GetBoolean(std::string block, std::string name) {
   // get pointer to node with same block name in singly linked list of InputBlocks
   pb = GetPtrToBlock(block);
   if (pb == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetReal]" << std::endl
+    msg << "### FATAL ERROR in function [ParameterInput::GetBoolean]" << std::endl
         << "Block name '" << block << "' not found when trying to set value "
         << "for parameter '" << name << "'";
     ATHENA_ERROR(msg);
@@ -508,7 +508,7 @@ bool ParameterInput::GetBoolean(std::string block, std::string name) {
   // get pointer to node with same parameter name in singly linked list of InputLines
   pl = pb->GetPtrToLine(name);
   if (pl == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetReal]" << std::endl
+    msg << "### FATAL ERROR in function [ParameterInput::GetBoolean]" << std::endl
         << "Parameter name '" << name << "' not found in block '" << block << "'";
     ATHENA_ERROR(msg);
   }
@@ -545,7 +545,7 @@ std::string ParameterInput::GetString(std::string block, std::string name) {
   // get pointer to node with same block name in singly linked list of InputBlocks
   pb = GetPtrToBlock(block);
   if (pb == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetReal]" << std::endl
+    msg << "### FATAL ERROR in function [ParameterInput::GetString]" << std::endl
         << "Block name '" << block << "' not found when trying to set value "
         << "for parameter '" << name << "'";
     ATHENA_ERROR(msg);
@@ -554,7 +554,7 @@ std::string ParameterInput::GetString(std::string block, std::string name) {
   // get pointer to node with same parameter name in singly linked list of InputLines
   pl = pb->GetPtrToLine(name);
   if (pl == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetReal]" << std::endl
+    msg << "### FATAL ERROR in function [ParameterInput::GetString]" << std::endl
         << "Parameter name '" << name << "' not found in block '" << block << "'";
     ATHENA_ERROR(msg);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [X] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
Error messages in parameter_inpit.cpp stated they were raised in the wrong function.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

...

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->

- [ ] Future development task
