### PR TITLE
Fixed Schwarzschild cell-width calculation

### DIFF
--- a/src/coordinates/schwarzschild.cpp
+++ b/src/coordinates/schwarzschild.cpp
@@ -354,7 +354,7 @@ void Coordinates::CenterWidth2(const int k, const int j, const int il, const int
 #pragma omp simd
   for (int i=il; i<=iu; ++i) {
     // \Delta W = r \Delta\theta
-    dx2(i) = x1v(i) * dx1f(j);
+    dx2(i) = x1v(i) * dx2f(j);
   }
   return;
 }


### PR DESCRIPTION
x1-array was accidentally used in place of x2-array, but indexed with j. As cell widths only affect relativity for timestep purposes, and as most simulations use horizon-penetrating coordinates, this had little effect except when non-square MeshBlocks would cause crashes.

Fixes #613