### PR TITLE
Matplotlib 3.6 API change.

### DIFF
--- a/vis/python/plot_mesh.py
+++ b/vis/python/plot_mesh.py
@@ -28,8 +28,7 @@ def main(**kwargs):
     from mpl_toolkits.mplot3d import Axes3D  # noqa
 
     # Read and plot block edges
-    fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    fig, ax = plt.subplots(1, 1, subplot_kw={'projection': '3d'})
     x = []
     y = []
     z = []


### PR DESCRIPTION
The method `gca()` of a [`Figure` object](https://matplotlib.org/3.6.3/api/figure_api.html) does not accept keyword arguments anymore since Matplotlib 3.6.

<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. Minor change: The python script `~/vis/python/plot_mesh.py` needs to be revised according to Matplotlib API change.

