### PR TITLE
Replace more nonconstant references with const

### DIFF
--- a/src/bvals/bvals_refine.cpp
+++ b/src/bvals/bvals_refine.cpp
@@ -95,7 +95,7 @@
 void BoundaryValues::ProlongateBoundaries(const Real time, const Real dt,
                                           std::vector<BoundaryVariable *> bvars_subset) {
   MeshBlock *pmb = pmy_block_;
-  int &mylevel = loc.level;
+  const int& mylevel = loc.level;
 
   // TODO(KGF): temporarily hardcode Hydro and Field array access for the below switch
   // around ApplyPhysicalBoundariesOnCoarseLevel()
@@ -318,7 +318,7 @@ void BoundaryValues::RestrictGhostCellsOnSameLevel(const NeighborBlock& nb, int 
   for (auto fc_pair : pmr->pvars_fc_) {
     FaceField *var_fc = std::get<0>(fc_pair);
     FaceField *coarse_fc = std::get<1>(fc_pair);
-    int &mylevel = loc.level;
+    const int& mylevel = loc.level;
     int rs = ris, re = rie + 1;
     if (rs == pmb->cis   && nblevel[nk+1][nj+1][ni  ] < mylevel) rs++;
     if (re == pmb->cie+1 && nblevel[nk+1][nj+1][ni+2] < mylevel) re--;
@@ -582,7 +582,7 @@ void BoundaryValues::ProlongateGhostCells(const NeighborBlock& nb,
   }
 
   // prolongate face-centered S/AMR-enrolled quantities (magnetic fields)
-  int &mylevel = pmb->loc.level;
+  const int& mylevel = pmb->loc.level;
   int il, iu, jl, ju, kl, ku;
   il = si, iu = ei + 1;
   if ((nb.ni.ox1 >= 0) && (nblevel[nb.ni.ox3+1][nb.ni.ox2+1][nb.ni.ox1  ] >= mylevel))

--- a/src/bvals/bvals_refine_postmg.cpp
+++ b/src/bvals/bvals_refine_postmg.cpp
@@ -33,7 +33,7 @@ class CellCenteredCellCenteredBoundaryVariable;
 
 void BoundaryValues::ProlongateBoundariesPostMG(CellCenteredBoundaryVariable* pbvar) {
   MeshBlock *pmb = pmy_block_;
-  int &mylevel = loc.level;
+  const int &mylevel = loc.level;
 
   // For each finer neighbor, to prolongate a boundary we need to fill one more cell
   // surrounding the boundary zone to calculate the slopes ("ghost-ghost zone"). 3x steps:

--- a/src/bvals/cc/bvals_cc.cpp
+++ b/src/bvals/cc/bvals_cc.cpp
@@ -86,7 +86,7 @@ CellCenteredBoundaryVariable::CellCenteredBoundaryVariable(
     int nc2 = pmb->ncells2;
     int nc3 = pmb->ncells3;
     int nx3 = pmb->block_size.nx3;
-    int &xgh = pbval_->xgh_;
+    const int& xgh = pbval_->xgh_;
     for (int upper=0; upper<2; upper++) {
       if (pbval_->is_shear[upper]) {
         shear_cc_[upper].NewAthenaArray(nu_+1, nc3, NGHOST, nc2+2*xgh+1);
@@ -196,7 +196,7 @@ CellCenteredBoundaryVariable::CellCenteredBoundaryVariable(
     int nc2 = pmb->ncells2;
     int nc3 = pmb->ncells3;
     int nx3 = pmb->block_size.nx3;
-    int &xgh = pbval_->xgh_;
+    const int& xgh = pbval_->xgh_;
     for (int upper=0; upper<2; upper++) {
       if (pbval_->is_shear[upper]) {
         shear_cc_[upper].NewAthenaArray(nc3, NGHOST, nc2+2*xgh+1, nu_+1);
@@ -614,7 +614,7 @@ void CellCenteredBoundaryVariable::PolarBoundarySingleAzimuthalBlock() {
 void CellCenteredBoundaryVariable::SetupPersistentMPI() {
 #ifdef MPI_PARALLEL
   MeshBlock* pmb = pmy_block_;
-  int &mylevel = pmb->loc.level;
+  const int& mylevel = pmb->loc.level;
 
   int f2 = pmy_mesh_->f2, f3 = pmy_mesh_->f3;
   int cng, cng1, cng2, cng3;
@@ -1120,4 +1120,3 @@ void CellCenteredBoundaryVariable::ExpandPhysicalBoundaries() {
 
   return;
 }
-

--- a/src/bvals/cc/bvals_shear_cc.cpp
+++ b/src/bvals/cc/bvals_shear_cc.cpp
@@ -136,7 +136,7 @@ void CellCenteredBoundaryVariable::SetShearingBoxBoundarySameLevel(
   MeshBlock *pmb = pmy_block_;
   Mesh *pmesh = pmb->pmy_mesh;
   int si, sj, sk, ei, ej, ek;
-  int &xgh = pbval_->xgh_;
+  const int& xgh = pbval_->xgh_;
   si = pmb->is-NGHOST; ei = pmb->is-1;
   sk = pmb->ks;        ek = pmb->ke;
   if (pmesh->mesh_size.nx3 > 1)  ek += NGHOST, sk -= NGHOST;
@@ -215,9 +215,9 @@ void CellCenteredBoundaryVariable::SetShearingBoxBoundaryBuffers() {
   OrbitalAdvection *porb = pmb->porb;
   AthenaArray<Real> &var = *var_cc;
   AthenaArray<Real> &pflux = pbval_->pflux_;
-  int &xgh = pbval_->xgh_;
-  int &xorder = pbval_->xorder_;
-  int nb_offset[2]{0, 4};
+  const int& xgh = pbval_->xgh_;
+  const int& xorder = pbval_->xorder_;
+  //int nb_offset[2]{0, 4};
   int ib[2]{pmb->is - NGHOST, pmb->ie + 1};
   int js = pmb->js, je = pmb->je;
   int kl = pmb->ks, ku = pmb->ke;

--- a/src/bvals/cc/bvals_shear_flux.cpp
+++ b/src/bvals/cc/bvals_shear_flux.cpp
@@ -122,7 +122,7 @@ void CellCenteredBoundaryVariable::SetFluxShearingBoxBoundarySameLevel(
                        AthenaArray<Real> &src, Real *buf, const int nb) {
   MeshBlock *pmb = pmy_block_;
   int sj, sk, ej, ek;
-  int &xgh = pbval_->xgh_;
+  const int& xgh = pbval_->xgh_;
   sk = pmb->ks;        ek = pmb->ke;
 
   int *jmin1 = pbval_->sb_flux_data_[0].jmin_recv;
@@ -201,11 +201,10 @@ bool CellCenteredBoundaryVariable::ReceiveFluxShearingBoxBoundaryBuffers() {
 
 void CellCenteredBoundaryVariable::SetFluxShearingBoxBoundaryBuffers() {
   MeshBlock *pmb = pmy_block_;
-  Mesh *pmesh = pmb->pmy_mesh;
   OrbitalAdvection *porb = pmb->porb;
   AthenaArray<Real> &pflux = pbval_->pflux_;
-  int &xgh = pbval_->xgh_;
-  int &xorder = pbval_->xorder_;
+  const int& xgh = pbval_->xgh_;
+  const int& xorder = pbval_->xorder_;
   int is = pmb->is, ie = pmb->ie;
   int js = pmb->js, je = pmb->je;
   int ks = pmb->ks, ke = pmb->ke;

--- a/src/bvals/cc/hydro/bvals_shear_hydro.cpp
+++ b/src/bvals/cc/hydro/bvals_shear_hydro.cpp
@@ -94,7 +94,7 @@ void HydroBoundaryVariable::AddHydroShearForInit() {
 void HydroBoundaryVariable::ShearQuantities(AthenaArray<Real> &shear_cc_, bool upper) {
   MeshBlock *pmb = pmy_block_;
   Mesh *pmesh = pmb->pmy_mesh;
-  int &xgh = pbval_->xgh_;
+  const int &xgh = pbval_->xgh_;
   int jl = pmb->js - NGHOST;
   int ju = pmb->je + NGHOST+2*xgh+1;
   int kl = pmb->ks;
@@ -106,7 +106,7 @@ void HydroBoundaryVariable::ShearQuantities(AthenaArray<Real> &shear_cc_, bool u
 
   Real qomL = pbval_->qomL_;
   int sign[2]{1, -1};
-  int ib[2]{pmb->is - NGHOST, pmb->ie + 1};
+  //int ib[2]{pmb->is - NGHOST, pmb->ie + 1};
 
   for (int k=kl; k<=ku; k++) {
     for (int i=0; i<NGHOST; i++) {

--- a/src/bvals/cc/mg/bvals_mg.cpp
+++ b/src/bvals/cc/mg/bvals_mg.cpp
@@ -160,7 +160,7 @@ void MGBoundaryValues::DispatchBoundaryFunction(BoundaryFace face, AthenaArray<R
   if (!fcoeff) {
     AthenaArray<Real> &mpcoeff = pmy_mg_->pmy_driver_->mpcoeff_[0];
     AthenaArray<Real> &mpo = pmy_mg_->pmy_driver_->mpo_;
-    int &mporder = pmy_mg_->pmy_driver_->mporder_;
+    const int& mporder = pmy_mg_->pmy_driver_->mporder_;
     switch (face) {
       case BoundaryFace::inner_x1:
         switch (block_bcs[BoundaryFace::inner_x1]) {

--- a/src/bvals/cc/nr_radiation/bvals_shear_rad.cpp
+++ b/src/bvals/cc/nr_radiation/bvals_shear_rad.cpp
@@ -110,7 +110,7 @@ void RadBoundaryVariable::ShearQuantities(AthenaArray<Real> &shear_cc_, bool upp
   Mesh *pmesh = pmb->pmy_mesh;
   Hydro *phydro = pmb->phydro;
   NRRadiation *prad = pmb->pnrrad;
-  int &xgh = pbval_->xgh_;
+  const int& xgh = pbval_->xgh_;
   int jl = pmb->js - NGHOST;
   int ju = pmb->je + NGHOST+2*xgh+1;
   int kl = pmb->ks;
@@ -209,7 +209,7 @@ void RadBoundaryVariable::SetShearingBoxBoundarySameLevel(
   MeshBlock *pmb = pmy_block_;
   Mesh *pmesh = pmb->pmy_mesh;
   int si, sj, sk, ei, ej, ek;
-  int &xgh = pbval_->xgh_;
+  const int& xgh = pbval_->xgh_;
   si = pmb->is-NGHOST; ei = pmb->is-1;
   sk = pmb->ks;        ek = pmb->ke;
   if (pmesh->mesh_size.nx3 > 1)  ek += NGHOST, sk -= NGHOST;
@@ -248,8 +248,8 @@ void RadBoundaryVariable::SetShearingBoxBoundaryBuffers() {
   OrbitalAdvection *porb = pmb->porb;
   AthenaArray<Real> &var = *var_cc;
   AthenaArray<Real> &pflux = pflux_;
-  int &xgh = pbval_->xgh_;
-  int &xorder = pmb->pnrrad->pradintegrator->rad_xorder;
+  const int& xgh = pbval_->xgh_;
+  const int& xorder = pmb->pnrrad->pradintegrator->rad_xorder;
   int ib[2]{pmb->is - NGHOST, pmb->ie + 1};
   int js = pmb->js, je = pmb->je;
   int kl = pmb->ks, ku = pmb->ke;

--- a/src/bvals/cc/nr_radiation/bvals_shear_rad_flux.cpp
+++ b/src/bvals/cc/nr_radiation/bvals_shear_rad_flux.cpp
@@ -90,7 +90,7 @@ void RadBoundaryVariable::SetFluxShearingBoxBoundarySameLevel(
                        AthenaArray<Real> &src, Real *buf, const int nb) {
   MeshBlock *pmb = pmy_block_;
   int sj, sk, ej, ek;
-  int &xgh = pbval_->xgh_;
+  const int& xgh = pbval_->xgh_;
   sk = pmb->ks;        ek = pmb->ke;
 
   int *jmin1 = pbval_->sb_flux_data_[0].jmin_recv;
@@ -131,8 +131,8 @@ void RadBoundaryVariable::SetFluxShearingBoxBoundaryBuffers() {
   MeshBlock *pmb = pmy_block_;
   OrbitalAdvection *porb = pmb->porb;
   AthenaArray<Real> &pflux = pflux_;
-  int &xgh = pbval_->xgh_;
-  int &xorder = pmb->pnrrad->pradintegrator->rad_xorder;
+  const int& xgh = pbval_->xgh_;
+  const int& xorder = pmb->pnrrad->pradintegrator->rad_xorder;
   int is = pmb->is, ie = pmb->ie;
   int js = pmb->js, je = pmb->je;
   int ks = pmb->ks, ke = pmb->ke;

--- a/src/bvals/cc/nr_radiation/outflow_rad.cpp
+++ b/src/bvals/cc/nr_radiation/outflow_rad.cpp
@@ -36,8 +36,8 @@
 void RadBoundaryVariable::OutflowInnerX1(Real time, Real dt, int il, int jl, int ju,
                                          int kl, int ku, int ngh) {
   // copy radiation variables into ghost zones,
-  int &nang = pmy_block_->pnrrad->nang; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmy_block_->pnrrad->nang; // angles per octant
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -62,8 +62,8 @@ void RadBoundaryVariable::OutflowInnerX1(Real time, Real dt, int il, int jl, int
 void RadBoundaryVariable::OutflowOuterX1(Real time, Real dt, int iu, int jl, int ju,
                                          int kl, int ku, int ngh) {
   // copy radiation variables into ghost zones,
-  int &nang = pmy_block_->pnrrad->nang; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmy_block_->pnrrad->nang; // angles per octant
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -89,7 +89,7 @@ void RadBoundaryVariable::OutflowInnerX2(Real time, Real dt, int il, int iu, int
                                          int kl, int ku, int ngh) {
   // copy radiation variables into ghost zones,
   int nang = pmy_block_->pnrrad->nang;
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=1; j<=ngh; ++j) {
@@ -114,8 +114,8 @@ void RadBoundaryVariable::OutflowInnerX2(Real time, Real dt, int il, int iu, int
 void RadBoundaryVariable::OutflowOuterX2(Real time, Real dt, int il, int iu, int ju,
                                          int kl, int ku, int ngh) {
   // copy radiation variables into ghost zones,
-  int &nang = pmy_block_->pnrrad->nang; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmy_block_->pnrrad->nang; // angles per octant
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=1; j<=ngh; ++j) {
@@ -141,8 +141,8 @@ void RadBoundaryVariable::OutflowInnerX3(Real time, Real dt, int il, int iu, int
                                          int ju, int kl, int ngh) {
   // copy radiation variables into ghost zones,
 
-  int &nang = pmy_block_->pnrrad->nang;
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmy_block_->pnrrad->nang;
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -168,8 +168,8 @@ void RadBoundaryVariable::OutflowOuterX3(Real time, Real dt, int il, int iu, int
                                          int ju, int ku, int ngh) {
   // copy radiation variables into ghost zones,
 
-  int &nang = pmy_block_->pnrrad->nang; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmy_block_->pnrrad->nang; // angles per octant
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {

--- a/src/bvals/cc/nr_radiation/reflect_rad.cpp
+++ b/src/bvals/cc/nr_radiation/reflect_rad.cpp
@@ -47,9 +47,9 @@ void RadBoundaryVariable::ReflectInnerX1(Real time, Real dt, int il, int jl, int
                                          int kl, int ku, int ngh) {
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -83,9 +83,9 @@ void RadBoundaryVariable::ReflectOuterX1(
     Real time, Real dt, int iu, int jl, int ju, int kl, int ku, int ngh) {
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -119,9 +119,9 @@ void RadBoundaryVariable::ReflectInnerX2(Real time, Real dt, int il, int iu, int
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
 
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=1; j<=ngh; ++j) {
@@ -156,9 +156,9 @@ void RadBoundaryVariable::ReflectOuterX2(Real time, Real dt, int il, int iu, int
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
 
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=1; j<=ngh; ++j) {
@@ -194,9 +194,9 @@ void RadBoundaryVariable::ReflectInnerX3(Real time, Real dt, int il, int iu, int
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
 
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -225,9 +225,9 @@ void RadBoundaryVariable::ReflectOuterX3(Real time, Real dt, int il, int iu, int
                                          int ju, int ku, int ngh) {
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {

--- a/src/bvals/cc/nr_radiation/rotate_rad.cpp
+++ b/src/bvals/cc/nr_radiation/rotate_rad.cpp
@@ -174,9 +174,9 @@ void CopyIntensity5(Real *ir, int n_ang, int direction) {
 void RadBoundaryVariable::RotateHPi_InnerX2(
     Real time, Real dt, int il, int iu, int jl, int kl, int ku, int ngh) {
   // copy radiation variables into ghost zones
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=1; j<=ngh; ++j) {
@@ -199,9 +199,9 @@ void RadBoundaryVariable::RotateHPi_InnerX2(
 
 void RadBoundaryVariable::RotateHPi_OuterX2(
     Real time, Real dt, int il, int iu, int ju, int kl, int ku, int ngh) {
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang =pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=1; j<=ngh; ++j) {
@@ -228,9 +228,9 @@ void RadBoundaryVariable::RotateHPi_OuterX2(
 void RadBoundaryVariable::RotateHPi_InnerX3(
     Real time, Real dt, int il, int iu, int jl, int ju, int kl, int ngh) {
   // copy radiation variables into ghost zones
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq =pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq =pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -257,9 +257,9 @@ void RadBoundaryVariable::RotateHPi_InnerX3(
 void RadBoundaryVariable::RotateHPi_OuterX3(
     Real time, Real dt, int il, int iu, int jl, int ju, int ku, int ngh) {
   // copy radiation variables into ghost zones
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -287,9 +287,9 @@ void RadBoundaryVariable::RotateHPi_OuterX3(
 void RadBoundaryVariable::RotatePi_InnerX3(
     Real time, Real dt, int il, int iu, int jl, int ju, int kl, int ngh) {
   // copy radiation variables into ghost zones
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -316,9 +316,9 @@ void RadBoundaryVariable::RotatePi_InnerX3(
 void RadBoundaryVariable::RotatePi_OuterX3(
     Real time, Real dt, int il, int iu, int jl, int ju, int ku, int ngh) {
   // copy radiation variables into ghost zones
-  int &noct = pmy_block_->pnrrad->noct;
+  const int& noct = pmy_block_->pnrrad->noct;
   int n_ang = pmy_block_->pnrrad->nang/noct; // angles per octant
-  int &nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
+  const int& nfreq = pmy_block_->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {

--- a/src/bvals/cc/nr_radiation/vacuum_rad.cpp
+++ b/src/bvals/cc/nr_radiation/vacuum_rad.cpp
@@ -37,8 +37,8 @@ void RadBoundaryVariable::VacuumInnerX1(Real time, Real dt, int il, int jl, int 
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
   MeshBlock *pmb=pmy_block_;
-  int &nang = pmb->pnrrad->nang; // angles per octant
-  int &nfreq = pmb->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmb->pnrrad->nang; // angles per octant
+  const int& nfreq = pmb->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -71,8 +71,8 @@ void RadBoundaryVariable::VacuumOuterX1(
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
   MeshBlock *pmb=pmy_block_;
-  int &nang = pmb->pnrrad->nang; // angles per octant
-  int &nfreq = pmb->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmb->pnrrad->nang; // angles per octant
+  const int& nfreq = pmb->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -108,8 +108,8 @@ void RadBoundaryVariable::VacuumInnerX2(
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
   MeshBlock *pmb=pmy_block_;
-  int &nang = pmb->pnrrad->nang; // angles per octant
-  int &nfreq = pmb->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmb->pnrrad->nang; // angles per octant
+  const int& nfreq = pmb->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=1; j<=ngh; ++j) {
@@ -142,8 +142,8 @@ void RadBoundaryVariable::VacuumOuterX2(
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
   MeshBlock *pmb=pmy_block_;
-  int &nang = pmb->pnrrad->nang; // angles per octant
-  int &nfreq = pmb->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmb->pnrrad->nang; // angles per octant
+  const int& nfreq = pmb->pnrrad->nfreq; // number of frequency bands
 
   for (int k=kl; k<=ku; ++k) {
     for (int j=1; j<=ngh; ++j) {
@@ -181,8 +181,8 @@ void RadBoundaryVariable::VacuumInnerX3(
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
   MeshBlock *pmb=pmy_block_;
-  int &nang = pmb->pnrrad->nang; // angles per octant
-  int &nfreq = pmb->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmb->pnrrad->nang; // angles per octant
+  const int& nfreq = pmb->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {
@@ -216,8 +216,8 @@ void RadBoundaryVariable::VacuumOuterX3(
   // copy radiation variables into ghost zones,
   // reflect rays along angles with opposite nx
   MeshBlock *pmb=pmy_block_;
-  int &nang = pmb->pnrrad->nang; // angles per octant
-  int &nfreq = pmb->pnrrad->nfreq; // number of frequency bands
+  const int& nang = pmb->pnrrad->nang; // angles per octant
+  const int& nfreq = pmb->pnrrad->nfreq; // number of frequency bands
 
   for (int k=1; k<=ngh; ++k) {
     for (int j=jl; j<=ju; ++j) {

--- a/src/bvals/cc/nr_radiation/vacuum_rad.cpp
+++ b/src/bvals/cc/nr_radiation/vacuum_rad.cpp
@@ -46,7 +46,7 @@ void RadBoundaryVariable::VacuumInnerX1(Real time, Real dt, int il, int jl, int 
         for (int ifr=0; ifr<nfreq; ++ifr) {
           for(int n=0; n<nang; ++n) {
             int ang=ifr*nang+n;
-            Real& miux=pmb->pnrrad->mu(0,k,j,il,n);
+            const Real& miux=pmb->pnrrad->mu(0,k,j,il,n);
             if (miux < 0.0) {
               (*var_cc)(k,j,il-i,ang) = (*var_cc)(k,j,il,ang);
             } else {
@@ -80,7 +80,7 @@ void RadBoundaryVariable::VacuumOuterX1(
         for (int ifr=0; ifr<nfreq; ++ifr) {
           for(int n=0; n<nang; ++n) {
             int ang=ifr*nang+n;
-            Real& miux=pmb->pnrrad->mu(0,k,j,iu,n);
+            const Real& miux=pmb->pnrrad->mu(0,k,j,iu,n);
             if (miux > 0.0) {
               (*var_cc)(k,j,iu+i,ang) = (*var_cc)(k,j,iu,ang);
             } else {
@@ -117,7 +117,7 @@ void RadBoundaryVariable::VacuumInnerX2(
         for (int ifr=0; ifr<nfreq; ++ifr) {
           for(int n=0; n<nang; ++n) {
             int ang=ifr*nang+n;
-            Real& miuy=pmb->pnrrad->mu(1,k,jl,i,n);
+            const Real& miuy=pmb->pnrrad->mu(1,k,jl,i,n);
             if (miuy < 0.0) {
               (*var_cc)(k,jl-j,i,ang) = (*var_cc)(k,jl,i,ang);
             } else {
@@ -151,7 +151,7 @@ void RadBoundaryVariable::VacuumOuterX2(
         for (int ifr=0; ifr<nfreq; ++ifr) {
           for(int n=0; n<nang; ++n) {
             int ang=ifr*nang+n;
-            Real& miuy=pmb->pnrrad->mu(1,k,ju,i,n);
+            const Real& miuy=pmb->pnrrad->mu(1,k,ju,i,n);
             if (miuy > 0.0) {
               (*var_cc)(k,ju+j,i,ang) = (*var_cc)(k,ju,i,ang);
             } else {
@@ -190,7 +190,7 @@ void RadBoundaryVariable::VacuumInnerX3(
         for (int ifr=0; ifr<nfreq; ++ifr) {
           for(int n=0; n<nang; ++n) {
             int ang=ifr*nang+n;
-            Real& miuz=pmb->pnrrad->mu(2,kl,j,i,n);
+            const Real& miuz=pmb->pnrrad->mu(2,kl,j,i,n);
             if (miuz < 0.0) {
               (*var_cc)(kl-k,j,i,ang) = (*var_cc)(kl,j,i,ang);
             } else {
@@ -225,7 +225,7 @@ void RadBoundaryVariable::VacuumOuterX3(
         for (int ifr=0; ifr<nfreq; ++ifr) {
           for(int n=0; n<nang; ++n) {
             int ang=ifr*nang+n;
-            Real& miuz=pmb->pnrrad->mu(2,ku,j,i,n);
+            const Real& miuz=pmb->pnrrad->mu(2,ku,j,i,n);
             if (miuz > 0.0) {
               (*var_cc)(ku+k,j,i,ang) = (*var_cc)(ku,j,i,ang);
             } else {

--- a/src/bvals/fc/bvals_fc.cpp
+++ b/src/bvals/fc/bvals_fc.cpp
@@ -127,7 +127,7 @@ FaceCenteredBoundaryVariable::FaceCenteredBoundaryVariable(MeshBlock *pmb,
     int nc3 = pmb->ncells3;
     int nx2 = pmb->block_size.nx2;
     int nx3 = pmb->block_size.nx3;
-    int &xgh = pbval_->xgh_;
+    const int& xgh = pbval_->xgh_;
     for (int upper=0; upper<2; upper++) {
       if (pbval_->is_shear[upper]) {
         shear_fc_[upper].x2f.NewAthenaArray(nc3, NGHOST, nc2+2*xgh+2);
@@ -1128,7 +1128,7 @@ void FaceCenteredBoundaryVariable::PolarFieldBoundaryAverage() {
 
 void FaceCenteredBoundaryVariable::CountFineEdges() {
   MeshBlock* pmb = pmy_block_;
-  int &mylevel = pmb->loc.level;
+  const int& mylevel = pmb->loc.level;
 
   // count the number of the fine meshblocks contacting on each edge
   int eid = 0;
@@ -1204,7 +1204,7 @@ void FaceCenteredBoundaryVariable::SetupPersistentMPI() {
   int nx1 = pmb->block_size.nx1;
   int nx2 = pmb->block_size.nx2;
   int nx3 = pmb->block_size.nx3;
-  int &mylevel = pmb->loc.level;
+  const int& mylevel = pmb->loc.level;
 
   int f2 = pmy_mesh_->f2, f3 = pmy_mesh_->f3;
   int cng, cng1, cng2, cng3;

--- a/src/bvals/fc/bvals_shear_emf.cpp
+++ b/src/bvals/fc/bvals_shear_emf.cpp
@@ -153,7 +153,7 @@ void FaceCenteredBoundaryVariable::SendEMFShearingBoxBoundaryCorrection() {
 void FaceCenteredBoundaryVariable::SetEMFShearingBoxBoundarySameLevel(
                                    EdgeField &dst, Real *buf, const int nb) {
   MeshBlock *pmb = pmy_block_;
-  int &xgh = pbval_->xgh_;
+  const int& xgh = pbval_->xgh_;
   int sj, sk, ej, ek;
 
   sk = pmb->ks; ek = pmb->ke;
@@ -244,8 +244,8 @@ bool FaceCenteredBoundaryVariable::ReceiveEMFShearingBoxBoundaryCorrection() {
 void FaceCenteredBoundaryVariable::SetEMFShearingBoxBoundaryCorrection() {
   MeshBlock *pmb = pmy_block_;
   OrbitalAdvection *porb = pmb->porb;
-  int &xgh = pbval_->xgh_;
-  int &xorder = pbval_->xorder_;
+  const int& xgh = pbval_->xgh_;
+  const int& xorder = pbval_->xorder_;
   AthenaArray<Real> &pflux = pbval_->pflux_;
   AthenaArray<Real> &e2 = pmb->pfield->e.x2e;
   AthenaArray<Real> &e3 = pmb->pfield->e.x3e;

--- a/src/bvals/fc/bvals_shear_fc.cpp
+++ b/src/bvals/fc/bvals_shear_fc.cpp
@@ -143,7 +143,7 @@ void FaceCenteredBoundaryVariable::SetShearingBoxBoundarySameLevel(
                            FaceField &dst, Real *buf, const int nb) {
   MeshBlock *pmb = pmy_block_;
   Mesh *pmesh = pmb->pmy_mesh;
-  int &xgh = pbval_->xgh_;
+  const int& xgh = pbval_->xgh_;
   int si, sj, sk, ei, ej, ek;
   si = pmb->is-NGHOST; ei = pmb->is-1;
   sk = pmb->ks;        ek = pmb->ke;
@@ -239,8 +239,8 @@ bool FaceCenteredBoundaryVariable::ReceiveShearingBoxBoundaryBuffers() {
 void FaceCenteredBoundaryVariable::SetShearingBoxBoundaryBuffers() {
   MeshBlock *pmb = pmy_block_;
   Mesh *pmesh = pmb->pmy_mesh;
-  int &xgh = pbval_->xgh_;
-  int &xorder = pbval_->xorder_;
+  const int& xgh = pbval_->xgh_;
+  const int& xorder = pbval_->xorder_;
   AthenaArray<Real> &pflux = pbval_->pflux_;
   FaceField &var = *var_fc;
   Coordinates *pco = pmb->pcoord;
@@ -296,12 +296,12 @@ void FaceCenteredBoundaryVariable::SetShearingBoxBoundaryBuffers() {
       // present way is only for cartesian
       if (upper==0) {
         for (int k=kl; k<=ku; k++) {
-          Real &dx3 = pco->dx3f(k);
+          const Real& dx3 = pco->dx3f(k);
           for (int j=jl; j<=ju; j++) {
-            Real &dx2 = pco->dx2f(j);
+            const Real& dx2 = pco->dx2f(j);
             for (int i=0; i<NGHOST; i++) {
               int ii = pmb->is-1-i;
-              Real &dx1 = pco->dx1f(ii);
+              const Real& dx1 = pco->dx1f(ii);
               var.x1f(k,j,ii) =
                  var.x1f(k,j,ii+1) +
                  dx1/dx2*(var.x2f(k,j+1,ii)-var.x2f(k,j,ii)) +
@@ -311,12 +311,12 @@ void FaceCenteredBoundaryVariable::SetShearingBoxBoundaryBuffers() {
         }
       } else {
         for (int k=kl; k<=ku; k++) {
-          Real &dx3 = pco->dx3f(k);
+          const Real& dx3 = pco->dx3f(k);
           for (int j=jl; j<=ju; j++) {
-            Real &dx2 = pco->dx2f(j);
+            const Real& dx2 = pco->dx2f(j);
             for (int i=0; i<NGHOST; i++) {
               int ii = pmb->ie+1+i;
-              Real &dx1 = pco->dx1f(ii);
+              const Real& dx1 = pco->dx1f(ii);
               var.x1f(k,j,ii+1) =
                  var.x1f(k,j,ii) -
                  dx1/dx2*(var.x2f(k,j+1,ii)-var.x2f(k,j,ii)) -

--- a/src/bvals/orbital/bvals_orbital.cpp
+++ b/src/bvals/orbital/bvals_orbital.cpp
@@ -856,7 +856,7 @@ void OrbitalBoundaryCommunication::LoadHydroBufferSameLevel(Real *buf, int &p, i
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       if (nb==0) {
         for(int k=pmb->ks; k<=pmb->ke; k++) {
           for(int i=pmb->is; i<=pmb->ie; i++) {
@@ -889,7 +889,7 @@ void OrbitalBoundaryCommunication::LoadHydroBufferSameLevel(Real *buf, int &p, i
         ATHENA_ERROR(msg);
       }
     } else if (porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       if (nb==0) {
         for(int j=pmb->js; j<=pmb->je; j++) {
           for(int i=pmb->is; i<=pmb->ie; i++) {
@@ -1022,7 +1022,7 @@ void OrbitalBoundaryCommunication::LoadHydroBufferToFiner(Real *buf, int &p, int
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int &onx = pmb->block_size.nx2;
       int il, iu, jl, ju, kl, ku;
       if (pmb->block_size.nx3>1) {
         if(nb%4<2) {
@@ -1059,7 +1059,7 @@ void OrbitalBoundaryCommunication::LoadHydroBufferToFiner(Real *buf, int &p, int
       BufferUtility::PackData(ui, buf, 0, NHYDRO-1,
                               il, iu, jl, ju, kl, ku, p);
     } else if (porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int &onx = pmb->block_size.nx3;
       int il, iu, jl, ju, kl, ku;
       if(nb%4<2) {
         jl = pmb->js-1;
@@ -1109,7 +1109,7 @@ void OrbitalBoundaryCommunication::SetHydroBufferSameLevel(
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int &onx = pmb->block_size.nx2;
       if (nb==0) {
         for(int k=pmb->ks; k<=pmb->ke; k++) {
           for(int i=pmb->is; i<=pmb->ie; i++) {
@@ -1152,7 +1152,7 @@ void OrbitalBoundaryCommunication::SetHydroBufferSameLevel(
         ATHENA_ERROR(msg);
       }
     } else if(porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       if (nb==0) {
         for(int j=pmb->js; j<=pmb->je; j++) {
           for(int i=pmb->is; i<=pmb->ie; i++) {
@@ -1213,7 +1213,7 @@ void OrbitalBoundaryCommunication::SetHydroBufferFromCoarser(
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       int il, iu, kl, ku;
       if (pmb->block_size.nx3>1) {
         kl = pmb->cks-1;
@@ -1296,7 +1296,7 @@ void OrbitalBoundaryCommunication::SetHydroBufferFromCoarser(
         ATHENA_ERROR(msg);
       }
     } else if(porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       int il, iu, jl, ju;
       il = pmb->cis-1;
       iu = pmb->cie+1;
@@ -1390,7 +1390,7 @@ void OrbitalBoundaryCommunication::SetHydroBufferFromFiner(
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       int hnx1 = pmb->block_size.nx1/2;
       int hnx3 = pmb->block_size.nx3/2;
       int il, iu, kl, ku;
@@ -1462,7 +1462,7 @@ void OrbitalBoundaryCommunication::SetHydroBufferFromFiner(
         ATHENA_ERROR(msg);
       }
     } else if(porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       int hnx1 = pmb->block_size.nx1/2;
       int hnx2 = pmb->block_size.nx2/2;
       int il, iu, jl, ju;
@@ -1537,7 +1537,7 @@ void OrbitalBoundaryCommunication::LoadFieldBufferSameLevel(Real *buf, int &p, i
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       if (nb==0) {
         // b1
         for(int k=pmb->ks; k<=pmb->ke  ; k++) {
@@ -1588,7 +1588,7 @@ void OrbitalBoundaryCommunication::LoadFieldBufferSameLevel(Real *buf, int &p, i
         ATHENA_ERROR(msg);
       }
     } else if (porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       if (nb==0) {
         // -b1
         for(int j=pmb->js; j<=pmb->je  ; j++) {
@@ -1889,7 +1889,7 @@ void OrbitalBoundaryCommunication::SetFieldBufferSameLevel(
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       if (nb==0) {
         for(int k=pmb->ks; k<=pmb->ke  ; k++) {
           for(int i=pmb->is; i<=pmb->ie+1; i++) {
@@ -1956,7 +1956,7 @@ void OrbitalBoundaryCommunication::SetFieldBufferSameLevel(
         ATHENA_ERROR(msg);
       }
     } else if (porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       if (nb==0) {
         for(int j=pmb->js; j<=pmb->je  ; j++) {
           for(int i=pmb->is; i<=pmb->ie+1; i++) {
@@ -2298,7 +2298,7 @@ void OrbitalBoundaryCommunication::SetFieldBufferFromFiner(
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       int hnx1 = pmb->block_size.nx1/2;
       int hnx3 = pmb->block_size.nx3/2;
       int il, iu, kl, ku;
@@ -2394,7 +2394,7 @@ void OrbitalBoundaryCommunication::SetFieldBufferFromFiner(
         ATHENA_ERROR(msg);
       }
     } else if(porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       int hnx1 = pmb->block_size.nx1/2;
       int hnx2 = pmb->block_size.nx2/2;
       int il, iu, jl, ju;
@@ -2493,7 +2493,7 @@ void OrbitalBoundaryCommunication::LoadScalarBufferSameLevel(
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       if (nb==0) {
         for(int k=pmb->ks; k<=pmb->ke; k++) {
           for(int i=pmb->is; i<=pmb->ie; i++) {
@@ -2526,7 +2526,7 @@ void OrbitalBoundaryCommunication::LoadScalarBufferSameLevel(
         ATHENA_ERROR(msg);
       }
     } else if (porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       if (nb==0) {
         for(int j=pmb->js; j<=pmb->je; j++) {
           for(int i=pmb->is; i<=pmb->ie; i++) {
@@ -2659,7 +2659,7 @@ void OrbitalBoundaryCommunication::LoadScalarBufferToFiner(Real *buf, int &p, in
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       int il, iu, jl, ju, kl, ku;
       if (pmb->block_size.nx3>1) {
         if(nb%4<2) {
@@ -2696,7 +2696,7 @@ void OrbitalBoundaryCommunication::LoadScalarBufferToFiner(Real *buf, int &p, in
       BufferUtility::PackData(si, buf, 0, NSCALARS-1,
                               il, iu, jl, ju, kl, ku, p);
     } else if (porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       int il, iu, jl, ju, kl, ku;
       if (nb%4<2) {
         jl = pmb->js-1;
@@ -2746,7 +2746,7 @@ void OrbitalBoundaryCommunication::SetScalarBufferSameLevel(
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       if(nb==0) {
         for(int k=pmb->ks; k<=pmb->ke; k++) {
           for(int i=pmb->is; i<=pmb->ie; i++) {
@@ -2789,7 +2789,7 @@ void OrbitalBoundaryCommunication::SetScalarBufferSameLevel(
         ATHENA_ERROR(msg);
       }
     } else if(porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       if (nb==0) {
         for(int j=pmb->js; j<=pmb->je; j++) {
           for(int i=pmb->is; i<=pmb->ie; i++) {
@@ -2850,7 +2850,7 @@ void OrbitalBoundaryCommunication::SetScalarBufferFromCoarser(
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       int il, iu, kl, ku;
       if(pmb->block_size.nx3>1) {
         kl = pmb->cks-1;
@@ -2933,7 +2933,7 @@ void OrbitalBoundaryCommunication::SetScalarBufferFromCoarser(
         ATHENA_ERROR(msg);
       }
     } else if(porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       int il, iu, jl, ju;
       jl = pmb->cjs-1;
       ju = pmb->cje+1;
@@ -3027,7 +3027,7 @@ void OrbitalBoundaryCommunication::SetScalarBufferFromFiner(
 
   if(porb->orbital_uniform_mesh) { // uniform mesh
     if(porb->orbital_direction == 1) {
-      int &onx = pmb->block_size.nx2;
+      const int& onx = pmb->block_size.nx2;
       int hnx1 = pmb->block_size.nx1/2;
       int hnx3 = pmb->block_size.nx3/2;
       int il, iu, kl, ku;
@@ -3099,7 +3099,7 @@ void OrbitalBoundaryCommunication::SetScalarBufferFromFiner(
         ATHENA_ERROR(msg);
       }
     } else if(porb->orbital_direction == 2) {
-      int &onx = pmb->block_size.nx3;
+      const int& onx = pmb->block_size.nx3;
       int hnx1 = pmb->block_size.nx1/2;
       int hnx2 = pmb->block_size.nx2/2;
       int il, iu, jl, ju;

--- a/src/coordinates/coordinates.cpp
+++ b/src/coordinates/coordinates.cpp
@@ -87,7 +87,7 @@ Coordinates::Coordinates(MeshBlock *pmb, ParameterInput *pin, bool flag) :
 
   std::int64_t nrootmesh, noffset;
   std::int64_t &lx1 = pmy_block->loc.lx1;
-  int &ll = pmy_block->loc.level;
+  const int &ll = pmy_block->loc.level;
 
   //--- X1-DIRECTION: initialize coordinates and spacing of cell FACES (x1f,dx1f)
 
@@ -817,7 +817,7 @@ void Coordinates::AngularVol(NRRadiation *prad, AthenaArray<Real> &vol) {
 
 void Coordinates::GetGeometryZeta(NRRadiation *prad, const int k, const int j,
                                   const int i, AthenaArray<Real> &g_zeta) {
-  int &nzeta = prad->nzeta;
+  const int& nzeta = prad->nzeta;
   for (int n=0; n<nzeta*2+1; ++n) {
     g_zeta(n) = 1.0;
   }
@@ -826,7 +826,7 @@ void Coordinates::GetGeometryZeta(NRRadiation *prad, const int k, const int j,
 void Coordinates::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
                                  const int i, const int n_zeta,
                                  AthenaArray<Real> &g_psi) {
-  int &npsi = prad->npsi;
+  const int& npsi = prad->npsi;
   for (int n=0; n<2*npsi+1; ++n) {
     g_psi(n) = 1.0;
   }
@@ -835,7 +835,7 @@ void Coordinates::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
 // function overwirte in case nzeta = 0
 void Coordinates::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
                                  const int i, AthenaArray<Real> &g_psi) {
-  int &npsi = prad->npsi;
+  const int& npsi = prad->npsi;
   for (int n=0; n<2*npsi+1; ++n) {
     g_psi(n) = 1.0;
   }

--- a/src/coordinates/cylindrical.cpp
+++ b/src/coordinates/cylindrical.cpp
@@ -315,8 +315,8 @@ void Cylindrical::AddCoordTermsDivergence(
         u(IM1,k,j,i) += dt*coord_src1_i_(i)*m_pp;
 
         // src_2 = -< M_{phi r} ><1/r>
-        Real& x_i   = x1f(i);
-        Real& x_ip1 = x1f(i+1);
+        const Real& x_i   = x1f(i);
+        const Real& x_ip1 = x1f(i+1);
         // Ju PhD thesis equation 2.14
         u(IM2,k,j,i) -= dt*coord_src2_i_(i)*(x_i*flux[X1DIR](IM2,k,j,i)
                                              + x_ip1*flux[X1DIR](IM2,k,j,i+1));
@@ -347,8 +347,8 @@ void Cylindrical::AddCoordTermsDivergence_STS(
           u(IM1,k,j,i) += dt*coord_src1_i_(i)*m_pp;
 
           // src_2 = -< M_{phi r} ><1/r>
-          Real& x_i   = x1f(i);
-          Real& x_ip1 = x1f(i+1);
+          const Real& x_i   = x1f(i);
+          const Real& x_ip1 = x1f(i+1);
           u(IM2,k,j,i) -= dt*coord_src2_i_(i)*(x_i*flux[X1DIR](IM2,k,j,i)
                                                + x_ip1*flux[X1DIR](IM2,k,j,i+1));
 
@@ -430,7 +430,7 @@ void Cylindrical::ConvertAngle(MeshBlock *pmb, const int nang,
 
     for (int k=0; k<n3z; ++k) {
       for (int j=0; j<n2z; ++j) {
-        Real& x2 = x2v(j);
+        const Real& x2 = x2v(j);
         Real cosx2 = cos(x2);
         Real sinx2 = sin(x2);
         if (n2z == 1) {

--- a/src/coordinates/spherical_polar.cpp
+++ b/src/coordinates/spherical_polar.cpp
@@ -717,7 +717,7 @@ void SphericalPolar::ConvertAngle(MeshBlock *pmb, const int nang,
 // this needs to go throug all the nzeta
 void SphericalPolar::GetGeometryZeta(NRRadiation *prad, const int k, const int j,
                                      const int i, AthenaArray<Real> &g_zeta) {
-  int &nzeta = prad->nzeta;
+  const int& nzeta = prad->nzeta;
   Real radius = x1v(i);
   for(int n=0; n<nzeta*2+1; ++n) {
     g_zeta(n) = 1./radius;
@@ -729,11 +729,11 @@ void SphericalPolar::GetGeometryZeta(NRRadiation *prad, const int k, const int j
 void SphericalPolar::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
                                     const int i, const int n_zeta,
                                     AthenaArray<Real> &g_psi) {
-  int &npsi = prad->npsi;
+  const int &npsi = prad->npsi;
   Real radius = x1v(i);
   Real sinzeta_v = 1.0 - prad->coszeta_v(n_zeta) * prad->coszeta_v(n_zeta);
   sinzeta_v = std::sqrt(sinzeta_v);
-  Real &cottheta = prad->cot_theta(j);
+  const Real &cottheta = prad->cot_theta(j);
   if (npsi == 1) {
     for(int n=0; n<2*npsi+1; ++n) {
       g_psi(n) = 0.0;
@@ -748,10 +748,10 @@ void SphericalPolar::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
 
 void SphericalPolar::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
                         const int i, AthenaArray<Real> &g_psi) {
-  int &npsi = prad->npsi;
+  const int& npsi = prad->npsi;
   Real radius = x1v(i);
 
-  Real &cottheta = prad->cot_theta(j);
+  const Real &cottheta = prad->cot_theta(j);
   if (npsi == 1) {
     for(int n=0; n<2*npsi+1; ++n) {
       g_psi(n) = 0.0;

--- a/src/hydro/new_blockdt.cpp
+++ b/src/hydro/new_blockdt.cpp
@@ -146,14 +146,14 @@ void Hydro::NewBlockTimeStep() {
 
       // compute minimum of (v1 +/- C)
       for (int i=is; i<=ie; ++i) {
-        Real& dt_1 = dt1(i);
+        const Real& dt_1 = dt1(i);
         min_dt_hyperbolic = std::min(min_dt_hyperbolic, dt_1);
       }
 
       // if grid is 2D/3D, compute minimum of (v2 +/- C)
       if (pmb->block_size.nx2 > 1) {
         for (int i=is; i<=ie; ++i) {
-          Real& dt_2 = dt2(i);
+          const Real& dt_2 = dt2(i);
           min_dt_hyperbolic = std::min(min_dt_hyperbolic, dt_2);
         }
       }
@@ -161,7 +161,7 @@ void Hydro::NewBlockTimeStep() {
       // if grid is 3D, compute minimum of (v3 +/- C)
       if (pmb->block_size.nx3 > 1) {
         for (int i=is; i<=ie; ++i) {
-          Real& dt_3 = dt3(i);
+          const Real& dt_3 = dt3(i);
           min_dt_hyperbolic = std::min(min_dt_hyperbolic, dt_3);
         }
       }

--- a/src/hydro/rsolvers/mhd/llf_mhd_rel_no_transform.cpp
+++ b/src/hydro/rsolvers/mhd/llf_mhd_rel_no_transform.cpp
@@ -93,52 +93,52 @@ void Hydro::RiemannSolver(const int k, const int j, const int il, const int iu,
     }
 
     // Extract left primitives
-    const Real &rho_l = prim_l(IDN,k,j,i);
-    const Real &pgas_l = prim_l(IPR,k,j,i);
-    const Real &uu1_l = prim_l(IVX,k,j,i);
-    const Real &uu2_l = prim_l(IVY,k,j,i);
-    const Real &uu3_l = prim_l(IVZ,k,j,i);
+    const Real &rho_l = prim_l(IDN,i);
+    const Real &pgas_l = prim_l(IPR,i);
+    const Real &uu1_l = prim_l(IVX,i);
+    const Real &uu2_l = prim_l(IVY,i);
+    const Real &uu3_l = prim_l(IVZ,i);
     Real bb1_l, bb2_l, bb3_l;
     switch (ivx) {
       case IVX:
         bb1_l = bb(k,j,i);
-        bb2_l = prim_l(IBY,k,j,i);
-        bb3_l = prim_l(IBZ,k,j,i);
+        bb2_l = prim_l(IBY,i);
+        bb3_l = prim_l(IBZ,i);
         break;
       case IVY:
         bb2_l = bb(k,j,i);
-        bb3_l = prim_l(IBY,k,j,i);
-        bb1_l = prim_l(IBZ,k,j,i);
+        bb3_l = prim_l(IBY,i);
+        bb1_l = prim_l(IBZ,i);
         break;
       case IVZ:
         bb3_l = bb(k,j,i);
-        bb1_l = prim_l(IBY,k,j,i);
-        bb2_l = prim_l(IBZ,k,j,i);
+        bb1_l = prim_l(IBY,i);
+        bb2_l = prim_l(IBZ,i);
         break;
     }
 
     // Extract right primitives
-    const Real &rho_r = prim_r(IDN,k,j,i);
-    const Real &pgas_r = prim_r(IPR,k,j,i);
-    const Real &uu1_r = prim_r(IVX,k,j,i);
-    const Real &uu2_r = prim_r(IVY,k,j,i);
-    const Real &uu3_r = prim_r(IVZ,k,j,i);
+    const Real &rho_r = prim_r(IDN,i);
+    const Real &pgas_r = prim_r(IPR,i);
+    const Real &uu1_r = prim_r(IVX,i);
+    const Real &uu2_r = prim_r(IVY,i);
+    const Real &uu3_r = prim_r(IVZ,i);
     Real bb1_r, bb2_r, bb3_r;
     switch (ivx) {
       case IVX:
         bb1_r = bb(k,j,i);
-        bb2_r = prim_r(IBY,k,j,i);
-        bb3_r = prim_r(IBZ,k,j,i);
+        bb2_r = prim_r(IBY,i);
+        bb3_r = prim_r(IBZ,i);
         break;
       case IVY:
         bb2_r = bb(k,j,i);
-        bb3_r = prim_r(IBY,k,j,i);
-        bb1_r = prim_r(IBZ,k,j,i);
+        bb3_r = prim_r(IBY,i);
+        bb1_r = prim_r(IBZ,i);
         break;
       case IVZ:
         bb3_r = bb(k,j,i);
-        bb1_r = prim_r(IBY,k,j,i);
-        bb2_r = prim_r(IBZ,k,j,i);
+        bb1_r = prim_r(IBY,i);
+        bb2_r = prim_r(IBZ,i);
         break;
     }
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1055,7 +1055,7 @@ void Mesh::OutputMeshStructure(int ndim) {
         std::int64_t &lx1 = loclist[j].lx1;
         std::int64_t &lx2 = loclist[j].lx2;
         std::int64_t &lx3 = loclist[j].lx3;
-        int &ll = loclist[j].level;
+        const int &ll = loclist[j].level;
         mincost = std::min(mincost,costlist[i]);
         maxcost = std::max(maxcost,costlist[i]);
         totalcost += costlist[i];
@@ -1883,7 +1883,7 @@ MeshBlock* Mesh::FindMeshBlock(int tgid) {
 void Mesh::SetBlockSizeAndBoundaries(LogicalLocation loc, RegionSize &block_size,
                                      BoundaryFlag *block_bcs) {
   std::int64_t &lx1 = loc.lx1;
-  int &ll = loc.level;
+  const int &ll = loc.level;
   std::int64_t nrbx_ll = nrbx1 << (ll - root_level);
 
   // calculate physical block size, x1

--- a/src/nr_radiation/implicit/implicit_angular_flux.cpp
+++ b/src/nr_radiation/implicit/implicit_angular_flux.cpp
@@ -53,7 +53,7 @@ void RadIntegrator::ImplicitAngularFluxesCoef(const Real wght) {
   Coordinates *pco=pmb->pcoord;
   std::stringstream msg;
 
-  int &nzeta = prad->nzeta;
+  const int& nzeta = prad->nzeta;
   //int &npsi = prad->npsi;
   AthenaArray<Real> &area_zeta = zeta_area_, &ang_vol = ang_vol_;
   int is = pmb->is; int js = pmb->js; int ks = pmb->ks;
@@ -105,7 +105,7 @@ void RadIntegrator::ImplicitPsiFluxCoef(int k, int j, int i, int n_zeta, Real wg
   NRRadiation *prad=pmy_rad;
   Coordinates *pco=prad->pmy_block->pcoord;
   AthenaArray<Real> &area_psi = psi_area_, &ang_vol = ang_vol_, &zeta_area = zeta_area_;
-  int &npsi = prad->npsi;
+  const int& npsi = prad->npsi;
   // the equation to solve
   //(1+zeta_coef0+zeta_coef1) I + Div F_psi = 0
   pco->GetGeometryPsi(prad,k,j,i,n_zeta,g_psi_);
@@ -147,10 +147,10 @@ void RadIntegrator::ImplicitAngularFluxes(const int k, const int j, const int i,
   NRRadiation *prad=pmy_rad;
   std::stringstream msg;
 
-  int &nzeta = prad->nzeta;
-  // int &npsi = prad->npsi;
-  int &nang = prad->nang;
-  int &nfreq = prad->nfreq;
+  const int& nzeta = prad->nzeta;
+  // const int& npsi = prad->npsi;
+  const int& nang = prad->nang;
+  const int& nfreq = prad->nfreq;
 
   // AthenaArray<Real> &area_zeta = zeta_area_, &ang_vol = ang_vol_;
 
@@ -176,10 +176,10 @@ void RadIntegrator::ImplicitAngularFluxes(const int k, const int j, const int i,
 void RadIntegrator::ImplicitPsiFlux(const int k, const int j, const int i,
                       int ifr, int n_zeta, AthenaArray<Real> &ir_ini) {
   NRRadiation *prad=pmy_rad;
-  int &npsi = prad->npsi;
+  const int& npsi = prad->npsi;
   // m=0
   int ang_num = n_zeta*2*npsi;
-  int &nang = prad->nang;
+  const int& nang = prad->nang;
 
   Real *psi_l = &(imp_ang_psi_l_(k,j,i,ang_num));
   Real *psi_r = &(imp_ang_psi_r_(k,j,i,ang_num));

--- a/src/nr_radiation/implicit/implicit_first_order.cpp
+++ b/src/nr_radiation/implicit/implicit_first_order.cpp
@@ -59,14 +59,6 @@ void RadIntegrator::FirstOrderFluxDivergenceCoef(const Real wght) {
                  &x2area_p1 = x2face_area_p1_, &x3area = x3face_area_,
                  &x3area_p1 = x3face_area_p1_, &vol = cell_volume_;
 
-  // AthenaArray<Real> &x1flux=prad->flux[X1DIR];
-  // AthenaArray<Real> &x2flux=prad->flux[X2DIR];
-  // AthenaArray<Real> &x3flux=prad->flux[X3DIR];
-
-  // AthenaArray<Real> &area_zeta = zeta_area_, &area_psi = psi_area_,
-  //                &ang_vol = ang_vol_;
-  // int &nzeta = prad->nzeta, &npsi = prad->npsi;
-
   for (int k=ks; k<=ke; ++k) {
     for (int j=js; j<=je; ++j) {
       pco->CenterWidth1(k,j,is-1,ie+1,dxw1_);

--- a/src/nr_radiation/implicit/rad_iteration.cpp
+++ b/src/nr_radiation/implicit/rad_iteration.cpp
@@ -206,8 +206,8 @@ void IMRadiation::Iteration(
 void IMRadiation::CheckResidual(MeshBlock *pmb,
                                 AthenaArray<Real> &ir_old, AthenaArray<Real> &ir_new) {
   NRRadiation *prad = pmb->pnrrad;
-  int &nang =prad->nang;
-  int &nfreq=prad->nfreq;
+  const int& nang =prad->nang;
+  const int& nfreq=prad->nfreq;
   int is = pmb->is; int js = pmb->js; int ks = pmb->ks;
   int ie = pmb->ie; int je = pmb->je; int ke = pmb->ke;
 

--- a/src/nr_radiation/integrators/frame_transform.cpp
+++ b/src/nr_radiation/integrators/frame_transform.cpp
@@ -47,8 +47,8 @@ void RadIntegrator::LabToCom(const Real vx, const Real vy, const Real vz,
                           Real *ir_lab, AthenaArray<Real> &ir_cm) {
   //Real& prat = pmy_rad->prat;
   Real invcrat = 1.0/pmy_rad->crat;
-  int& nang=pmy_rad->nang;
-  int& nfreq=pmy_rad->nfreq;
+  const int& nang=pmy_rad->nang;
+  const int& nfreq=pmy_rad->nfreq;
 
   // square of Lorentz factor
   Real lorzsq = 1.0/(1.0 - (vx * vx + vy * vy + vz * vz) * invcrat * invcrat);
@@ -74,8 +74,8 @@ void RadIntegrator::ComToLab(const Real vx, const Real vy, const Real vz,
                           Real *mux, Real *muy, Real *muz,
                           AthenaArray<Real> &ir_cm, Real *ir_lab) {
   Real invcrat = 1.0/pmy_rad->crat;
-  int& nang=pmy_rad->nang;
-  int& nfreq=pmy_rad->nfreq;
+  const int& nang=pmy_rad->nang;
+  const int& nfreq=pmy_rad->nfreq;
 
   // square of Lorentz factor
   Real lorzsq = 1.0/(1.0 - (vx * vx + vy * vy + vz * vz) * invcrat * invcrat);
@@ -101,8 +101,8 @@ void RadIntegrator::ComToLabMultiGroup(const Real vx, const Real vy, const Real 
                           Real *mux, Real *muy, Real *muz,
                           AthenaArray<Real> &ir_cm, Real *ir_lab) {
   Real invcrat = 1.0/pmy_rad->crat;
-  int& nang=pmy_rad->nang;
-  int& nfreq=pmy_rad->nfreq;
+  const int& nang=pmy_rad->nang;
+  const int& nfreq=pmy_rad->nfreq;
   AthenaArray<Real> split_ratio;
   AthenaArray<int> map_start, map_end;
 

--- a/src/nr_radiation/integrators/multi_group.cpp
+++ b/src/nr_radiation/integrators/multi_group.cpp
@@ -56,7 +56,7 @@ void RadIntegrator::MapLabToCmFrequency(Real &tran_coef,
                    AthenaArray<Real> &split_ratio,
                    AthenaArray<int> &map_start, AthenaArray<int> &map_end,
                    AthenaArray<Real> &ir_cm, AthenaArray<Real> &ir_shift) {
-  int &nfreq=pmy_rad->nfreq;
+  const int& nfreq=pmy_rad->nfreq;
 
   // prepare the frequency bin width
   for (int ifr=0; ifr<nfreq-1; ++ifr) {
@@ -72,7 +72,7 @@ void RadIntegrator::MapLabToCmFrequency(Real &tran_coef,
 
 void RadIntegrator::GetCmMCIntensity(AthenaArray<Real> &ir_cm,
                           AthenaArray<Real> &delta_nu_n, AthenaArray<Real> &ir_face) {
-  int &nfreq = pmy_rad->nfreq;
+  const int& nfreq = pmy_rad->nfreq;
   if (nfreq > 1) {
     ir_face(0) = 0.0;
     for (int ifr=1; ifr<nfreq; ++ifr) {
@@ -92,7 +92,7 @@ void RadIntegrator::ForwardSplitting(
     Real &tran_coef, AthenaArray<Real> &ir_cm, AthenaArray<Real> &ir_face,
     AthenaArray<Real> &split_ratio, AthenaArray<int> &map_start,
     AthenaArray<int> &map_end) {
-  int &nfreq = pmy_rad->nfreq;
+  const int& nfreq = pmy_rad->nfreq;
   Real *nu_lab = &(pmy_rad->nu_grid(0));
   // check to make sure nfreq > 2
   if (nfreq < 2) {
@@ -203,7 +203,7 @@ void RadIntegrator::ForwardSplitting(
 void RadIntegrator::MapIrcmFrequency( AthenaArray<Real> &split_ratio,
       AthenaArray<int> &map_start, AthenaArray<int> &map_end,
       AthenaArray<Real> &input_array, AthenaArray<Real> &shift_array) {
-  int &nfreq = pmy_rad->nfreq;
+  const int& nfreq = pmy_rad->nfreq;
 
   // initialize ir_shift to be 0
   shift_array.ZeroClear();
@@ -220,8 +220,8 @@ void RadIntegrator::MapIrcmFrequency( AthenaArray<Real> &split_ratio,
   // map intensity to the desired bin
   for (int ifr=0; ifr<nfreq; ++ifr) {
     // map shifted intensity to the nu_grid
-    int &fre_start=map_start(ifr);
-    int &fre_end = map_end(ifr);
+    const int& fre_start=map_start(ifr);
+    const int& fre_end = map_end(ifr);
     for (int m=fre_start; m<=fre_end; ++m) {
       shift_array(m) += input_array(ifr) * split_ratio(ifr,m-fre_start);
     }
@@ -236,7 +236,7 @@ bool RadIntegrator::FreMapMatrix(AthenaArray<Real> &split_ratio,
           Real &tran_coef, AthenaArray<int> &map_bin_start,
           AthenaArray<int> &map_bin_end, AthenaArray<int> &map_count,
                                       AthenaArray<Real> &map_matrix) {
-  int &nfreq = pmy_rad->nfreq;
+  const int& nfreq = pmy_rad->nfreq;
 
   map_matrix.ZeroClear();
   map_count.ZeroClear();
@@ -255,8 +255,8 @@ bool RadIntegrator::FreMapMatrix(AthenaArray<Real> &split_ratio,
     // fre_map_matrix is lower triangle
     // make sure fre_map_matrix(ifr,0) is always the diagonal
     for (int ifr=0; ifr<nfreq; ++ifr) {
-      int &fre_start=map_bin_start(ifr);
-      int &fre_end = map_bin_end(ifr);
+      const int& fre_start=map_bin_start(ifr);
+      const int& fre_end = map_bin_end(ifr);
       // m is always larger than ifr
       // lower triangle, when store the matrix, we always start from diagonal
       for (int m=fre_start; m<=fre_end; ++m) {
@@ -268,8 +268,8 @@ bool RadIntegrator::FreMapMatrix(AthenaArray<Real> &split_ratio,
     // fre_map_matrix is upper triangle
     // make sure fre_map_matrix(ifr,0) is always the diagonal
     for (int ifr=0; ifr<nfreq; ++ifr) {
-      int &fre_start=map_bin_start(ifr);
-      int &fre_end = map_bin_end(ifr);
+      const int& fre_start=map_bin_start(ifr);
+      const int& fre_end = map_bin_end(ifr);
       // m is always smaller than ifr
       // upper triangle, when store the matrix, we always start from diagonal
       for (int m=fre_start; m<=fre_end; ++m) {
@@ -289,7 +289,7 @@ bool RadIntegrator::InverseMapFrequency(
     Real &tran_coef,
     AthenaArray<int> &map_count, AthenaArray<Real> &map_matrix,
     AthenaArray<Real> &input_array, AthenaArray<Real> &shift_array) {
-  int &nfreq = pmy_rad->nfreq;
+  const int& nfreq = pmy_rad->nfreq;
   // clear zero
   shift_array.ZeroClear();
   // Now invert the matrix split_ratio
@@ -398,7 +398,7 @@ void RadIntegrator::BackwardSplitting(Real &tran_coef,
                       AthenaArray<Real> &ir_cm, AthenaArray<Real> &ir_face,
                       AthenaArray<Real> &split_ratio,
                       AthenaArray<int> &map_start,AthenaArray<int> &map_end) {
-  int &nfreq = pmy_rad->nfreq;
+  const int& nfreq = pmy_rad->nfreq;
   Real *nu_lab = &(pmy_rad->nu_grid(0));
   Real *nu_shift = &(nu_shift_(0));
   // check to make sure nfreq > 2

--- a/src/nr_radiation/integrators/rad_integrators.cpp
+++ b/src/nr_radiation/integrators/rad_integrators.cpp
@@ -390,11 +390,11 @@ void RadIntegrator::GetTgasVel(MeshBlock *pmb, const Real dt,
   NRRadiation *prad=pmb->pnrrad;
   Coordinates *pco=pmb->pcoord;
 
-  Real& prat = prad->prat;
+  const Real& prat = prad->prat;
   Real invcrat = 1.0/prad->crat;
 
-  int &nang =prad->nang;
-  int &nfreq=prad->nfreq;
+  const int &nang =prad->nang;
+  const int &nfreq=prad->nfreq;
 
   int is = pmb->is; int js = pmb->js; int ks = pmb->ks;
   int ie = pmb->ie; int je = pmb->je; int ke = pmb->ke;

--- a/src/nr_radiation/integrators/rad_integrators.cpp
+++ b/src/nr_radiation/integrators/rad_integrators.cpp
@@ -247,8 +247,8 @@ RadIntegrator::RadIntegrator(NRRadiation *prad, ParameterInput *pin) {
   imp_ang_psi_l_.NewAthenaArray(ncells3,ncells2,ncells1,prad->n_fre_ang);
 
   if (prad->angle_flag == 1) {
-    int &nzeta = prad->nzeta;
-    int &npsi = prad->npsi;
+    const int& nzeta = prad->nzeta;
+    const int& npsi = prad->npsi;
     if (nzeta > 0) {
       g_zeta_.NewAthenaArray(2*nzeta+1);
       q_zeta_.NewAthenaArray(2*nzeta+2*NGHOST);
@@ -672,11 +672,11 @@ void RadIntegrator::PredictVel(AthenaArray<Real> &ir, int k, int j, int i,
                                Real dt, Real rho, Real *vx, Real *vy, Real *vz) {
   NRRadiation *prad = pmy_rad;
 
-  Real &prat = prad->prat;
+  const Real &prat = prad->prat;
   Real invcrat = 1.0/prad->crat;
   Real ct = dt * prad->reduced_c;
-  int& nang =prad->nang;
-  int& nfreq=prad->nfreq;
+  const int& nang =prad->nang;
+  const int& nfreq=prad->nfreq;
   // first, calculate the moments
   Real er =0.0, fr1=0.0, fr2=0.0, fr3=0.0,
       pr11=0.0,pr12=0.0,pr13=0.0,pr22=0.0,

--- a/src/nr_radiation/integrators/rad_source.cpp
+++ b/src/nr_radiation/integrators/rad_source.cpp
@@ -61,8 +61,8 @@ void RadIntegrator::CalSourceTerms(MeshBlock *pmb, const Real dt,
   Real *sigma_at, *sigma_s, *sigma_p, *sigma_pe;
   Real *lab_ir;
 
-  int &nang =prad->nang;
-  int &nfreq=prad->nfreq;
+  const int &nang =prad->nang;
+  const int &nfreq=prad->nfreq;
 
   // Get the temporary arrays
   AthenaArray<Real> &wmu_cm = wmu_cm_;
@@ -264,7 +264,7 @@ void RadIntegrator::AddMultiGroupCompt(MeshBlock *pmb, const Real dt,
   // need to transform lab frame ir to co-moving frame
   NRRadiation *prad=pmb->pnrrad;
 
-  Real& prat = prad->prat;
+  const Real& prat = prad->prat;
   Real invcrat = 1.0/prad->crat;
   Real invredfactor = prad->crat/prad->reduced_c;
 
@@ -422,7 +422,7 @@ void RadIntegrator::AddMultiGroupCompt(MeshBlock *pmb, const Real dt,
 void RadIntegrator::GetHydroSourceTerms(MeshBlock *pmb,
                        AthenaArray<Real> &ir_ini, AthenaArray<Real> &ir) {
   NRRadiation *prad=pmb->pnrrad;
-  Real& prat = prad->prat;
+  const Real& prat = prad->prat;
   Real invcrat = 1.0/prad->crat;
   Real invredc = 1.0/prad->reduced_c;
   Real invredfactor = invredc/invcrat;

--- a/src/nr_radiation/integrators/rad_source.cpp
+++ b/src/nr_radiation/integrators/rad_source.cpp
@@ -273,8 +273,8 @@ void RadIntegrator::AddMultiGroupCompt(MeshBlock *pmb, const Real dt,
 
   Real *lab_ir;
 
-  int &nang =prad->nang;
-  int &nfreq=prad->nfreq;
+  const int& nang =prad->nang;
+  const int& nfreq=prad->nfreq;
 
   // only apply for multi-grou case
   if ((nfreq > 1) && (compton_flag_ > 0) && (split_compton_ > 0)) {
@@ -427,8 +427,8 @@ void RadIntegrator::GetHydroSourceTerms(MeshBlock *pmb,
   Real invredc = 1.0/prad->reduced_c;
   Real invredfactor = invredc/invcrat;
 
-  int &nang =prad->nang;
-  int &nfreq=prad->nfreq;
+  const int& nang =prad->nang;
+  const int& nfreq=prad->nfreq;
 
   int is = pmb->is; int js = pmb->js; int ks = pmb->ks;
   int ie = pmb->ie; int je = pmb->je; int ke = pmb->ke;

--- a/src/nr_radiation/integrators/rad_transport.cpp
+++ b/src/nr_radiation/integrators/rad_transport.cpp
@@ -131,7 +131,7 @@ void RadIntegrator::CalculateFluxes(AthenaArray<Real> &w,
                             + smin[n] * (smax[n] - vl) * irrn[n] * sm_diff[n];
         }
         if (adv_flag_ > 0) {
-          Real &advv = adv_vel(0,k,j,i);
+          const Real &advv = adv_vel(0,k,j,i);
           if (advv >0) {
             for (int n=0; n<prad->n_fre_ang; ++n) {
               x1flux(k,j,i,n) += advv * irln[n];
@@ -225,7 +225,7 @@ void RadIntegrator::CalculateFluxes(AthenaArray<Real> &w,
             // + smax[n] * smin[n] * (irrn[n] - irln[n]))/(smax[n] - smin[n]);
           }
           if (adv_flag_ > 0) {
-            Real &advv = adv_vel(1,k,j,i);
+            const Real &advv = adv_vel(1,k,j,i);
             if (advv >0) {
               for (int n=0; n<prad->n_fre_ang; ++n) {
                 x2flux(k,j,i,n) += advv * irln[n];
@@ -323,7 +323,7 @@ void RadIntegrator::CalculateFluxes(AthenaArray<Real> &w,
             // + smax[n] * smin[n] * (irrn[n] - irln[n]))/(smax[n] - smin[n]);
           }// end n
           if (adv_flag_ > 0) {
-            Real &advv = adv_vel(2,k,j,i);
+            const Real &advv = adv_vel(2,k,j,i);
             if (advv >0) {
               for (int n=0; n<prad->n_fre_ang; ++n) {
                 x3flux(k,j,i,n) += advv * irln[n];
@@ -348,8 +348,8 @@ void RadIntegrator::CalculateFluxes(AthenaArray<Real> &w,
         for (int i=is; i<=ie; ++i) {
           // going through all frequency groups
           for (int ifr=0; ifr<nfreq; ++ifr) {
-            int &nzeta = prad->nzeta;
-            int &npsi = prad->npsi;
+            const int& nzeta = prad->nzeta;
+            const int& npsi = prad->npsi;
             int psi_limit=2*npsi;
             if (npsi == 0) psi_limit=1;
 
@@ -406,8 +406,8 @@ void RadIntegrator::CalculateFluxes(AthenaArray<Real> &w,
       for (int j=js; j<=je; ++j) {
         for (int i=is; i<=ie; ++i) {
           for (int ifr=0; ifr<nfreq; ++ifr) {
-            int &nzeta = prad->nzeta;
-            int &npsi = prad->npsi;
+            const int& nzeta = prad->nzeta;
+            const int& npsi = prad->npsi;
             int zeta_limit=2*nzeta;
             if (nzeta == 0) zeta_limit=1;
 
@@ -503,7 +503,7 @@ void RadIntegrator::CalculateFluxes(AthenaArray<Real> &ir, const int order) {
 
       // calculate flux with velocity times the interface state
       for (int i=is; i<=ie+1; ++i) {
-        Real &vel = adv_vel(0,k,j,i);
+        const Real &vel = adv_vel(0,k,j,i);
         if (vel >0) {
           for (int n=0; n<prad->n_fre_ang; ++n) {
             x1flux(k,j,i,n) = vel * il_(i,n);
@@ -547,7 +547,7 @@ void RadIntegrator::CalculateFluxes(AthenaArray<Real> &ir, const int order) {
 
         // calculate flux with velocity times the interface state
         for (int i=il; i<=iu; ++i) {
-          Real &vel = adv_vel(1,k,j,i);
+          const Real &vel = adv_vel(1,k,j,i);
           if (vel > 0) {
             for (int n=0; n<prad->n_fre_ang; ++n) {
               x2flux(k,j,i,n) = vel * il_(i,n);
@@ -592,7 +592,7 @@ void RadIntegrator::CalculateFluxes(AthenaArray<Real> &ir, const int order) {
 
         // calculate flux with velocity times the interface state
         for (int i=il; i<=iu; ++i) {
-          Real &vel = adv_vel(2,k,j,i);
+          const Real &vel = adv_vel(2,k,j,i);
           if (vel > 0) {
             for (int n=0; n<prad->n_fre_ang; ++n) {
               x3flux(k,j,i,n) = vel * il_(i,n);
@@ -707,7 +707,8 @@ void RadIntegrator::FluxDivergence(const Real wght, AthenaArray<Real> &ir_in,
 
   AthenaArray<Real> &area_zeta = zeta_area_, &area_psi = psi_area_,
                       &ang_vol = ang_vol_, &dflx_ang = dflx_ang_;
-  int &nzeta = prad->nzeta, &npsi = prad->npsi;
+  const int& nzeta = prad->nzeta;
+  const int& npsi = prad->npsi;
 
   for (int k=ks; k<=ke; ++k) {
     for (int j=js; j<=je; ++j) {

--- a/src/nr_radiation/integrators/srcterms/absorption_scattering.cpp
+++ b/src/nr_radiation/integrators/srcterms/absorption_scattering.cpp
@@ -51,11 +51,11 @@ Real RadIntegrator::AbsorptionScattering(
     AthenaArray<Real> &wmu_cm, AthenaArray<Real> &tran_coef, Real *sigma_a,
     Real *sigma_p, Real *sigma_pe, Real *sigma_s, Real dt, Real lorz,
     Real rho, Real &tgas, AthenaArray<Real> &implicit_coef, AthenaArray<Real> &ir_cm) {
-  Real& prat = pmy_rad->prat;
+  const Real& prat = pmy_rad->prat;
   Real ct = dt * pmy_rad->crat;
   Real redfactor=pmy_rad->reduced_c/pmy_rad->crat;
-  int& nang=pmy_rad->nang;
-  int& nfreq=pmy_rad->nfreq;
+  const int& nang=pmy_rad->nang;
+  const int& nfreq=pmy_rad->nfreq;
   Real gamma = pmy_rad->pmy_block->peos->GetGamma();
 
   // Temporary array

--- a/src/nr_radiation/integrators/srcterms/compton.cpp
+++ b/src/nr_radiation/integrators/srcterms/compton.cpp
@@ -45,12 +45,12 @@ void RadIntegrator::Compton(AthenaArray<Real> &wmu_cm,
                             AthenaArray<Real> &tran_coef, Real *sigma_s,
                             Real dt, Real lorz, Real rho, Real &tgas,
                             AthenaArray<Real> &ir_cm) {
-  Real& prat = pmy_rad->prat;
+  const Real& prat = pmy_rad->prat;
   Real ct = dt * pmy_rad->crat;
   Real redfactor=pmy_rad->reduced_c/pmy_rad->crat;
 
-  int& nang=pmy_rad->nang;
-  int& nfreq=pmy_rad->nfreq;
+  const int& nang=pmy_rad->nang;
+  const int& nfreq=pmy_rad->nfreq;
   Real gamma = pmy_rad->pmy_block->peos->GetGamma();
   Real telectron = 1.0/pmy_rad->telectron;
 
@@ -114,12 +114,12 @@ void RadIntegrator::MultiGroupCompton(
     Real &tgas_ini, Real &tgas, AthenaArray<Real> &ir_cm) {
   int bd_cell_flag = 0;
 
-  Real& prat = pmy_rad->prat;
+  const Real& prat = pmy_rad->prat;
   Real ct = dt * pmy_rad->crat;
   Real redfactor=pmy_rad->reduced_c/pmy_rad->crat;
 
-  int& nang=pmy_rad->nang;
-  int& nfreq=pmy_rad->nfreq;
+  const int& nang=pmy_rad->nang;
+  const int& nfreq=pmy_rad->nfreq;
   Real gamma = pmy_rad->pmy_block->peos->GetGamma();
   Real one_telectron = 1.0/pmy_rad->telectron;
   //correction factor for high order terms of energy change per scattering

--- a/src/nr_radiation/integrators/srcterms/multigroup_abs_sca.cpp
+++ b/src/nr_radiation/integrators/srcterms/multigroup_abs_sca.cpp
@@ -52,11 +52,11 @@ Real RadIntegrator::MultiGroupAbsScat(
     AthenaArray<Real> &wmu_cm, AthenaArray<Real> &tran_coef, Real *sigma_a, Real *sigma_p,
     Real *sigma_pe, Real *sigma_s, Real dt, Real lorz, Real rho, Real &tgas,
     AthenaArray<Real> &implicit_coef, AthenaArray<Real> &ir_cm) {
-  Real& prat = pmy_rad->prat;
+  const Real& prat = pmy_rad->prat;
   Real ct = dt * pmy_rad->crat;
   Real redfactor=pmy_rad->reduced_c/pmy_rad->crat;
-  int& nang=pmy_rad->nang;
-  int& nfreq=pmy_rad->nfreq;
+  const int& nang=pmy_rad->nang;
+  const int& nfreq=pmy_rad->nfreq;
   Real gamma = pmy_rad->pmy_block->peos->GetGamma();
 
   // Temporary array

--- a/src/nr_radiation/radiation.cpp
+++ b/src/nr_radiation/radiation.cpp
@@ -46,7 +46,7 @@ inline void DefaultFrequency(NRRadiation *prad) {
 // The default opacity function.
 // Do nothing. Keep the opacity as the initial value
 inline void DefaultEmission(NRRadiation *prad, Real tgas) {
-  int &nfreq = prad->nfreq;
+  const int &nfreq = prad->nfreq;
   if (nfreq > 1) {
     for(int ifr=0; ifr<nfreq-1; ++ifr) {
       prad->emission_spec(ifr) =

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -98,10 +98,10 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             // NEW_OUTPUT_TYPES:
 
             // Hydro conserved variables:
-            Real& u_d  = porb->u_orb(IDN,k,j,i);
-            Real& u_mx = porb->u_orb(IM1,k,j,i);
-            Real& u_my = porb->u_orb(IM2,k,j,i);
-            Real& u_mz = porb->u_orb(IM3,k,j,i);
+            const Real& u_d  = porb->u_orb(IDN,k,j,i);
+            const Real& u_mx = porb->u_orb(IM1,k,j,i);
+            const Real& u_my = porb->u_orb(IM2,k,j,i);
+            const Real& u_mz = porb->u_orb(IM3,k,j,i);
 
             hst_data[0] += vol(i)*u_d;
             hst_data[1] += vol(i)*u_mx;
@@ -113,19 +113,19 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             hst_data[6] += vol(i)*0.5*SQR(u_mz)/u_d;
 
             if (NON_BAROTROPIC_EOS) {
-              Real& u_e = porb->u_orb(IEN,k,j,i);
+              const Real& u_e = porb->u_orb(IEN,k,j,i);
               hst_data[7] += vol(i)*u_e;
             }
             // Graviatational potential energy:
             if (SELF_GRAVITY_ENABLED) {
-              Real& phi = pgrav->phi(k,j,i);
+              const Real& phi = pgrav->phi(k,j,i);
               hst_data[NHYDRO + 3] += vol(i)*0.5*u_d*phi;
             }
             // Cell-centered magnetic energy, partitioned by coordinate direction:
             if (MAGNETIC_FIELDS_ENABLED) {
-              Real& bcc1 = pfld->bcc(IB1,k,j,i);
-              Real& bcc2 = pfld->bcc(IB2,k,j,i);
-              Real& bcc3 = pfld->bcc(IB3,k,j,i);
+              const Real& bcc1 = pfld->bcc(IB1,k,j,i);
+              const Real& bcc2 = pfld->bcc(IB2,k,j,i);
+              const Real& bcc3 = pfld->bcc(IB3,k,j,i);
               constexpr int prev_out = NHYDRO + 3 + (SELF_GRAVITY_ENABLED > 0);
               hst_data[prev_out] += vol(i)*0.5*bcc1*bcc1;
               hst_data[prev_out + 1] += vol(i)*0.5*bcc2*bcc2;
@@ -133,14 +133,14 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             }
             // (conserved variable) Passive scalars:
             for (int n=0; n<NSCALARS; n++) {
-              Real& s = psclr->s(n,k,j,i);
+              const Real& s = psclr->s(n,k,j,i);
               constexpr int prev_out = NHYDRO + 3 + (SELF_GRAVITY_ENABLED > 0) + NFIELD;
               hst_data[prev_out + n] += vol(i)*s;
             }
             // average radiation field strength:
             if (CHEMRADIATION_ENABLED) {
               for (int n=0; n<pchemrad->nfreq; n++) {
-                Real& ir = pchemrad->ir_avg(n,k,j,i);
+                const Real& ir = pchemrad->ir_avg(n,k,j,i);
                 constexpr int prev_out = NHYDRO + 3 + (SELF_GRAVITY_ENABLED > 0) + NFIELD
                   + NSCALARS;
                 hst_data[prev_out + n] += vol(i)*ir;
@@ -201,10 +201,10 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             // NEW_OUTPUT_TYPES:
 
             // Hydro conserved variables:
-            Real& u_d  = phyd->u(IDN,k,j,i);
-            Real& u_mx = phyd->u(IM1,k,j,i);
-            Real& u_my = phyd->u(IM2,k,j,i);
-            Real& u_mz = phyd->u(IM3,k,j,i);
+            const Real& u_d  = phyd->u(IDN,k,j,i);
+            const Real& u_mx = phyd->u(IM1,k,j,i);
+            const Real& u_my = phyd->u(IM2,k,j,i);
+            const Real& u_mz = phyd->u(IM3,k,j,i);
 
             hst_data[0] += vol(i)*u_d;
             hst_data[1] += vol(i)*u_mx;
@@ -216,19 +216,19 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             hst_data[6] += vol(i)*0.5*SQR(u_mz)/u_d;
 
             if (NON_BAROTROPIC_EOS) {
-              Real& u_e = phyd->u(IEN,k,j,i);
+              const Real& u_e = phyd->u(IEN,k,j,i);
               hst_data[7] += vol(i)*u_e;
             }
             // Graviatational potential energy:
             if (SELF_GRAVITY_ENABLED) {
-              Real& phi = pgrav->phi(k,j,i);
+              const Real& phi = pgrav->phi(k,j,i);
               hst_data[NHYDRO + 3] += vol(i)*0.5*u_d*phi;
             }
             // Cell-centered magnetic energy, partitioned by coordinate direction:
             if (MAGNETIC_FIELDS_ENABLED) {
-              Real& bcc1 = pfld->bcc(IB1,k,j,i);
-              Real& bcc2 = pfld->bcc(IB2,k,j,i);
-              Real& bcc3 = pfld->bcc(IB3,k,j,i);
+              const Real& bcc1 = pfld->bcc(IB1,k,j,i);
+              const Real& bcc2 = pfld->bcc(IB2,k,j,i);
+              const Real& bcc3 = pfld->bcc(IB3,k,j,i);
               constexpr int prev_out = NHYDRO + 3 + (SELF_GRAVITY_ENABLED > 0);
               hst_data[prev_out] += vol(i)*0.5*bcc1*bcc1;
               hst_data[prev_out + 1] += vol(i)*0.5*bcc2*bcc2;
@@ -236,14 +236,14 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             }
             // (conserved variable) Passive scalars:
             for (int n=0; n<NSCALARS; n++) {
-              Real& s = psclr->s(n,k,j,i);
+              const Real& s = psclr->s(n,k,j,i);
               constexpr int prev_out = NHYDRO + 3 + (SELF_GRAVITY_ENABLED > 0) + NFIELD;
               hst_data[prev_out + n] += vol(i)*s;
             }
             // average radiation field strength:
             if (CHEMRADIATION_ENABLED) {
               for (int n=0; n<pchemrad->nfreq; n++) {
-                Real& ir = pchemrad->ir_avg(n,k,j,i);
+                const Real& ir = pchemrad->ir_avg(n,k,j,i);
                 constexpr int prev_out = NHYDRO + 3 + (SELF_GRAVITY_ENABLED > 0) + NFIELD
                   + NSCALARS;
                 hst_data[prev_out + n] += vol(i)*ir;

--- a/src/pgen/chem_turb.cpp
+++ b/src/pgen/chem_turb.cpp
@@ -191,9 +191,9 @@ void MeshBlock::UserWorkInLoop() {
           Real gam = peos->GetGamma();
           Real& w_p  = phydro->w(IPR,k,j,i);
           Real& u_e  = phydro->u(IEN,k,j,i);
-          Real& u_m1 = phydro->u(IM1,k,j,i);
-          Real& u_m2 = phydro->u(IM2,k,j,i);
-          Real& u_m3 = phydro->u(IM3,k,j,i);
+          const Real& u_m1 = phydro->u(IM1,k,j,i);
+          const Real& u_m2 = phydro->u(IM2,k,j,i);
+          const Real& u_m3 = phydro->u(IM3,k,j,i);
           w_p = (w_p > pfloor) ?  w_p : pfloor;
           Real di = 1.0/u_d;
           Real ke = 0.5*di*(SQR(u_m1) + SQR(u_m2) + SQR(u_m3));

--- a/src/pgen/strat.cpp
+++ b/src/pgen/strat.cpp
@@ -368,9 +368,9 @@ void MeshBlock::UserWorkInLoop() {
           Real gam = peos->GetGamma();
           Real& w_p  = phydro->w(IPR,k,j,i);
           Real& u_e  = phydro->u(IEN,k,j,i);
-          Real& u_m1 = phydro->u(IM1,k,j,i);
-          Real& u_m2 = phydro->u(IM2,k,j,i);
-          Real& u_m3 = phydro->u(IM3,k,j,i);
+          const Real& u_m1 = phydro->u(IM1,k,j,i);
+          const Real& u_m2 = phydro->u(IM2,k,j,i);
+          const Real& u_m3 = phydro->u(IM3,k,j,i);
           w_p = (w_p > pfloor) ?  w_p : pfloor;
           Real di = 1.0/u_d;
           Real ke = 0.5*di*(SQR(u_m1) + SQR(u_m2) + SQR(u_m3));

--- a/src/reconstruct/reconstruction.cpp
+++ b/src/reconstruct/reconstruction.cpp
@@ -127,9 +127,9 @@ Reconstruction::Reconstruction(MeshBlock *pmb, ParameterInput *pin) :
             << "x3rat= " << pmb->block_size.x3rat << std::endl;
         ATHENA_ERROR(msg);
       }
-      Real& dx_i   = pmb->pcoord->dx1f(pmb->is);
-      Real& dx_j   = pmb->pcoord->dx2f(pmb->js);
-      Real& dx_k   = pmb->pcoord->dx3f(pmb->ks);
+      const Real& dx_i   = pmb->pcoord->dx1f(pmb->is);
+      const Real& dx_j   = pmb->pcoord->dx2f(pmb->js);
+      const Real& dx_k   = pmb->pcoord->dx3f(pmb->ks);
       // Note, probably want to make the following condition less strict (signal warning
       // for small differences due to floating-point issues) but upgrade to error for
       // large deviations from a square mesh. Currently signals a warning for each

--- a/src/task_list/im_radit_task_list.cpp
+++ b/src/task_list/im_radit_task_list.cpp
@@ -111,7 +111,7 @@ void IMRadITTaskList::AddTask(const TaskID& id, const TaskID& dep) {
 TaskStatus IMRadITTaskList::AddFluxAndSourceTerms(MeshBlock *pmb) {
   NRRadiation *prad = pmb->pnrrad;
   Hydro *ph = pmb->phydro;
-  int &rb_or_not = pmy_mesh->pimrad->rb_or_not;
+  const int &rb_or_not = pmy_mesh->pimrad->rb_or_not;
 
   int is=pmb->is, ie=pmb->ie;
   int js=pmb->js, je=pmb->je;

--- a/src/utils/matrix_mult.cpp
+++ b/src/utils/matrix_mult.cpp
@@ -26,8 +26,8 @@ void MatrixMult(int m, int n, AthenaArray<Real> &a,
   for (int i=0; i<m; ++i) {
     c(i) = 0.0;
     for (int j=0; j<n; ++j) {
-      Real& ap = a(i,j);
-      Real& bp = b(j);
+      const Real& ap = a(i,j);
+      const Real& bp = b(j);
       c(i) += ap * bp;
     }
   }
@@ -104,8 +104,8 @@ void Ludcmp_nr(int n, AthenaArray<Real> &a, AthenaArray<int> &indx,
     for (int i=0; i<j; ++i) {
       sum=a(i,j);
       for (int k=0; k<i; ++k) {
-        Real& aik = a(i,k);
-        Real& akj = a(k,j);
+        const Real& aik = a(i,k);
+        const Real& akj = a(k,j);
         sum -= aik * akj;
       }
       a(i,j)=sum;
@@ -115,8 +115,8 @@ void Ludcmp_nr(int n, AthenaArray<Real> &a, AthenaArray<int> &indx,
     for (int i=j; i<n; ++i) {
       sum=a(i,j);
       for (int k=0; k<j; ++k) {
-        Real& aik = a(i,k);
-        Real& akj = a(k,j);
+        const Real& aik = a(i,k);
+        const Real& akj = a(k,j);
         sum -= aik * akj;
       }
       a(i,j)=sum;
@@ -177,8 +177,8 @@ void Lubksb_nr(int n, AthenaArray<Real> &a, AthenaArray<int> &indx,
   for (int i=n-1; i>=0; --i) {
     sum=b(i);
     for (int j=i+1; j<n; ++j) {
-      Real& ap = a(i,j);
-      Real& bp = b(j);
+      const Real& ap = a(i,j);
+      const Real& bp = b(j);
       sum -= ap * bp;
     }
     b(i)=sum/a(i,i);


### PR DESCRIPTION
Follow up to #566; there were tons of misused references in `bvals/` and `nr_radiation/` mostly as a product of copy-pasting bad initial code patterns. I didnt fix all of them, but hopefully this will minimize future subtle bugs. 
