### PR TITLE
Divergence-preserving prolongation of coarse/fine shared face-centered fields for 3D spherical polar and cylindrical grids 

### DIFF
--- a/src/coordinates/spherical_polar.cpp
+++ b/src/coordinates/spherical_polar.cpp
@@ -131,14 +131,16 @@ SphericalPolar::SphericalPolar(MeshBlock *pmb, ParameterInput *pin, bool flag)
       x2s1(jl) = x2s3(jl) = x2v(jl);
     } else {
       for (int j=jl-ng; j<=ju+ng; ++j) {
-        x2s1(j) = x2s3(j) = x2v(j);
+        x2s1(j) = (std::sin(x2f(j+1)) - x2f(j+1)*std::cos(x2f(j+1)) - std::sin(x2f(j)) 
+                  + x2f(j)*std::cos(x2f(j)))/(std::cos(x2f(j)) - std::cos(x2f(j+1)));
+	x2s3(j) = 0.5*(x2f(j+1) + x2f(j));
       }
     }
     if (pmb->block_size.nx3 == 1) {
       x3s1(kl) = x3s2(kl) = x3v(kl);
     } else {
       for (int k=kl-ng; k<=ku+ng; ++k) {
-        x3s1(k) = x3s2(k) = x3v(k);
+        x3s1(k) = x3s2(k) = 0.5*(x3f(k+1) + x3f(k));
       }
     }
   }

--- a/src/coordinates/spherical_polar.cpp
+++ b/src/coordinates/spherical_polar.cpp
@@ -131,9 +131,9 @@ SphericalPolar::SphericalPolar(MeshBlock *pmb, ParameterInput *pin, bool flag)
       x2s1(jl) = x2s3(jl) = x2v(jl);
     } else {
       for (int j=jl-ng; j<=ju+ng; ++j) {
-        x2s1(j) = (std::sin(x2f(j+1)) - x2f(j+1)*std::cos(x2f(j+1)) - std::sin(x2f(j)) 
+        x2s1(j) = (std::sin(x2f(j+1)) - x2f(j+1)*std::cos(x2f(j+1)) - std::sin(x2f(j))
                   + x2f(j)*std::cos(x2f(j)))/(std::cos(x2f(j)) - std::cos(x2f(j+1)));
-	x2s3(j) = 0.5*(x2f(j+1) + x2f(j));
+        x2s3(j) = 0.5*(x2f(j+1) + x2f(j));
       }
     }
     if (pmb->block_size.nx3 == 1) {

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -102,9 +102,9 @@ MeshRefinement::MeshRefinement(MeshBlock *pmb, ParameterInput *pin) :
   // Create coarse area arrays used in prolongation of shared face-centered fields in
   // curvilinear grids
   if (fluxinterp_) {
-    csarea_x1.NewAthenaArray(nc1);
-    csarea_x2.NewAthenaArray(nc1);
-    csarea_x3.NewAthenaArray(nc1);
+    csarea_x1_.NewAthenaArray(nc1);
+    csarea_x2_.NewAthenaArray(nc1);
+    csarea_x3_.NewAthenaArray(nc1);
   }
 
   // KGF: probably don't need to preallocate space for pointers in these vectors
@@ -819,11 +819,11 @@ void MeshRefinement::ProlongateSharedFieldX1(
           pco->Face1Area(fk,   fj+1, fsi, fei, sarea_x1_[0][1]);
           pco->Face1Area(fk+1, fj,   fsi, fei, sarea_x1_[1][0]);
           pco->Face1Area(fk+1, fj+1, fsi, fei, sarea_x1_[1][1]);
-          pcoarsec->Face1Area(k, j, si, ei, csarea_x1);
+          pcoarsec->Face1Area(k, j, si, ei, csarea_x1_);
           for (int i=si; i<=ei; i++) {
             int fi = (i - pmb->cis)*2 + pmb->is;
             Real ccval = coarse(k,j,i);
-            Real csarea = csarea_x1(i);
+            Real csarea = csarea_x1_(i);
             Real fsa00 = sarea_x1_[0][0](fi);
             Real fsa01 = sarea_x1_[0][1](fi);
             Real fsa10 = sarea_x1_[1][0](fi);
@@ -947,7 +947,7 @@ void MeshRefinement::ProlongateSharedFieldX2(
           int fj = (j - pmb->cjs)*2 + pmb->js;
           pco->Face2Area(fk,   fj,  fsi, fei, sarea_x2_[0][0]);
           pco->Face2Area(fk+1, fj,  fsi, fei, sarea_x2_[1][0]);
-          pcoarsec->Face2Area(k, j, si, ei, csarea_x2);
+          pcoarsec->Face2Area(k, j, si, ei, csarea_x2_);
           for (int i=si; i<=ei; i++) {
             int fi = (i - pmb->cis)*2 + pmb->is;
             const Real& x1m = pcoarsec->x1s2(i-1);
@@ -959,7 +959,7 @@ void MeshRefinement::ProlongateSharedFieldX2(
             const Real& fx1p = pco->x1s2(fi+1);
             Real ccval = coarse(k,j,i);
             Real dfx1 = fx1p - fx1m;
-            Real csarea = csarea_x2(i) + TINY_NUMBER;
+            Real csarea = csarea_x2_(i) + TINY_NUMBER;
             Real fsa00 = sarea_x2_[0][0](fi);
             Real fsa01 = sarea_x2_[0][0](fi+1);
             Real fsa10 = sarea_x2_[1][0](fi);
@@ -1091,7 +1091,7 @@ void MeshRefinement::ProlongateSharedFieldX3(
           Real dfx2 = fx2p - fx2m;
           pco->Face3Area(fk,   fj,  fsi, fei, sarea_x3_[0][0]);
           pco->Face3Area(fk, fj+1,  fsi, fei, sarea_x3_[0][1]);
-          pcoarsec->Face3Area(k, j, si, ei, csarea_x3);
+          pcoarsec->Face3Area(k, j, si, ei, csarea_x3_);
 
           for (int i=si; i<=ei; i++) {
             int fi = (i - pmb->cis)*2 + pmb->is;
@@ -1113,7 +1113,7 @@ void MeshRefinement::ProlongateSharedFieldX3(
             Real gx2c = 0.5*(SIGN(gx2m) + SIGN(gx2p))*std::min(std::abs(gx2m),
                                                              std::abs(gx2p));
             Real dfx1 = fx1p - fx1m;
-            Real csarea = csarea_x3(i);
+            Real csarea = csarea_x3_(i);
             Real fsa00 = sarea_x3_[0][0](fi);
             Real fsa01 = sarea_x3_[0][0](fi+1);
             Real fsa10 = sarea_x3_[0][1](fi);

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -823,7 +823,7 @@ void MeshRefinement::ProlongateSharedFieldX1(
             Real dfx2 = fx2p - fx2m;
             Real dfx3 = fx3p - fx3m;
             Real ccval = coarse(k,j,i);
-	    Real csarea = csarea_x1(i);
+            Real csarea = csarea_x1(i);
             Real fsa00 = sarea_x1_[0][0](fi);
             Real fsa01 = sarea_x1_[0][1](fi);
             Real fsa10 = sarea_x1_[1][0](fi);
@@ -845,8 +845,8 @@ void MeshRefinement::ProlongateSharedFieldX1(
                                        + gx3c*dfx3*(fsa00 + fsa01)/csarea;
             fine(fk+1,fj+1,fi) = ccval + gx2c*dfx2*(fsa00 + fsa10)/csarea
                                        + gx3c*dfx3*(fsa00 + fsa01)/csarea;
-	  }
-	}
+          }
+        }
       }
     } else {
       for (int k=sk; k<=ek; k++) {
@@ -1020,8 +1020,8 @@ void MeshRefinement::ProlongateSharedFieldX2(
             fine(fk  ,fj,fi+1) = ccval + gx1c*(fx1p - x1c) - gx3c*(x3c - fx3m);
             fine(fk+1,fj,fi  ) = ccval - gx1c*(x1c - fx1m) + gx3c*(fx3p - x3c);
             fine(fk+1,fj,fi+1) = ccval + gx1c*(fx1p - x1c) + gx3c*(fx3p - x3c);
-	  }
-	}
+          }
+        }
       }
     }
   } else if (pmb->block_size.nx2 > 1) {
@@ -1164,8 +1164,8 @@ void MeshRefinement::ProlongateSharedFieldX3(
             fine(fk,fj  ,fi+1) = ccval + gx1c*(fx1p - x1c) - gx2c*(x2c - fx2m);
             fine(fk,fj+1,fi  ) = ccval - gx1c*(x1c - fx1m) + gx2c*(fx2p - x2c);
             fine(fk,fj+1,fi+1) = ccval + gx1c*(fx1p - x1c) + gx2c*(fx2p - x2c);
-	  }
-	}
+          }
+        }
       }
     }
   } else if (pmb->block_size.nx2 > 1) {

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -804,6 +804,7 @@ void MeshRefinement::ProlongateSharedFieldX1(
         Real dx3p = x3p - x3c;
         const Real& fx3m = pco->x3s1(fk);
         const Real& fx3p = pco->x3s1(fk+1);
+        Real dfx3 = fx3p - fx3m;
         for (int j=sj; j<=ej; j++) {
           int fj = (j - pmb->cjs)*2 + pmb->js;
           const Real& x2m = pcoarsec->x2s1(j-1);
@@ -813,6 +814,7 @@ void MeshRefinement::ProlongateSharedFieldX1(
           Real dx2p = x2p - x2c;
           const Real& fx2m = pco->x2s1(fj);
           const Real& fx2p = pco->x2s1(fj+1);
+          Real dfx2 = fx2p - fx2m;
           pco->Face1Area(fk,   fj,   fsi, fei, sarea_x1_[0][0]);
           pco->Face1Area(fk,   fj+1, fsi, fei, sarea_x1_[0][1]);
           pco->Face1Area(fk+1, fj,   fsi, fei, sarea_x1_[1][0]);
@@ -820,8 +822,6 @@ void MeshRefinement::ProlongateSharedFieldX1(
           pcoarsec->Face1Area(k, j, si, ei, csarea_x1);
           for (int i=si; i<=ei; i++) {
             int fi = (i - pmb->cis)*2 + pmb->is;
-            Real dfx2 = fx2p - fx2m;
-            Real dfx3 = fx3p - fx3m;
             Real ccval = coarse(k,j,i);
             Real csarea = csarea_x1(i);
             Real fsa00 = sarea_x1_[0][0](fi);
@@ -940,6 +940,7 @@ void MeshRefinement::ProlongateSharedFieldX2(
         const Real& x3p = pcoarsec->x3s2(k+1);
         Real dx3m = x3c - x3m;
         Real dx3p = x3p - x3c;
+        Real dfx3 = fx3p - fx3m;
         const Real& fx3m = pco->x3s2(fk);
         const Real& fx3p = pco->x3s2(fk+1);
         for (int j=sj; j<=ej; j++) {
@@ -958,7 +959,6 @@ void MeshRefinement::ProlongateSharedFieldX2(
             const Real& fx1p = pco->x1s2(fi+1);
             Real ccval = coarse(k,j,i);
             Real dfx1 = fx1p - fx1m;
-            Real dfx3 = fx3p - fx3m;
             Real csarea = csarea_x2(i) + TINY_NUMBER;
             Real fsa00 = sarea_x2_[0][0](fi);
             Real fsa01 = sarea_x2_[0][0](fi+1);

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -68,12 +68,12 @@ MeshRefinement::MeshRefinement(MeshBlock *pmb, ParameterInput *pin) :
   // face fields
   if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0 ||
       std::strcmp(COORDINATE_SYSTEM, "cylindrical") == 0) {
-    fluxinterp = true;
+    fluxinterp_ = true;
   } else {
-    fluxinterp = false;
+    fluxinterp_ = false;
   }
 
-  if (fluxinterp) {
+  if (fluxinterp_) {
     qx1 = 2;
   } else {
     qx1 = 1;
@@ -101,7 +101,7 @@ MeshRefinement::MeshRefinement(MeshBlock *pmb, ParameterInput *pin) :
 
   // Create coarse area arrays used in prolongation of shared face-centered fields in
   // curvilinear grids
-  if (fluxinterp) {
+  if (fluxinterp_) {
     csarea_x1.NewAthenaArray(nc1);
     csarea_x2.NewAthenaArray(nc1);
     csarea_x3.NewAthenaArray(nc1);
@@ -794,7 +794,7 @@ void MeshRefinement::ProlongateSharedFieldX1(
   Coordinates *pco = pmb->pcoord;
   int fsi = (si - pmb->cis)*2 + pmb->is, fei = (ei - pmb->cis)*2 + pmb->is + 1;
   if (pmb->block_size.nx3 > 1) {
-    if (fluxinterp) {
+    if (fluxinterp_) {
       for (int k=sk; k<=ek; k++) {
         int fk = (k - pmb->cks)*2 + pmb->ks;
         const Real& x3m = pcoarsec->x3s1(k-1);
@@ -932,7 +932,7 @@ void MeshRefinement::ProlongateSharedFieldX2(
   Coordinates *pco = pmb->pcoord;
   int fsi = (si - pmb->cis)*2 + pmb->is, fei = (ei - pmb->cis)*2 + pmb->is + 1;
   if (pmb->block_size.nx3 > 1) {
-    if (fluxinterp) {
+    if (fluxinterp_) {
       for (int k=sk; k<=ek; k++) {
         int fk = (k - pmb->cks)*2 + pmb->ks;
         const Real& x3m = pcoarsec->x3s2(k-1);
@@ -1076,7 +1076,7 @@ void MeshRefinement::ProlongateSharedFieldX3(
   Coordinates *pco = pmb->pcoord;
   int fsi = (si - pmb->cis)*2 + pmb->is, fei = (ei - pmb->cis)*2 + pmb->is + 1;
   if (pmb->block_size.nx3 > 1) {
-    if (fluxinterp) {
+    if (fluxinterp_) {
       for (int k=sk; k<=ek; k++) {
         int fk = (k - pmb->cks)*2 + pmb->ks;
         for (int j=sj; j<=ej; j++) {

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -62,10 +62,18 @@ MeshRefinement::MeshRefinement(MeshBlock *pmb, ParameterInput *pin) :
   }
   int qx1;
   int nc1 = pmb->ncells1;
-  // In spherical polar grids, prolongation of shared face-centered fields requires face
+
+  // In curvilinear grids, prolongation of shared face-centered fields requires face
   // area arrays, these are longer than the arrays used in the prolongation of internal
   // face fields
-  if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0) {
+  if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0 ||
+      std::strcmp(COORDINATE_SYSTEM, "cylindrical") == 0) {
+    fluxinterp = true;
+  } else {
+    fluxinterp = false;
+  }
+
+  if (fluxinterp) {
     qx1 = 2;
   } else {
     qx1 = 1;
@@ -92,8 +100,8 @@ MeshRefinement::MeshRefinement(MeshBlock *pmb, ParameterInput *pin) :
   sarea_x3_[2][1].NewAthenaArray(nc1);
 
   // Create coarse area arrays used in prolongation of shared face-centered fields in
-  // spherical polar grids
-  if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0) {
+  // curvilinear grids
+  if (fluxinterp) {
     csarea_x1.NewAthenaArray(nc1);
     csarea_x2.NewAthenaArray(nc1);
     csarea_x3.NewAthenaArray(nc1);
@@ -786,63 +794,91 @@ void MeshRefinement::ProlongateSharedFieldX1(
   Coordinates *pco = pmb->pcoord;
   int fsi = (si - pmb->cis)*2 + pmb->is, fei = (ei - pmb->cis)*2 + pmb->is + 1;
   if (pmb->block_size.nx3 > 1) {
-    for (int k=sk; k<=ek; k++) {
-      int fk = (k - pmb->cks)*2 + pmb->ks;
-      const Real& x3m = pcoarsec->x3s1(k-1);
-      const Real& x3c = pcoarsec->x3s1(k);
-      const Real& x3p = pcoarsec->x3s1(k+1);
-      Real dx3m = x3c - x3m;
-      Real dx3p = x3p - x3c;
-      const Real& fx3m = pco->x3s1(fk);
-      const Real& fx3p = pco->x3s1(fk+1);
-      for (int j=sj; j<=ej; j++) {
-        int fj = (j - pmb->cjs)*2 + pmb->js;
-        const Real& x2m = pcoarsec->x2s1(j-1);
-        const Real& x2c = pcoarsec->x2s1(j);
-        const Real& x2p = pcoarsec->x2s1(j+1);
-        Real dx2m = x2c - x2m;
-        Real dx2p = x2p - x2c;
-        const Real& fx2m = pco->x2s1(fj);
-        const Real& fx2p = pco->x2s1(fj+1);
-        if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0) {
+    if (fluxinterp) {
+      for (int k=sk; k<=ek; k++) {
+        int fk = (k - pmb->cks)*2 + pmb->ks;
+        const Real& x3m = pcoarsec->x3s1(k-1);
+        const Real& x3c = pcoarsec->x3s1(k);
+        const Real& x3p = pcoarsec->x3s1(k+1);
+        Real dx3m = x3c - x3m;
+        Real dx3p = x3p - x3c;
+        const Real& fx3m = pco->x3s1(fk);
+        const Real& fx3p = pco->x3s1(fk+1);
+        for (int j=sj; j<=ej; j++) {
+          int fj = (j - pmb->cjs)*2 + pmb->js;
+          const Real& x2m = pcoarsec->x2s1(j-1);
+          const Real& x2c = pcoarsec->x2s1(j);
+          const Real& x2p = pcoarsec->x2s1(j+1);
+          Real dx2m = x2c - x2m;
+          Real dx2p = x2p - x2c;
+          const Real& fx2m = pco->x2s1(fj);
+          const Real& fx2p = pco->x2s1(fj+1);
           pco->Face1Area(fk,   fj,   fsi, fei, sarea_x1_[0][0]);
           pco->Face1Area(fk,   fj+1, fsi, fei, sarea_x1_[0][1]);
           pco->Face1Area(fk+1, fj,   fsi, fei, sarea_x1_[1][0]);
           pco->Face1Area(fk+1, fj+1, fsi, fei, sarea_x1_[1][1]);
           pcoarsec->Face1Area(k, j, si, ei, csarea_x1);
-        }
-        for (int i=si; i<=ei; i++) {
-          int fi = (i - pmb->cis)*2 + pmb->is;
-          Real ccval = coarse(k,j,i);
-
-          Real gx2m = (ccval - coarse(k,j-1,i))/dx2m;
-          Real gx2p = (coarse(k,j+1,i) - ccval)/dx2p;
-          Real gx2c = 0.5*(SIGN(gx2m) + SIGN(gx2p))*std::min(std::abs(gx2m),
-                                                             std::abs(gx2p));
-          Real gx3m = (ccval - coarse(k-1,j,i))/dx3m;
-          Real gx3p = (coarse(k+1,j,i) - ccval)/dx3p;
-          Real gx3c = 0.5*(SIGN(gx3m) + SIGN(gx3p))*std::min(std::abs(gx3m),
-                                                             std::abs(gx3p));
-          if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0) {
+          for (int i=si; i<=ei; i++) {
+            int fi = (i - pmb->cis)*2 + pmb->is;
             Real dfx2 = fx2p - fx2m;
             Real dfx3 = fx3p - fx3m;
-            fine(fk  ,fj  ,fi) = ccval - gx2c*dfx2*(sarea_x1_[0][1](fi)
-                                       + sarea_x1_[1][1](fi))/csarea_x1(i)
-                                       - gx3c*dfx3*(sarea_x1_[1][0](fi)
-                                       + sarea_x1_[1][1](fi))/csarea_x1(i);
-            fine(fk  ,fj+1,fi) = ccval + gx2c*dfx2*(sarea_x1_[0][0](fi)
-                                       + sarea_x1_[1][0](fi))/csarea_x1(i)
-                                       - gx3c*dfx3*(sarea_x1_[1][0](fi)
-                                       + sarea_x1_[1][1](fi))/csarea_x1(i);
-            fine(fk+1,fj  ,fi) = ccval - gx2c*dfx2*(sarea_x1_[0][1](fi)
-                                       + sarea_x1_[1][1](fi))/csarea_x1(i)
-                                       + gx3c*dfx3*(sarea_x1_[0][0](fi)
-                                       + sarea_x1_[0][1](fi))/csarea_x1(i);
-            fine(fk+1,fj+1,fi) = ccval + gx2c*dfx2*(sarea_x1_[0][0](fi)
-                                       + sarea_x1_[1][0](fi))/csarea_x1(i)
-                                       + gx3c*dfx3*(sarea_x1_[0][0](fi)
-                                       + sarea_x1_[0][1](fi))/csarea_x1(i);
-          } else {
+            Real ccval = coarse(k,j,i);
+	    Real csarea = csarea_x1(i);
+            Real fsa00 = sarea_x1_[0][0](fi);
+            Real fsa01 = sarea_x1_[0][1](fi);
+            Real fsa10 = sarea_x1_[1][0](fi);
+            Real fsa11 = sarea_x1_[1][1](fi);
+
+            Real gx2m = (ccval - coarse(k,j-1,i))/dx2m;
+            Real gx2p = (coarse(k,j+1,i) - ccval)/dx2p;
+            Real gx2c = 0.5*(SIGN(gx2m) + SIGN(gx2p))*std::min(std::abs(gx2m),
+                                                               std::abs(gx2p));
+            Real gx3m = (ccval - coarse(k-1,j,i))/dx3m;
+            Real gx3p = (coarse(k+1,j,i) - ccval)/dx3p;
+            Real gx3c = 0.5*(SIGN(gx3m) + SIGN(gx3p))*std::min(std::abs(gx3m),
+                                                               std::abs(gx3p));
+            fine(fk  ,fj  ,fi) = ccval - gx2c*dfx2*(fsa01 + fsa11)/csarea
+                                       - gx3c*dfx3*(fsa10 + fsa11)/csarea;
+            fine(fk  ,fj+1,fi) = ccval + gx2c*dfx2*(fsa00 + fsa10)/csarea
+                                       - gx3c*dfx3*(fsa10 + fsa11)/csarea;
+            fine(fk+1,fj  ,fi) = ccval - gx2c*dfx2*(fsa01 + fsa11)/csarea
+                                       + gx3c*dfx3*(fsa00 + fsa01)/csarea;
+            fine(fk+1,fj+1,fi) = ccval + gx2c*dfx2*(fsa00 + fsa10)/csarea
+                                       + gx3c*dfx3*(fsa00 + fsa01)/csarea;
+	  }
+	}
+      }
+    } else {
+      for (int k=sk; k<=ek; k++) {
+        int fk = (k - pmb->cks)*2 + pmb->ks;
+        const Real& x3m = pcoarsec->x3s1(k-1);
+        const Real& x3c = pcoarsec->x3s1(k);
+        const Real& x3p = pcoarsec->x3s1(k+1);
+        Real dx3m = x3c - x3m;
+        Real dx3p = x3p - x3c;
+        const Real& fx3m = pco->x3s1(fk);
+        const Real& fx3p = pco->x3s1(fk+1);
+        for (int j=sj; j<=ej; j++) {
+          int fj = (j - pmb->cjs)*2 + pmb->js;
+          const Real& x2m = pcoarsec->x2s1(j-1);
+          const Real& x2c = pcoarsec->x2s1(j);
+          const Real& x2p = pcoarsec->x2s1(j+1);
+          Real dx2m = x2c - x2m;
+          Real dx2p = x2p - x2c;
+          const Real& fx2m = pco->x2s1(fj);
+          const Real& fx2p = pco->x2s1(fj+1);
+          for (int i=si; i<=ei; i++) {
+            int fi = (i - pmb->cis)*2 + pmb->is;
+            Real ccval = coarse(k,j,i);
+
+            Real gx2m = (ccval - coarse(k,j-1,i))/dx2m;
+            Real gx2p = (coarse(k,j+1,i) - ccval)/dx2p;
+            Real gx2c = 0.5*(SIGN(gx2m) + SIGN(gx2p))*std::min(std::abs(gx2m),
+                                                             std::abs(gx2p));
+            Real gx3m = (ccval - coarse(k-1,j,i))/dx3m;
+            Real gx3p = (coarse(k+1,j,i) - ccval)/dx3p;
+            Real gx3c = 0.5*(SIGN(gx3m) + SIGN(gx3p))*std::min(std::abs(gx3m),
+                                                             std::abs(gx3p));
             fine(fk  ,fj  ,fi) = ccval - gx2c*(x2c - fx2m) - gx3c*(x3c - fx3m);
             fine(fk  ,fj+1,fi) = ccval + gx2c*(fx2p - x2c) - gx3c*(x3c - fx3m);
             fine(fk+1,fj  ,fi) = ccval - gx2c*(x2c - fx2m) + gx3c*(fx3p - x3c);
@@ -896,67 +932,96 @@ void MeshRefinement::ProlongateSharedFieldX2(
   Coordinates *pco = pmb->pcoord;
   int fsi = (si - pmb->cis)*2 + pmb->is, fei = (ei - pmb->cis)*2 + pmb->is + 1;
   if (pmb->block_size.nx3 > 1) {
-    for (int k=sk; k<=ek; k++) {
-      int fk = (k - pmb->cks)*2 + pmb->ks;
-      const Real& x3m = pcoarsec->x3s2(k-1);
-      const Real& x3c = pcoarsec->x3s2(k);
-      const Real& x3p = pcoarsec->x3s2(k+1);
-      Real dx3m = x3c - x3m;
-      Real dx3p = x3p - x3c;
-      const Real& fx3m = pco->x3s2(fk);
-      const Real& fx3p = pco->x3s2(fk+1);
-      for (int j=sj; j<=ej; j++) {
-        int fj = (j - pmb->cjs)*2 + pmb->js;
-        if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0) {
+    if (fluxinterp) {
+      for (int k=sk; k<=ek; k++) {
+        int fk = (k - pmb->cks)*2 + pmb->ks;
+        const Real& x3m = pcoarsec->x3s2(k-1);
+        const Real& x3c = pcoarsec->x3s2(k);
+        const Real& x3p = pcoarsec->x3s2(k+1);
+        Real dx3m = x3c - x3m;
+        Real dx3p = x3p - x3c;
+        const Real& fx3m = pco->x3s2(fk);
+        const Real& fx3p = pco->x3s2(fk+1);
+        for (int j=sj; j<=ej; j++) {
+          int fj = (j - pmb->cjs)*2 + pmb->js;
           pco->Face2Area(fk,   fj,  fsi, fei, sarea_x2_[0][0]);
           pco->Face2Area(fk+1, fj,  fsi, fei, sarea_x2_[1][0]);
           pcoarsec->Face2Area(k, j, si, ei, csarea_x2);
-        }
-        for (int i=si; i<=ei; i++) {
-          int fi = (i - pmb->cis)*2 + pmb->is;
-          const Real& x1m = pcoarsec->x1s2(i-1);
-          const Real& x1c = pcoarsec->x1s2(i);
-          const Real& x1p = pcoarsec->x1s2(i+1);
-          Real dx1m = x1c - x1m;
-          Real dx1p = x1p - x1c;
-          const Real& fx1m = pco->x1s2(fi);
-          const Real& fx1p = pco->x1s2(fi+1);
-          Real ccval = coarse(k,j,i);
-
-          Real gx1m = (ccval - coarse(k,j,i-1))/dx1m;
-          Real gx1p = (coarse(k,j,i+1) - ccval)/dx1p;
-          Real gx1c = 0.5*(SIGN(gx1m) + SIGN(gx1p))*std::min(std::abs(gx1m),
-                                                             std::abs(gx1p));
-          Real gx3m = (ccval - coarse(k-1,j,i))/dx3m;
-          Real gx3p = (coarse(k+1,j,i) - ccval)/dx3p;
-          Real gx3c = 0.5*(SIGN(gx3m) + SIGN(gx3p))*std::min(std::abs(gx3m),
-                                                             std::abs(gx3p));
-          if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0) {
+          for (int i=si; i<=ei; i++) {
+            int fi = (i - pmb->cis)*2 + pmb->is;
+            const Real& x1m = pcoarsec->x1s2(i-1);
+            const Real& x1c = pcoarsec->x1s2(i);
+            const Real& x1p = pcoarsec->x1s2(i+1);
+            Real dx1m = x1c - x1m;
+            Real dx1p = x1p - x1c;
+            const Real& fx1m = pco->x1s2(fi);
+            const Real& fx1p = pco->x1s2(fi+1);
+            Real ccval = coarse(k,j,i);
             Real dfx1 = fx1p - fx1m;
             Real dfx3 = fx3p - fx3m;
-            fine(fk  ,fj  ,fi) = ccval - gx1c*dfx1*(sarea_x2_[0][0](fi+1)
-                                       + sarea_x2_[1][0](fi+1))/csarea_x2(i)
-                                       - gx3c*dfx3*(sarea_x2_[1][0](fi)
-                                       + sarea_x2_[1][0](fi+1))/csarea_x2(i);
-            fine(fk  ,fj,fi+1) = ccval + gx1c*dfx1*(sarea_x2_[0][0](fi)
-                                       + sarea_x2_[1][0](fi))/csarea_x2(i)
-                                       - gx3c*dfx3*(sarea_x2_[1][0](fi)
-                                       + sarea_x2_[1][0](fi+1))/csarea_x2(i);
-            fine(fk+1,fj  ,fi) = ccval - gx1c*dfx1*(sarea_x2_[0][0](fi+1)
-                                       + sarea_x2_[1][0](fi+1))/csarea_x2(i)
-                                       + gx3c*dfx3*(sarea_x2_[0][0](fi)
-                                       + sarea_x2_[0][0](fi+1))/csarea_x2(i);
-            fine(fk+1,fj,fi+1) = ccval + gx1c*dfx1*(sarea_x2_[0][0](fi)
-                                       + sarea_x2_[1][0](fi))/csarea_x2(i)
-                                       + gx3c*dfx3*(sarea_x2_[0][0](fi)
-                                       + sarea_x2_[0][0](fi+1))/csarea_x2(i);
-          } else {
+            Real csarea = csarea_x2(i) + TINY_NUMBER;
+            Real fsa00 = sarea_x2_[0][0](fi);
+            Real fsa01 = sarea_x2_[0][0](fi+1);
+            Real fsa10 = sarea_x2_[1][0](fi);
+            Real fsa11 = sarea_x2_[1][0](fi+1);
+
+            Real gx1m = (ccval - coarse(k,j,i-1))/dx1m;
+            Real gx1p = (coarse(k,j,i+1) - ccval)/dx1p;
+            Real gx1c = 0.5*(SIGN(gx1m) + SIGN(gx1p))*std::min(std::abs(gx1m),
+                                                             std::abs(gx1p));
+            Real gx3m = (ccval - coarse(k-1,j,i))/dx3m;
+            Real gx3p = (coarse(k+1,j,i) - ccval)/dx3p;
+            Real gx3c = 0.5*(SIGN(gx3m) + SIGN(gx3p))*std::min(std::abs(gx3m),
+                                                             std::abs(gx3p));
+
+            fine(fk  ,fj  ,fi) = ccval - gx1c*dfx1*(fsa01 + fsa11)/csarea
+                                       - gx3c*dfx3*(fsa10 + fsa11)/csarea;
+            fine(fk  ,fj,fi+1) = ccval + gx1c*dfx1*(fsa00 + fsa10)/csarea
+                                       - gx3c*dfx3*(fsa10 + fsa11)/csarea;
+            fine(fk+1,fj  ,fi) = ccval - gx1c*dfx1*(fsa01 + fsa11)/csarea
+                                       + gx3c*dfx3*(fsa00 + fsa01)/csarea;
+            fine(fk+1,fj,fi+1) = ccval + gx1c*dfx1*(fsa00 + fsa10)/csarea
+                                       + gx3c*dfx3*(fsa00 + fsa01)/csarea;
+          }
+        }
+      }
+    } else {
+      for (int k=sk; k<=ek; k++) {
+        int fk = (k - pmb->cks)*2 + pmb->ks;
+        const Real& x3m = pcoarsec->x3s2(k-1);
+        const Real& x3c = pcoarsec->x3s2(k);
+        const Real& x3p = pcoarsec->x3s2(k+1);
+        Real dx3m = x3c - x3m;
+        Real dx3p = x3p - x3c;
+        const Real& fx3m = pco->x3s2(fk);
+        const Real& fx3p = pco->x3s2(fk+1);
+        for (int j=sj; j<=ej; j++) {
+          int fj = (j - pmb->cjs)*2 + pmb->js;
+          for (int i=si; i<=ei; i++) {
+            int fi = (i - pmb->cis)*2 + pmb->is;
+            const Real& x1m = pcoarsec->x1s2(i-1);
+            const Real& x1c = pcoarsec->x1s2(i);
+            const Real& x1p = pcoarsec->x1s2(i+1);
+            Real dx1m = x1c - x1m;
+            Real dx1p = x1p - x1c;
+            const Real& fx1m = pco->x1s2(fi);
+            const Real& fx1p = pco->x1s2(fi+1);
+            Real ccval = coarse(k,j,i);
+
+            Real gx1m = (ccval - coarse(k,j,i-1))/dx1m;
+            Real gx1p = (coarse(k,j,i+1) - ccval)/dx1p;
+            Real gx1c = 0.5*(SIGN(gx1m) + SIGN(gx1p))*std::min(std::abs(gx1m),
+                                                               std::abs(gx1p));
+            Real gx3m = (ccval - coarse(k-1,j,i))/dx3m;
+            Real gx3p = (coarse(k+1,j,i) - ccval)/dx3p;
+            Real gx3c = 0.5*(SIGN(gx3m) + SIGN(gx3p))*std::min(std::abs(gx3m),
+                                                               std::abs(gx3p));
             fine(fk  ,fj,fi  ) = ccval - gx1c*(x1c - fx1m) - gx3c*(x3c - fx3m);
             fine(fk  ,fj,fi+1) = ccval + gx1c*(fx1p - x1c) - gx3c*(x3c - fx3m);
             fine(fk+1,fj,fi  ) = ccval - gx1c*(x1c - fx1m) + gx3c*(fx3p - x3c);
             fine(fk+1,fj,fi+1) = ccval + gx1c*(fx1p - x1c) + gx3c*(fx3p - x3c);
-          }
-        }
+	  }
+	}
       }
     }
   } else if (pmb->block_size.nx2 > 1) {
@@ -1011,67 +1076,96 @@ void MeshRefinement::ProlongateSharedFieldX3(
   Coordinates *pco = pmb->pcoord;
   int fsi = (si - pmb->cis)*2 + pmb->is, fei = (ei - pmb->cis)*2 + pmb->is + 1;
   if (pmb->block_size.nx3 > 1) {
-    for (int k=sk; k<=ek; k++) {
-      int fk = (k - pmb->cks)*2 + pmb->ks;
-      for (int j=sj; j<=ej; j++) {
-        int fj = (j - pmb->cjs)*2 + pmb->js;
-        const Real& x2m = pcoarsec->x2s3(j-1);
-        const Real& x2c = pcoarsec->x2s3(j);
-        const Real& x2p = pcoarsec->x2s3(j+1);
-        Real dx2m = x2c - x2m;
-        Real dx2p = x2p - x2c;
-        const Real& fx2m = pco->x2s3(fj);
-        const Real& fx2p = pco->x2s3(fj+1);
-        if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0) {
+    if (fluxinterp) {
+      for (int k=sk; k<=ek; k++) {
+        int fk = (k - pmb->cks)*2 + pmb->ks;
+        for (int j=sj; j<=ej; j++) {
+          int fj = (j - pmb->cjs)*2 + pmb->js;
+          const Real& x2m = pcoarsec->x2s3(j-1);
+          const Real& x2c = pcoarsec->x2s3(j);
+          const Real& x2p = pcoarsec->x2s3(j+1);
+          Real dx2m = x2c - x2m;
+          Real dx2p = x2p - x2c;
+          const Real& fx2m = pco->x2s3(fj);
+          const Real& fx2p = pco->x2s3(fj+1);
           pco->Face3Area(fk,   fj,  fsi, fei, sarea_x3_[0][0]);
           pco->Face3Area(fk, fj+1,  fsi, fei, sarea_x3_[0][1]);
           pcoarsec->Face3Area(k, j, si, ei, csarea_x3);
-        }
-        for (int i=si; i<=ei; i++) {
-          int fi = (i - pmb->cis)*2 + pmb->is;
-          const Real& x1m = pcoarsec->x1s3(i-1);
-          const Real& x1c = pcoarsec->x1s3(i);
-          const Real& x1p = pcoarsec->x1s3(i+1);
-          Real dx1m = x1c - x1m;
-          Real dx1p = x1p - x1c;
-          const Real& fx1m = pco->x1s3(fi);
-          const Real& fx1p = pco->x1s3(fi+1);
-          Real ccval = coarse(k,j,i);
 
-          Real gx1m = (ccval - coarse(k,j,i-1))/dx1m;
-          Real gx1p = (coarse(k,j,i+1) - ccval)/dx1p;
-          Real gx1c = 0.5*(SIGN(gx1m) + SIGN(gx1p))*std::min(std::abs(gx1m),
+          for (int i=si; i<=ei; i++) {
+            int fi = (i - pmb->cis)*2 + pmb->is;
+            const Real& x1m = pcoarsec->x1s3(i-1);
+            const Real& x1c = pcoarsec->x1s3(i);
+            const Real& x1p = pcoarsec->x1s3(i+1);
+            Real dx1m = x1c - x1m;
+            Real dx1p = x1p - x1c;
+            const Real& fx1m = pco->x1s3(fi);
+            const Real& fx1p = pco->x1s3(fi+1);
+            Real ccval = coarse(k,j,i);
+
+            Real gx1m = (ccval - coarse(k,j,i-1))/dx1m;
+            Real gx1p = (coarse(k,j,i+1) - ccval)/dx1p;
+            Real gx1c = 0.5*(SIGN(gx1m) + SIGN(gx1p))*std::min(std::abs(gx1m),
                                                              std::abs(gx1p));
-          Real gx2m = (ccval - coarse(k,j-1,i))/dx2m;
-          Real gx2p = (coarse(k,j+1,i) - ccval)/dx2p;
-          Real gx2c = 0.5*(SIGN(gx2m) + SIGN(gx2p))*std::min(std::abs(gx2m),
+            Real gx2m = (ccval - coarse(k,j-1,i))/dx2m;
+            Real gx2p = (coarse(k,j+1,i) - ccval)/dx2p;
+            Real gx2c = 0.5*(SIGN(gx2m) + SIGN(gx2p))*std::min(std::abs(gx2m),
                                                              std::abs(gx2p));
-          if (std::strcmp(COORDINATE_SYSTEM, "spherical_polar") == 0) {
             Real dfx1 = fx1p - fx1m;
             Real dfx2 = fx2p - fx2m;
-            fine(fk  ,fj  ,fi) = ccval - gx1c*dfx1*(sarea_x3_[0][0](fi+1)
-                                       + sarea_x3_[0][1](fi+1))/csarea_x3(i)
-                                       - gx2c*dfx2*(sarea_x3_[0][1](fi)
-                                       + sarea_x3_[0][1](fi+1))/csarea_x3(i);
-            fine(fk  ,fj,fi+1) = ccval + gx1c*dfx1*(sarea_x3_[0][0](fi)
-                                       + sarea_x3_[0][1](fi))/csarea_x3(i)
-                                       - gx2c*dfx2*(sarea_x3_[0][1](fi)
-                                       + sarea_x3_[0][1](fi+1))/csarea_x3(i);
-            fine(fk,fj+1  ,fi) = ccval - gx1c*dfx1*(sarea_x3_[0][0](fi+1)
-                                       + sarea_x3_[0][1](fi+1))/csarea_x3(i)
-                                       + gx2c*dfx2*(sarea_x3_[0][0](fi)
-                                       + sarea_x3_[0][0](fi+1))/csarea_x3(i);
-            fine(fk,fj+1,fi+1) = ccval + gx1c*dfx1*(sarea_x3_[0][0](fi)
-                                       + sarea_x3_[0][1](fi))/csarea_x3(i)
-                                       + gx2c*dfx2*(sarea_x3_[0][0](fi)
-                                       + sarea_x3_[0][0](fi+1))/csarea_x3(i);
-          } else {
+            Real csarea = csarea_x3(i);
+            Real fsa00 = sarea_x3_[0][0](fi);
+            Real fsa01 = sarea_x3_[0][0](fi+1);
+            Real fsa10 = sarea_x3_[0][1](fi);
+            Real fsa11 = sarea_x3_[0][1](fi+1);
+            fine(fk  ,fj  ,fi) = ccval - gx1c*dfx1*(fsa01 + fsa11)/csarea
+                                       - gx2c*dfx2*(fsa10 + fsa11)/csarea;
+            fine(fk  ,fj,fi+1) = ccval + gx1c*dfx1*(fsa00 + fsa10)/csarea
+                                       - gx2c*dfx2*(fsa10 + fsa11)/csarea;
+            fine(fk,fj+1  ,fi) = ccval - gx1c*dfx1*(fsa01 + fsa11)/csarea
+                                       + gx2c*dfx2*(fsa00 + fsa01)/csarea;
+            fine(fk,fj+1,fi+1) = ccval + gx1c*dfx1*(fsa00 + fsa10)/csarea
+                                       + gx2c*dfx2*(fsa00 + fsa01)/csarea;
+          }
+        }
+      }
+    } else {
+      for (int k=sk; k<=ek; k++) {
+        int fk = (k - pmb->cks)*2 + pmb->ks;
+        for (int j=sj; j<=ej; j++) {
+          int fj = (j - pmb->cjs)*2 + pmb->js;
+          const Real& x2m = pcoarsec->x2s3(j-1);
+          const Real& x2c = pcoarsec->x2s3(j);
+          const Real& x2p = pcoarsec->x2s3(j+1);
+          Real dx2m = x2c - x2m;
+          Real dx2p = x2p - x2c;
+          const Real& fx2m = pco->x2s3(fj);
+          const Real& fx2p = pco->x2s3(fj+1);
+          for (int i=si; i<=ei; i++) {
+            int fi = (i - pmb->cis)*2 + pmb->is;
+            const Real& x1m = pcoarsec->x1s3(i-1);
+            const Real& x1c = pcoarsec->x1s3(i);
+            const Real& x1p = pcoarsec->x1s3(i+1);
+            Real dx1m = x1c - x1m;
+            Real dx1p = x1p - x1c;
+            const Real& fx1m = pco->x1s3(fi);
+            const Real& fx1p = pco->x1s3(fi+1);
+            Real ccval = coarse(k,j,i);
+
+            Real gx1m = (ccval - coarse(k,j,i-1))/dx1m;
+            Real gx1p = (coarse(k,j,i+1) - ccval)/dx1p;
+            Real gx1c = 0.5*(SIGN(gx1m) + SIGN(gx1p))*std::min(std::abs(gx1m),
+                                                             std::abs(gx1p));
+            Real gx2m = (ccval - coarse(k,j-1,i))/dx2m;
+            Real gx2p = (coarse(k,j+1,i) - ccval)/dx2p;
+            Real gx2c = 0.5*(SIGN(gx2m) + SIGN(gx2p))*std::min(std::abs(gx2m),
+                                                             std::abs(gx2p));
             fine(fk,fj  ,fi  ) = ccval - gx1c*(x1c - fx1m) - gx2c*(x2c - fx2m);
             fine(fk,fj  ,fi+1) = ccval + gx1c*(fx1p - x1c) - gx2c*(x2c - fx2m);
             fine(fk,fj+1,fi  ) = ccval - gx1c*(x1c - fx1m) + gx2c*(fx2p - x2c);
             fine(fk,fj+1,fi+1) = ccval + gx1c*(fx1p - x1c) + gx2c*(fx2p - x2c);
-          }
-        }
+	  }
+	}
       }
     }
   } else if (pmb->block_size.nx2 > 1) {

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -940,9 +940,9 @@ void MeshRefinement::ProlongateSharedFieldX2(
         const Real& x3p = pcoarsec->x3s2(k+1);
         Real dx3m = x3c - x3m;
         Real dx3p = x3p - x3c;
-        Real dfx3 = fx3p - fx3m;
         const Real& fx3m = pco->x3s2(fk);
         const Real& fx3p = pco->x3s2(fk+1);
+        Real dfx3 = fx3p - fx3m;
         for (int j=sj; j<=ej; j++) {
           int fj = (j - pmb->cjs)*2 + pmb->js;
           pco->Face2Area(fk,   fj,  fsi, fei, sarea_x2_[0][0]);
@@ -1088,6 +1088,7 @@ void MeshRefinement::ProlongateSharedFieldX3(
           Real dx2p = x2p - x2c;
           const Real& fx2m = pco->x2s3(fj);
           const Real& fx2p = pco->x2s3(fj+1);
+          Real dfx2 = fx2p - fx2m;
           pco->Face3Area(fk,   fj,  fsi, fei, sarea_x3_[0][0]);
           pco->Face3Area(fk, fj+1,  fsi, fei, sarea_x3_[0][1]);
           pcoarsec->Face3Area(k, j, si, ei, csarea_x3);
@@ -1112,7 +1113,6 @@ void MeshRefinement::ProlongateSharedFieldX3(
             Real gx2c = 0.5*(SIGN(gx2m) + SIGN(gx2p))*std::min(std::abs(gx2m),
                                                              std::abs(gx2p));
             Real dfx1 = fx1p - fx1m;
-            Real dfx2 = fx2p - fx2m;
             Real csarea = csarea_x3(i);
             Real fsa00 = sarea_x3_[0][0](fi);
             Real fsa01 = sarea_x3_[0][0](fi+1);

--- a/src/mesh/mesh_refinement.hpp
+++ b/src/mesh/mesh_refinement.hpp
@@ -99,6 +99,7 @@ class MeshRefinement {
   AthenaArray<Real> fvol_[2][2], sarea_x1_[2][2], sarea_x2_[2][3], sarea_x3_[3][2];
   AthenaArray<Real> csarea_x1, csarea_x2, csarea_x3;
   int refine_flag_, neighbor_rflag_, deref_count_, deref_threshold_;
+  bool fluxinterp;
 
   // functions
   AMRFlagFunc AMRFlag_; // duplicate of Mesh class member

--- a/src/mesh/mesh_refinement.hpp
+++ b/src/mesh/mesh_refinement.hpp
@@ -99,7 +99,7 @@ class MeshRefinement {
   AthenaArray<Real> fvol_[2][2], sarea_x1_[2][2], sarea_x2_[2][3], sarea_x3_[3][2];
   AthenaArray<Real> csarea_x1, csarea_x2, csarea_x3;
   int refine_flag_, neighbor_rflag_, deref_count_, deref_threshold_;
-  bool fluxinterp;
+  bool fluxinterp_;
 
   // functions
   AMRFlagFunc AMRFlag_; // duplicate of Mesh class member

--- a/src/mesh/mesh_refinement.hpp
+++ b/src/mesh/mesh_refinement.hpp
@@ -97,7 +97,7 @@ class MeshRefinement {
   Coordinates *pcoarsec;
 
   AthenaArray<Real> fvol_[2][2], sarea_x1_[2][2], sarea_x2_[2][3], sarea_x3_[3][2];
-  AthenaArray<Real> csarea_x1, csarea_x2, csarea_x3;
+  AthenaArray<Real> csarea_x1_, csarea_x2_, csarea_x3_;
   int refine_flag_, neighbor_rflag_, deref_count_, deref_threshold_;
   bool fluxinterp_;
 

--- a/src/pgen/field_loop_poles.cpp
+++ b/src/pgen/field_loop_poles.cpp
@@ -697,15 +697,6 @@ Real ncells(MeshBlock *pmb, int iout) {
 
 // Total number of cells in the simulation
 Real totcells(MeshBlock *pmb, int iout) {
-  int tcell = 0;
-  int is=pmb->is, ie=pmb->ie, js=pmb->js, je=pmb->je, ks=pmb->ks, ke=pmb->ke;
-
-  for(int k=ks; k<=ke; k++) {
-    for(int j=js; j<=je; j++) {
-      for(int i=is; i<=ie; i++) {
-        tcell += 1;
-      }
-    }
-  }
+  int tcell = pmb->GetNumberOfMeshBlockCells();
   return tcell;
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The changes follow from pull request #582: Divergence-preserving prolongation of coarse/fine shared face-centered fields for 3D spherical polar grids. The divergence-preserving interpolation is now also triggered for 3D cylindrical grids. The condition for this is now evaluated outside the loops for performance. I also added area-averaged coordinates for spherical polar and cylindrical coordinates, which are used for MHD with AMR. Finally, I changed how the total cells in the field loop poles problem generator are computed: from a loop to using the function `MeshBlock::GetNumberOfMeshBlockCells()`.

<!--- Why is this change required? What problem does it solve? -->
The main changes were required to preserve the divergence of the magnetic field during refinement of curvilinear grids.
<!--- If it fixes an open issue, please link to the issue here. -->

Interpolation in ProlongateSharedFieldX functions now preserves the divergence and magnetic flux during refinement of 3D spherical polar and cylindrical grids.


## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
I ran the field loop poles test (using the input file `athinput.field_loop_poles_checkdivb`), forcing refinement at a specific cycle to check the divergence growth. The new prolongation scheme preserves the divergence.

<!--- Include details of your testing environment, and the tests you ran to -->
 I compiled the code with gcc 4.8.5 and ran the field loop poles test.

<!--- see how your change affects other areas of the code, etc. -->
The field loop poles test has a polar boundary, therefore, to run this test it is necessary to comment the AMR-polar boundary error flag in `bvals/utils/check_polar.cpp`. The test did not refine meshblocks adjacent to the pole so it was not a problem. I reverted this comment in `check_polar.cpp` as it cannot be generally applied.
