### PR TITLE
Add better exclusion for MHD+shearing box+SMR with refinement in x3 dir at shearing boundary

### DIFF
--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -60,6 +60,7 @@
 BoundaryValues::BoundaryValues(MeshBlock *pmb, BoundaryFlag *input_bcs,
                                ParameterInput *pin)
     : BoundaryBase(pmb->pmy_mesh, pmb->loc, pmb->block_size, input_bcs), pmy_block_(pmb),
+      is_shear{}, loc_shear{0, pmy_mesh_->nrbx1*(1L << pmb->loc.level - 1)},
       sb_data_{}, sb_flux_data_{} {
   // Check BC functions for each of the 6 boundaries in turn ---------------------
   for (int i=0; i<6; i++) {
@@ -122,13 +123,6 @@ BoundaryValues::BoundaryValues(MeshBlock *pmb, BoundaryFlag *input_bcs,
   // set parameters for shearing box bc and allocate buffers
   shearing_box = 0;
   if (pmy_mesh_->shear_periodic) {
-    // see discussion #569
-    if (pmy_mesh_->multilevel && MAGNETIC_FIELDS_ENABLED) {
-      std::stringstream msg;
-      msg << "### FATAL ERROR in BoundaryValues Class" << std::endl
-          << "SMR is incompatible with shearing box with MHD" << std::endl;
-      ATHENA_ERROR(msg);
-    }
     // It is required to know the reconstruction scheme before pmb->precon is defined.
     // If a higher-order scheme than PPM is implemented, xgh_ must be larger than 2.
     std::string input_recon = pin->GetOrAddString("time", "xorder", "2");
@@ -210,15 +204,10 @@ BoundaryValues::BoundaryValues(MeshBlock *pmb, BoundaryFlag *input_bcs,
     }
 
     int level = pmb->loc.level - pmy_mesh_->root_level;
-    // nblx2 is only used for allocating SimpleNeighborBlock arrays; nblx1 for loc_shear
-    // TODO(felker): initialize loc_shear{0, pmy_mesh_->nrbx2*(1L << pmb->loc.level - ..)}
-    // in ctor member initializer list and update as refinement occurs. And nblx2
+    // nblx2 is the only var used in the ctor for alllocating SimpleNeighborBlock arrays
+    nblx1 = pmy_mesh_->nrbx1*(1L << level);
     nblx2 = pmy_mesh_->nrbx2*(1L << level);
-    // is_shear{} in member init_list
-    is_shear[0] = false;
-    is_shear[1] = false;
-    loc_shear[0] = 0;
-    loc_shear[1] = pmy_mesh_->nrbx1*(1L << level) - 1;
+    nblx3 = pmy_mesh_->nrbx3*(1L << level);
 
     if (shearing_box == 1) {
       if (NGHOST+xgh_ > pmb->block_size.nx2) {
@@ -264,15 +253,16 @@ BoundaryValues::~BoundaryValues() {
 //! initializes the shearing block lists
 
 void BoundaryValues::SetupPersistentMPI() {
+  // TODO(KGF): given the fn name, it is confusing that the fn contents are not entirely
+  // wrapped in #ifdef MPI_PARALLEL
   for (auto bvars_it = bvars_main_int.begin(); bvars_it != bvars_main_int.end();
        ++bvars_it) {
     (*bvars_it)->SetupPersistentMPI();
   }
-
   // KGF: begin exclusive shearing-box section in BoundaryValues::SetupPersistentMPI()
-  // TODO(KGF): it is confusing that it is not wrapped in #ifdef MPI_PARALLEL
-  // The shearing box metadata is required regardless if MPI is used, so might be better
-  // encapsulated in a separate function
+
+  // TODO(KGF): the shearing box metadata is required regardless if MPI is used, so better
+  // to encapsulate it in a separate function
 
   // initialize the shearing block lists
   if (shearing_box != 0) {
@@ -281,7 +271,8 @@ void BoundaryValues::SetupPersistentMPI() {
     int *nslist = pmy_mesh_->nslist;
     LogicalLocation *loclist = pmy_mesh_->loclist;
     // this error needs to be downgraded to a non-fatal warning if the AMR+SMR workaround
-    // to the MHD+shear+refinement restriction is employed. See discussion #569
+    // to the MHD+shear+refinement restriction is employed (#569)--- or remove entirely,
+    // hoping that RefinementCondition() does not violate below restrictions
     if (pmy_mesh_->adaptive) {
       std::stringstream msg;
       msg << "### FATAL ERROR in BoundaryValues Class" << std::endl
@@ -293,6 +284,22 @@ void BoundaryValues::SetupPersistentMPI() {
           LogicalLocation loc;
           loc.level = pmb->loc.level;
           loc.lx1   = loc_shear[upper];
+          loc.lx2   = pmb->loc.lx2;
+          for (int64_t lx3=0; lx3<nblx3; lx3++) {
+            loc.lx3   = lx3;
+            MeshBlockTree *mbt = pmy_mesh_->tree.FindMeshBlock(loc);
+            // see discussion #569: hydro+shear with SMR (not AMR) works with x1, x3
+            // refinement but MHD with x3 refinement will NOT work without adjusting
+            // corner E-field flux correction to also take into account adjacent x3 block
+            // emf (currently just averages emf values between inner/outermost x1 MBs)
+            if ((mbt == nullptr || mbt->GetGid() == -1) && MAGNETIC_FIELDS_ENABLED) {
+              std::stringstream msg;
+              msg << "### FATAL ERROR in BoundaryValues Class" << std::endl
+                  << "shear_periodic boundaries do NOT work with MHD"
+                  << "if there is refinment in the x3 direction." << std::endl;
+              ATHENA_ERROR(msg);
+            }
+          }
           loc.lx3   = pmb->loc.lx3;
           for (int64_t lx2=0; lx2<nblx2; lx2++) {
             loc.lx2 = lx2;

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -297,14 +297,14 @@ void BoundaryValues::SetupPersistentMPI() {
           for (int64_t lx2=0; lx2<nblx2; lx2++) {
             loc.lx2 = lx2;
             MeshBlockTree *mbt = pmy_mesh_->tree.FindMeshBlock(loc);
-            int gid = mbt->GetGid();
-            if (mbt == nullptr || gid == -1) {
+            if (mbt == nullptr || mbt->GetGid() == -1) {
               std::stringstream msg;
               msg << "### FATAL ERROR in BoundaryValues Class" << std::endl
                   << "shear_periodic boundaries do NOT work "
                   << "if there is refinment in the x2 direction." << std::endl;
               ATHENA_ERROR(msg);
             }
+            int gid = mbt->GetGid();
             shbb_[upper][lx2].gid = gid;
             shbb_[upper][lx2].lid = gid - nslist[ranklist[gid]];
             shbb_[upper][lx2].rank = ranklist[gid];

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -60,7 +60,7 @@
 BoundaryValues::BoundaryValues(MeshBlock *pmb, BoundaryFlag *input_bcs,
                                ParameterInput *pin)
     : BoundaryBase(pmb->pmy_mesh, pmb->loc, pmb->block_size, input_bcs), pmy_block_(pmb),
-      is_shear{}, loc_shear{0, pmy_mesh_->nrbx1*(1L << pmb->loc.level - 1)},
+      is_shear{}, loc_shear{0, pmy_mesh_->nrbx1*(1L << pmb->loc.level) - 1},
       sb_data_{}, sb_flux_data_{} {
   // Check BC functions for each of the 6 boundaries in turn ---------------------
   for (int i=0; i<6; i++) {

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -183,17 +183,17 @@ class BoundaryValues : public BoundaryBase, //public BoundaryPhysics,
 
   // Shearing box (shared with Field and Hydro)
   // KGF: remove the redundancies in these variables:
-  int shearing_box; // flag for shearing box: 0 = none, 1: xy, 2: xz
-  int joverlap_, joverlap_flux_; // # of cells the shear runs over one block
-  Real ssize_;                  // # of ghost cells in x-z plane
-  Real eps_, eps_flux_;          // fraction part of the shear
+  int shearing_box;               // flag for shearing box: 0 = none, 1: xy, 2: xz
+  int joverlap_, joverlap_flux_;  // # of cells the shear runs over one block
+  Real ssize_;                    // # of ghost cells in x-z plane
+  Real eps_, eps_flux_;           // fraction part of the shear
   Real qomL_;
   int xorder_, xgh_;
   AthenaArray<Real> pflux_;    // pencil buffer for remapping
 
   std::int64_t nblx2;
-  //! it is possible for a MeshBlock to have is_shear={true, true},
-  //! if it is the only block along x1
+  //! note: it is possible for a MeshBlock to have is_shear={true, true},
+  //! if it is the only block along entire x1 range of domain
   bool is_shear[2]; // inner_x1=0, outer_x1=1
   SimpleNeighborBlock *shbb_[2];
   std::int64_t loc_shear[2];  // x1 LogicalLocation of block(s) on inner/outer shear bndry

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -189,14 +189,20 @@ class BoundaryValues : public BoundaryBase, //public BoundaryPhysics,
   Real eps_, eps_flux_;           // fraction part of the shear
   Real qomL_;
   int xorder_, xgh_;
-  AthenaArray<Real> pflux_;    // pencil buffer for remapping
+  AthenaArray<Real> pflux_;        // pencil buffer for remapping
 
-  std::int64_t nblx2;
+
+  std::int64_t nblx1, nblx2, nblx3; // max number of MeshBlocks in each dir
+                                    // on this level of refinement
+
   //! note: it is possible for a MeshBlock to have is_shear={true, true},
   //! if it is the only block along entire x1 range of domain
-  bool is_shear[2]; // inner_x1=0, outer_x1=1
+  bool is_shear[2];                 // inner_x1=0, outer_x1=1
+
+  std::int64_t loc_shear[2];        // x1 LogicalLocation of block(s)
+                                    // on inner/outer shear bndry
+
   SimpleNeighborBlock *shbb_[2];
-  std::int64_t loc_shear[2];  // x1 LogicalLocation of block(s) on inner/outer shear bndry
 
   // tomo-ono: 3x arrays and 4x arrays are required for int and fc, respectively
   ShearNeighborData<4> sb_data_[2];


### PR DESCRIPTION
Alternative to #585 suggested by @tomidakn that might be more narrowly-tailored. 
See https://github.com/PrincetonUniversity/athena/issues/571 and https://github.com/PrincetonUniversity/athena/discussions/569.

Ideally, we would want to check the refinement restrictions only at the beginning of the simulation and after refinement (if adaptive)-- but I am not really sure I implemented this check correctly. @tomidakn am I correct in interpreting `nblx3 = pmy_mesh_->nrbx3*(1L << level);` as  "the maximum possible number of MeshBlocks in the x3 direction across the entire mesh at the same level of refinement as the current MeshBlock"? So that the following traverses the root `MeshBlockTree` to check that every MeshBlock at the same (x1, x2) logical location as the current MeshBlock (which is on a shearing domain boundary) is on the same refinement level?
```
          for (int64_t lx3=0; lx3<nblx3; lx3++) {
            loc.lx3   = lx3;
            MeshBlockTree *mbt = pmy_mesh_->tree.FindMeshBlock(loc);
...
            if ((mbt == nullptr || mbt->GetGid() == -1) && MAGNETIC_FIELDS_ENABLED) {
...
```

Along with the existing similar check for the blocks at the same (x1, x3) logical location, but at all other x2, at the shearing boundary, this should ensure that at any timestep all blocks on the shearing boundaries are at the same level of refinement, I think? Note, this existing check along x2 is run for both Hydro and MHD, since I assume the refinement along the shearing direction breaks even the hydro flux corrections. 

Since these checks are in the BoundaryValues constructor, I think it also holds during initialization? I havent really thought about the 2D `shboxcoord=2` case, but I think this is sufficient

Questions for @tomo-ono on shearing box stuff:
- Is `shboxcoord=2` "2D x-z case" only ever used if `mesh/nx3=1`, and similarly `shboxcoord=1` only in 3D simulations? If so, isnt the switch redundant?
- [ ] Can we add a 2D shearing sheet diagram to https://github.com/PrincetonUniversity/athena/wiki/Shearing-Box alongside the conventional 3D shearing box diagram that is there? It would have helped me when reading and editing the shear code. It especially gets confusing when dealing with `shboxcoord=2`  case and thinking in (x1,x2)=(x,z) with y into the page?

- [ ] Remove the error if AMR is used with shearing box; leave it up to the user to define a smart `RefinementCondition()` that guarantees that the requirements arent violated? Keep a runtime warning?
https://github.com/PrincetonUniversity/athena/blob/f701e6785d710ef6a90fb23254e4932b8de27ff6/src/bvals/bvals.cpp#L273-L278