### PR TITLE
 Fixes athena_read's unnecessarily large memory allocation

### DIFF
--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -772,14 +772,14 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                     block_data = f[dataset][index, block_num, :]
                     if s > 1:
                         if nx1 > 1:
-                            block_data = np.repeat(block_data, s, axis=2)
+                            block_data = np.repeat(block_data, s, axis=2)[:,:,il_s:iu_s]
                         if nx2 > 1:
-                            block_data = np.repeat(block_data, s, axis=1)
+                            block_data = np.repeat(block_data, s, axis=1)[:,jl_s:ju_s,:]
                         if nx3 > 1:
-                            block_data = np.repeat(block_data, s, axis=0)
-                    data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data[kl_s:ku_s,
-                                                                          jl_s:ju_s,
-                                                                          il_s:iu_s]
+                            block_data = np.repeat(block_data, s, axis=0)[kl_s:ku_s,:,:]
+                        data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data
+                    else:
+                        data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data[kl_s:ku_s,jl_s:ju_s,il_s:iu_s]
 
             # Restrict fine data
             else:

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -780,8 +780,8 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                         data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data
                     else:
                         data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data[kl_s:ku_s,
-                                                                          jl_s:ju_s,
-                                                                          il_s:iu_s]
+                                                                              jl_s:ju_s,
+                                                                              il_s:iu_s]
 
             # Restrict fine data
             else:

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -779,7 +779,9 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
                             block_data = np.repeat(block_data, s, axis=0)[kl_s:ku_s,:,:]
                         data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data
                     else:
-                        data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data[kl_s:ku_s,jl_s:ju_s,il_s:iu_s]
+                        data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data[kl_s:ku_s,
+                                                                          jl_s:ju_s,
+                                                                          il_s:iu_s]
 
             # Restrict fine data
             else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
athena_read allocates unnecessarily large amount of memory for each quantity, rendering file reading unnecessarily slow or even impossible. (see #586)

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Description
 ```
                    if s > 1:
                        if nx1 > 1:
                            block_data = np.repeat(block_data, s, axis=2)
                        if nx2 > 1:
                            block_data = np.repeat(block_data, s, axis=1)
                        if nx3 > 1:
                            block_data = np.repeat(block_data, s, axis=0)
                   data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data[kl_s:ku_s,
                                                                          jl_s:ju_s,
                                                                          il_s:iu_s]


```
Allocates an array of size ( 2^s nx1, 2^s nx2, 2^s nx3), in 3D, whatever the selected size of the domain.
```

                    if s > 1:
                        if nx1 > 1:
                            block_data = np.repeat(block_data, s, axis=2)[:,:,il_s:iu_s]
                        if nx2 > 1:
                            block_data = np.repeat(block_data, s, axis=1)[:,jl_s:ju_s,:]
                        if nx3 > 1:
                            block_data = np.repeat(block_data, s, axis=0)[kl_s:ku_s,:,:]
                        data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data
                    else:
                        data[q][kl_d:ku_d, jl_d:ju_d, il_d:iu_d] = block_data[kl_s:ku_s,jl_s:ju_s,il_s:iu_s]
```
instead applies the selection of block_data's source indices during np.repeat.

