### PR TITLE
Removed fp16 warnings

### DIFF
--- a/src/athena.hpp
+++ b/src/athena.hpp
@@ -27,7 +27,6 @@
 #endif
 #else
 #define fp16_t_not_supported
-#pragma message("fp16 not supported for icpx")
 #endif // __INTEL_LLVM_COMPILER
 
 // primitive type alias that allows code to run with either floats or doubles


### PR DESCRIPTION
Removed fp16 compile time warnings.

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] All new and existing tests passed.

## To-do
<!-- Describe remaining tasks or open questions related to this PR-->

- [x] Hope CI tests pass
