### PR TITLE
Update constant values in units.hpp to agree with values in Astropy and FITS standard

### DIFF
--- a/src/units/units.hpp
+++ b/src/units/units.hpp
@@ -20,12 +20,12 @@
 //! \brief Physical constants defined in c.g.s.
 namespace Constants {
 static const Real grav_const_cgs       = 6.67259e-8;
-static const Real solar_mass_cgs       = 1.9891e+33;
+static const Real solar_mass_cgs       = 1.9884099e33;
 static const Real solar_lum_cgs        = 3.8268e+33;
-static const Real yr_cgs               = 3.155815e+7;
-static const Real million_yr_cgs       = 3.155815e+13;
-static const Real pc_cgs               = 3.085678e+18;
-static const Real kpc_cgs              = 3.085678e+21;
+static const Real yr_cgs               = 3.15576e7;
+static const Real million_yr_cgs       = 3.15576e13;
+static const Real pc_cgs               = 3.08567758e18;
+static const Real kpc_cgs              = 3.08567758e21;
 static const Real km_s_cgs             = 1.0e+5;
 static const Real hydrogen_mass_cgs    = 1.6733e-24;
 static const Real radiation_aconst_cgs = 7.5646e-15;


### PR DESCRIPTION
- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.

Very minor changes:
1. Changed solar_mass_cgs from 1.9891e33 to 1.9884099e33 to agree with value used in Astropy.
2. Changed yr_cgs from 3.155815e7 to 3.15576e7 to agree with value used in Astropy and the FITS standard of using a Julian year of exactly 365.25 days.
3. Changed pc_cgs from 3.085678e18 to 3.08567758e18 to agree with value used in Astropy.


