### PR TITLE
Add missing problem reference in RJ2A input file

### DIFF
--- a/inputs/mhd/athinput.rj2a
+++ b/inputs/mhd/athinput.rj2a
@@ -1,7 +1,7 @@
 <comment>
 problem   = Riemann problem from Figure 2a of Ryu & Jones (1995)
 reference = Ryu, D. & Jones, T.W., ApJ 442, 228-258 (1995)
-configure = -b
+configure = -b --prob=shock_tube
 
 <job>
 problem_id  = RJ2a      # problem ID: basename of output filenames


### PR DESCRIPTION
There was no reference to a problem in the athinput.rj2a input file. I have added the `--prob=shock_tube` argument.

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->
The source code hasn't been changed.

- [ ] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was no reference to a problem in the `athinput.rj2a` input file. I have added the `--prob=shock_tube` argument.
This issue made it impossible to run the RJ2a problem simply; forcing the user to dive in the code to check where this problem was generated.
You may want to categorize major vs. minor changes and list them:
1. Minor change : modify an input file

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
I followed the procedure described in the Athena Wiki for the 1D MHD problem set up, with the athinput.rj2a file. the output was the following 
```bash
  python3 configure.py --prob=shock_tube -b
  Your Athena++ distribution has now been configured with the following options: 
  Problem generator:            shock_tube
  Coordinate system:            cartesian
  Equation of state:            adiabatic
  Riemann solver:               hlld
  Magnetic fields:              ON
  Number of scalars:            0
  Number of chemical species:   0
  Special relativity:           OFF
  General relativity:           OFF
  Radiative Transfer:           OFF
  Implicit Radiation:           OFF
  Cosmic Ray Transport:         OFF
  Cosmic Ray Diffusion:         OFF
  Frame transformations:        OFF
  Self-Gravity:                 OFF
  Super-Time-Stepping:          OFF
  Chemistry:                    OFF
  KIDA rates:                   OFF
  ChemRadiation:                OFF
  chem_ode_solver:              OFF
  Debug flags:                  OFF
  Code coverage flags:          OFF
  Linker flags:                  
  Floating-point precision:     double
  Number of ghost cells:        2
  MPI parallelism:              OFF
  OpenMP parallelism:           OFF
  FFT:                          OFF
  HDF5 output:                  OFF
  Compiler:                     g++
  Compilation command:          g++  -O3 -std=c++11
```
After that, I compiled with 

```bash
make clean
make
```

All compiled fine, and I then ran the problem with 
```bash 
bin/athena -i inputs/mhd/athinput.rj2a
```

<!--- Include details of your testing environment, and the tests you ran to -->
I ran it on MacOS Sequoia 15.4 equipped with an Intel Core i9. 
The plot for the profile density was the following
```bash
plot "RJ2a.block0.out1.00040.tab" using 2:3 with lines
```
![RJ2_rho](https://github.com/user-attachments/assets/fdad7283-638d-470c-ad5e-f87e011e2104)

<!--- see how your change affects other areas of the code, etc. -->
This change does not affect any other part of the code.
...

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->
No other task associated with this PR
