### PR TITLE
Initialized turb_flag in the Mesh constructor

### DIFF
--- a/inputs/hydro/athinput.turb
+++ b/inputs/hydro/athinput.turb
@@ -63,6 +63,7 @@ gamma           = 1.666666666667 # gamma = C_p/C_v
 iso_sound_speed = 1.00           # equivalent to sqrt(gamma*p/d) for p=0.1, d=1
 
 <turbulence>
+turb_flag  = 1    # 1 for decaying, 2 (impulsive) or 3 (continuous) for driven turbulence
 dedt       = 1.0  # Energy injection rate (for driven) or Total energy (for decaying)
 nlow       = 0    # cut-off wavenumber at low-k
 nhigh      = 16   # cut-off wavenumber at high-k
@@ -71,6 +72,3 @@ tcorr      = 0.1  # correlation time for OU process (both impulsive and continuo
 dtdrive    = 0.1  # time interval between perturbation (impulsive)
 f_shear    = 0.5  # the ratio of the shear component
 rseed      = -1   # if non-negative, seed will be set by hand (slow PS generation)
-
-<problem>
-turb_flag  = 1    # 1 for decaying, 2 (impulsive) or 3 (continuous) for driven turbulence

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -108,7 +108,9 @@ Mesh::Mesh(ParameterInput *pin, int mesh_test) :
     sts_loc(TaskType::main_int),
     muj(), nuj(), muj_tilde(), gammaj_tilde(),
     nbnew(), nbdel(),
-    step_since_lb(), turb_flag(), amr_updated(multilevel),
+    step_since_lb(),
+    turb_flag(pin->GetOrAddInteger("turbulence", "turb_flag", 0)),
+    amr_updated(multilevel),
     // private members:
     next_phys_id_(), num_mesh_threads_(pin->GetOrAddInteger("mesh", "num_threads", 1)),
     gids_(), gide_(),
@@ -610,7 +612,9 @@ Mesh::Mesh(ParameterInput *pin, IOWrapper& resfile, int mesh_test) :
     sts_loc(TaskType::main_int),
     muj(), nuj(), muj_tilde(), gammaj_tilde(),
     nbnew(), nbdel(),
-    step_since_lb(), turb_flag(), amr_updated(multilevel),
+    step_since_lb(),
+    turb_flag(pin->GetOrAddInteger("turbulence", "turb_flag", 0)),
+    amr_updated(multilevel),
     // private members:
     next_phys_id_(), num_mesh_threads_(pin->GetOrAddInteger("mesh", "num_threads", 1)),
     gids_(), gide_(),

--- a/src/pgen/chem_turb.cpp
+++ b/src/pgen/chem_turb.cpp
@@ -45,21 +45,6 @@ void Mesh::InitUserMeshData(ParameterInput *pin) {
     SetFourPiG(four_pi_G);
   }
 
-  // turb_flag is initialzed in the Mesh constructor to 0 by default;
-  // turb_flag = 1 for decaying turbulence
-  // turb_flag = 2 for impulsively driven turbulence
-  // turb_flag = 3 for continuously driven turbulence
-  turb_flag = pin->GetInteger("problem","turb_flag");
-  if (turb_flag != 0) {
-#ifndef FFT
-    std::stringstream msg;
-    msg << "### FATAL ERROR in TurbulenceDriver::TurbulenceDriver" << std::endl
-        << "non zero Turbulence flag is set without FFT!" << std::endl;
-    ATHENA_ERROR(msg);
-    return;
-#endif
-  }
-
   return;
 }
 

--- a/src/pgen/turb.cpp
+++ b/src/pgen/turb.cpp
@@ -41,21 +41,6 @@ void Mesh::InitUserMeshData(ParameterInput *pin) {
     SetFourPiG(four_pi_G);
   }
 
-  // turb_flag is initialzed in the Mesh constructor to 0 by default;
-  // turb_flag = 1 for decaying turbulence
-  // turb_flag = 2 for impulsively driven turbulence
-  // turb_flag = 3 for continuously driven turbulence
-  turb_flag = pin->GetInteger("problem","turb_flag");
-  if (turb_flag != 0) {
-#ifndef FFT
-    std::stringstream msg;
-    msg << "### FATAL ERROR in TurbulenceDriver::TurbulenceDriver" << std::endl
-        << "non zero Turbulence flag is set without FFT!" << std::endl;
-    ATHENA_ERROR(msg);
-    return;
-#endif
-  }
-
   return;
 }
 

--- a/tst/regression/scripts/tests/turb/turb_3d.py
+++ b/tst/regression/scripts/tests/turb/turb_3d.py
@@ -42,7 +42,7 @@ def run(**kwargs):
                  'meshblock/nx1=16',
                  'meshblock/nx2=16',
                  'meshblock/nx3=16',
-                 'problem/turb_flag=3',
+                 'turbulence/turb_flag=3',
                  'turbulence/rseed=1',
                  'output2/dt=-1', 'time/tlim=0.3']
     athena.run('hydro/athinput.turb', arguments + ['job/problem_id=turb_serial'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. Initialized `turb_flag` in the Mesh constructor by reading it from the problem input under the `turbulence` block (with the default being 0). No need to initialize it in the pgen files. 

This closes #634 