### PR TITLE
bugfix for viscosity + 3d polar boundary condition

### DIFF
--- a/src/hydro/hydro_diffusion/viscosity.cpp
+++ b/src/hydro/hydro_diffusion/viscosity.cpp
@@ -397,7 +397,7 @@ void HydroDiffusion::FaceYdz(const int k, const int j, const int il, const int i
                / pco_->h31v(i)
                / (pco_->dx3v(k-1) + pco_->dx3v(k))
                // edge case for polar boundary
-               / ( !pco_->h32f(j) ? 1.0 : pco_->h32f(j) );
+               / ( pco_->IsPole(j) ? 1.0 : pco_->h32f(j) );
     }
   } else if (pmb_->pmy_mesh->f2) {
 #pragma omp simd

--- a/src/hydro/hydro_diffusion/viscosity.cpp
+++ b/src/hydro/hydro_diffusion/viscosity.cpp
@@ -395,7 +395,9 @@ void HydroDiffusion::FaceYdz(const int k, const int j, const int il, const int i
                + 0.5*(    (prim(IM2,k+1,j,i) + prim(IM2,k+1,j-1,i))
                           - (prim(IM2,k-1,j,i) + prim(IM2,k-1,j-1,i)) )
                / pco_->h31v(i)
-               / pco_->h32f(j) / (pco_->dx3v(k-1) + pco_->dx3v(k));
+               / (pco_->dx3v(k-1) + pco_->dx3v(k))
+               // edge case for polar boundary
+               / ( !pco_->h32f(j) ? 1.0 : pco_->h32f(j) );
     }
   } else if (pmb_->pmy_mesh->f2) {
 #pragma omp simd


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a simple fix for a divide-by-zero I stumbled upon. I think it is just a missed edge case when viscosity is used in conjunction with 3d spherical polar extending to the pole x2min=0.0. The offending code is line 398 of viscosity.cpp:
```
void HydroDiffusion::FaceYdz(const int k, const int j, const int il, const int iu,
                             const AthenaArray<Real> &prim, AthenaArray<Real> &len) {
  if (pmb_->pmy_mesh->f3) {
#pragma omp simd
    for (int i=il; i<=iu; ++i) {
      len(i) = pco_->h32f(j)
               * ( prim(IM3,k,j,i)/pco_->h32v(j) - prim(IM3,k,j-1,i)/pco_->h32v(j-1) )
               / pco_->h2v(i) / pco_->dx2v(j-1)
               // KGF: add the off-centered quantities first to preserve FP symmetry
               + 0.5*(    (prim(IM2,k+1,j,i) + prim(IM2,k+1,j-1,i))
                          - (prim(IM2,k-1,j,i) + prim(IM2,k-1,j-1,i)) )
               / pco_->h31v(i)
               / pco_->h32f(j) / (pco_->dx3v(k-1) + pco_->dx3v(k));
    }
```
When computing the FaceYdz viscous flux for active cells at the pole pco_->h32f(j) occurring in the denominator evaluates to zero at the pole. Adding the flux divergence propagates this NaN to the first active cell which spreads throughout the domain with each timestep. 

This is just a simple fix that replaces pco_->h32f(j) in the denominator with a conditional that returns 1.0 if h32f(j)=0.0 and returns h32f(j) otherwise. The value the conditional returns when h32f(j)=0.0 is irrelevant since this flux gets multiplied by a zero area face later, it just needs to be non-NaN so as not to persist. The case for the conditional to return 1.0 is only triggered in 3D spherical polar as h32f is always 1.0 for cartesian and cylindrical and the scope of this block of code is limited to 3D.


## Testing and validation
tested that a 3d polar run inviscid and vanishingly small nu_iso=1.0e-10 give similar and now non-NaN results.
10 out of 10 existing diffusion regression tests passed on laptop.

