### PR TITLE
Throw fatal runtime error for asymmetric x2 bounds for 1D spherical-polar mesh

### DIFF
--- a/inputs/hydro/athinput.mignone_radial
+++ b/inputs/hydro/athinput.mignone_radial
@@ -34,9 +34,9 @@ ix1_bc     = reflecting   # inner-X1 boundary flag
 ox1_bc     = outflow   # outer-X1 boundary flag
 x1rat      = 1.0       # non-uniform grid ratio
 
-nx2        =  1        # Number of zones in X2-direction
-x2min      = 0.0       # minimum value of X2
-x2max      = 1.0       # maximum value of X2
+nx2        =  1       # Number of zones in X2-direction
+x2min       = 1.0707963267948966   # minimum value of X2
+x2max       = 2.0707963267948966   # maximum value of X2
 ix2_bc     = periodic  # inner-X2 boundary flag
 ox2_bc     = periodic  # outer-X2 boundary flag
 

--- a/src/coordinates/spherical_polar.cpp
+++ b/src/coordinates/spherical_polar.cpp
@@ -51,6 +51,23 @@ void Coordinates::Initialize(ParameterInput *pin) {
     ATHENA_ERROR(msg);
   }
 
+  // x2 limits must be symmetric about PI/2 in 1D
+  if (pm->ndim == 1) {
+    Real dmax = pm->mesh_size.x2max - PI/2.0;
+    Real dmin = PI/2.0 - pm->mesh_size.x2min;
+    if (std::abs(dmax - dmin) > std::numeric_limits<Real>::epsilon()) {
+      std::stringstream msg;
+      msg << "### FATAL ERROR in BoundaryValues constructor" << std::endl
+          << "1D spherical-like coordinates requires x2-limits to be symmetric about "
+          << std::setprecision(std::numeric_limits<Real>::max_digits10 -1)
+          << std::scientific << PI/2.0 << "\n"
+          << "Current x2 domsin limits are: \n"
+          << "x2min=" << pm->mesh_size.x2min << "\n"
+          << "x2max=" << pm->mesh_size.x2max << std::endl;
+      ATHENA_ERROR(msg);
+    }
+  }
+
   // initialize volume-averaged coordinates and spacing
   // x1-direction: x1v = (\int r dV / \int dV) = d(r^4/4)/d(r^3/3)
   for (int i=il-ng; i<=iu+ng; ++i) {


### PR DESCRIPTION
## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
Add fatal error for 1d spherical polar problems if the x2 limits are not symmetric about PI/2. This addresses the raised issue #354. This also updates the x2-limits for the 1d mignone radial test to be symmetric so that the regression test doesn't conflict with this PR. 

## Testing and validation
tested against regression tests involving spherical polar coordinates

## To-do
does not address associated non-zero vtheta in 1d spherical in any way

Closes #354 
