### PR TITLE
Fixing a linking error for chemistry with no network

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -722,7 +722,7 @@ if args['chemistry'] is not None:
 else:
     definitions['CHEMISTRY_ENABLED'] = '0'
     definitions['NUMBER_CHEMICAL_SPECIES'] = '0'
-    makefile_options['CHEMNET_FILE'] = ''
+    makefile_options['CHEMNET_FILE'] = 'src/chemistry/network/none.cpp'
     definitions['CHEMNETWORK_HEADER'] = '../chemistry/network/chem_network.hpp'
 
 # check number of species and scalars

--- a/src/chemistry/network/none.cpp
+++ b/src/chemistry/network/none.cpp
@@ -1,0 +1,16 @@
+//========================================================================================
+// Athena++ astrophysical MHD code
+// Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//! \file none.cpp
+//! \brief implementation of empty (default) chemical network
+
+// Athena++ header
+#include "../../defs.hpp"
+#include "chem_network.hpp"
+#include "network.hpp"
+
+// species names
+const std::array<std::string, NSPECIES> ChemNetwork::species_names = {};
+


### PR DESCRIPTION
The original code caused a linking error of outputs.cpp and history.cpp with icpc when compiled with -O0 (configure with `--cxx icpc -d`) because ChemNetwork::species_names (a static const member) was declared but not set. The error did not appear with -O3, possibly because it was optimized out. (I do not know why gcc has no problem with this.)

This fix adds none.cpp for an empty chemical network and initialize species_names.

## Prerequisite checklist
- [X] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.

