### PR TITLE
Fix Liska-Wendroff initial conditions for parallel.

### DIFF
--- a/src/pgen/lw_implode.cpp
+++ b/src/pgen/lw_implode.cpp
@@ -40,20 +40,10 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
 
   Real gm1 = peos->GetGamma() - 1.0;
 
-  // to make sure the ICs are symmetric, set y0 to be at a cell center
-  // Use global mesh properties to compute y0 consistently across all MeshBlocks
-  Real y0 = 0.5*(pmy_mesh->mesh_size.x2max + pmy_mesh->mesh_size.x2min);
-  // Compute the global cell size (uniform mesh assumed)
-  Real dx2 = (pmy_mesh->mesh_size.x2max - pmy_mesh->mesh_size.x2min)
-             / pmy_mesh->mesh_size.nx2;
-  // Find the first global cell index whose center is > y0
-  int j_global = static_cast<int>((y0 - pmy_mesh->mesh_size.x2min) / dx2);
-  Real center_j = pmy_mesh->mesh_size.x2min + (j_global + 0.5) * dx2;
-  if (center_j <= y0) {
-    j_global++;
-  }
-  // Set y0 to the center of that cell (matches original single-block behavior)
-  y0 = pmy_mesh->mesh_size.x2min + (j_global + 0.5) * dx2;
+  // alpha_x is the x-intercept of the lower left triangle in physical space
+  Real alpha_x = 0.15;
+  // alpha_y is the y-intercept of the lower left triangle in physical space
+  Real alpha_y = 0.15;
 
   // Set initial conditions
   for (int k=ks; k<=ke; k++) {
@@ -62,7 +52,9 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
         phydro->u(IM1,k,j,i) = 0.0;
         phydro->u(IM2,k,j,i) = 0.0;
         phydro->u(IM3,k,j,i) = 0.0;
-        if (pcoord->x2v(j) > (y0 - pcoord->x1v(i))) {
+        Real y0 = alpha_y * (1.0 - pcoord->x1v(i)/alpha_x);
+        // Check 1/2 cell above
+        if (pcoord->x2v(j) > y0 + 0.5*pcoord->dx2f(j)) {
           phydro->u(IDN,k,j,i) = d_out;
           phydro->u(IEN,k,j,i) = p_out/gm1;
         } else {

--- a/src/pgen/lw_implode.cpp
+++ b/src/pgen/lw_implode.cpp
@@ -44,7 +44,8 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
   // Use global mesh properties to compute y0 consistently across all MeshBlocks
   Real y0 = 0.5*(pmy_mesh->mesh_size.x2max + pmy_mesh->mesh_size.x2min);
   // Compute the global cell size (uniform mesh assumed)
-  Real dx2 = (pmy_mesh->mesh_size.x2max - pmy_mesh->mesh_size.x2min) / pmy_mesh->mesh_size.nx2;
+  Real dx2 = (pmy_mesh->mesh_size.x2max - pmy_mesh->mesh_size.x2min)
+             / pmy_mesh->mesh_size.nx2;
   // Find the first global cell index whose center is > y0
   int j_global = static_cast<int>((y0 - pmy_mesh->mesh_size.x2min) / dx2);
   Real center_j = pmy_mesh->mesh_size.x2min + (j_global + 0.5) * dx2;


### PR DESCRIPTION
(cf., SIAM J. Sci. Comput. 25, pp.3 2003)
Previous version of the code had a symmetry bias in the initial conditions that yielded unsymmetric results in parallel symmetric problems.

<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

You may want to categorize major vs. minor changes and list them:
1. Major change #1
2. ...

## Testing and validation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

...

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->

- [ ] Future development task
