### PR TITLE
implicit radiation bug fixes

### DIFF
--- a/src/coordinates/spherical_polar.cpp
+++ b/src/coordinates/spherical_polar.cpp
@@ -775,9 +775,9 @@ void Coordinates::ConvertAngle(MeshBlock *pmb, const int nang,
 void Coordinates::GetGeometryZeta(NRRadiation *prad, const int k, const int j,
                                      const int i, AthenaArray<Real> &g_zeta) {
   const int& nzeta = prad->nzeta;
-  Real radius = x1v(i);
+  Real inv_radius = coord_src1_i_(i);
   for(int n=0; n<nzeta*2+1; ++n) {
-    g_zeta(n) = 1./radius;
+    g_zeta(n) = inv_radius;
   }
 }
 
@@ -787,7 +787,7 @@ void Coordinates::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
                                     const int i, const int n_zeta,
                                     AthenaArray<Real> &g_psi) {
   const int &npsi = prad->npsi;
-  Real radius = x1v(i);
+  Real inv_radius = coord_src1_i_(i);
   Real sinzeta_v = 1.0 - prad->coszeta_v(n_zeta) * prad->coszeta_v(n_zeta);
   sinzeta_v = std::sqrt(sinzeta_v);
   const Real &cottheta = prad->cot_theta(j);
@@ -797,7 +797,7 @@ void Coordinates::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
     }
   } else {
     for(int n=0; n<2*npsi+1; ++n) {
-      g_psi(n) = sinzeta_v * cottheta * prad->sin_psi_f(n)/radius;
+      g_psi(n) = sinzeta_v * cottheta * prad->sin_psi_f(n) * inv_radius;
     }
   }
 }
@@ -806,7 +806,7 @@ void Coordinates::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
 void Coordinates::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
                         const int i, AthenaArray<Real> &g_psi) {
   const int& npsi = prad->npsi;
-  Real radius = x1v(i);
+  Real inv_radius = coord_src1_i_(i);
 
   const Real &cottheta = prad->cot_theta(j);
   if (npsi == 1) {
@@ -815,7 +815,7 @@ void Coordinates::GetGeometryPsi(NRRadiation *prad, const int k, const int j,
     }
   } else {
     for(int n=0; n<2*npsi+1; ++n) {
-      g_psi(n) = cottheta * prad->sin_psi_f(n)/radius;
+      g_psi(n) = cottheta * prad->sin_psi_f(n) * inv_radius;
     }
   }
 }

--- a/src/nr_radiation/angulargrid.cpp
+++ b/src/nr_radiation/angulargrid.cpp
@@ -451,6 +451,9 @@ void NRRadiation::AngularGrid(int angle_flag, int nzeta, int npsi) {
 
       for (int i=0; i<2*npsi+1; ++i)
         sin_psi_f(i) = sin(psi_f(i));
+      sin_psi_f(0)        = 0.0;
+      sin_psi_f(npsi)     = 0.0;
+      sin_psi_f(2*npsi)   = 0.0;
 
       for (int i=0; i<2*npsi; ++i)
         len_psi(i) = psi_f(i+1) - psi_f(i);

--- a/src/nr_radiation/radiation.cpp
+++ b/src/nr_radiation/radiation.cpp
@@ -282,8 +282,11 @@ NRRadiation::NRRadiation(MeshBlock *pmb, ParameterInput *pin):
     AngularGrid(angle_flag, nzeta, npsi);
     if (nc2 > 1) {
       cot_theta.NewAthenaArray(nc2);
-      for(int i=0; i<nc2; ++i)
-        cot_theta(i) = cos(pmb->pcoord->x2v(i))/sin(pmb->pcoord->x2v(i));
+      for(int i=0; i<nc2; ++i) {
+        Real th_l = pmb->pcoord->x2f(i);
+        Real th_r = pmb->pcoord->x2f(i+1);
+        cot_theta(i) = (sin(th_r) - sin(th_l)) / (cos(th_l) - cos(th_r));
+      }
     }
   } else {
     AngularGrid(angle_flag, nmu);

--- a/src/task_list/im_rad_task_list.cpp
+++ b/src/task_list/im_rad_task_list.cpp
@@ -14,9 +14,13 @@
 
 // Athena++ headers
 #include "../athena.hpp"
+#include "../bvals/bvals.hpp"
+#include "../bvals/cc/hydro/bvals_hydro.hpp"
 #include "../globals.hpp"
+#include "../hydro/hydro.hpp"
 #include "../mesh/mesh.hpp"
 #include "../nr_radiation/radiation.hpp"
+#include "../scalars/scalars.hpp"
 #include "im_rad_task_list.hpp"
 
 #ifdef OPENMP_PARALLEL
@@ -87,6 +91,15 @@ void IMRadTaskList::DoTaskListOneStage(Real wght) {
 }
 
 TaskStatus IMRadTaskList::PhysicalBoundary(MeshBlock *pmb) {
+  Hydro *ph = pmb->phydro;
+  ph->hbvar.SwapHydroQuantity(ph->w, HydroBoundaryQuantity::prim);
+  if (NSCALARS > 0) {
+    PassiveScalars *ps = pmb->pscalars;
+    ps->sbvar.var_cc = &(ps->r);
+    if (pmb->pmy_mesh->multilevel) {
+      ps->sbvar.coarse_buf = &(ps->coarse_r_);
+    }
+  }
   pmb->pnrrad->rad_bvar.var_cc = &(pmb->pnrrad->ir);
   pmb->pbval->ApplyPhysicalBoundaries(time, dt, pmb->pbval->bvars_main_int);
   return TaskStatus::success;


### PR DESCRIPTION

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description
This PR fixes 3 issues in the existing implicit radiation module described below

### 1) Persistent residual at the pole due to cot(theta) discretization in angular psi term

As far as I can tell, spherical polar simulations running implicit radiation with angle_flag=1 suffer from a persistent artifact when including the pole. Plotted below is an example of a spherically symmetric problem run on a 2D spherical polar grid including the pole tracing $E_r$ over $\theta$ at fixed $r$. This 20-30% error in the pole-adjecent cell does not converge away with increased iteration, angular resolution (left panel) or spatial resolution (right panel).

<img width="1805" height="684" alt="image" src="https://github.com/user-attachments/assets/45824fee-f669-4069-abc4-6766ea154eca" />

When the solving the spherical tetrad form of the transfer equation (`angle_flag=1`), the $\psi$ term of in the transfer 

$$-\frac{c\sin\zeta\cot\theta}{r}\frac{\partial(\sin\psi I)}{\partial\psi}$$

discretizes $\cot\theta\rightarrow \cot\theta_j$ at cell centers. The $\theta$-component of the flux divergence $\nabla\cdot (\hat{n}I)$ uses the standard fluxes at cell faces

$$\left[\nabla\cdot F\right]_\theta =\frac{\Delta (A\cdot F)}{V}=\frac{\sin\theta_{j+1/2}\cdot F_{j+1/2}-\sin\theta_{j-1/2}\cdot F_{j-1/2}}
     {\cos\theta_{j+1/2} - \cos\theta_{j-1/2}}$$

Ignoring the flux variation, this is effectively $\sim$ cell-averaged $\cot\theta$

$$<\cot\theta> = \frac{\sin\theta_{j+1/2}-\sin\theta_{j-1/2}}
     {\cos\theta_{j+1/2} - \cos\theta_{j-1/2}}$$

Both of $<\cot\theta>, \cot(\theta_j)$ has truncation error O($\Delta\theta^{-1}$) near the pole and their mismatch (also O($\Delta\theta^{-1}$)) seems to result in this persistent $O(1)$ artifact at the pole. I think it is preferable to discretize $\cot\theta$ in the $\psi$ term as in the flux term $\cot\theta_j\rightarrow <\cot\theta_j>$ to minimize the mismatch between these two terms. This also seems consistent with the idea that the $\theta$ flux term and the $\psi$ term at least partially cancel in the continuum sense and a more similar discretization between the two terms would improve this cancellation at the discrete level.

$$[\nabla\cdot F]_\theta -\frac{c\sin\zeta\cot\theta}{r}\frac{\partial(\sin\psi I)}{\partial\psi} =     \frac{1}{r\sin\theta}\frac{\partial(n_\theta I \sin\theta)}{\partial \theta} - \frac{n_\theta I\cos\theta}{r\sin\theta}-\frac{n_\varphi\cos\theta}{r\sin\theta}\frac{\partial I}{\partial \psi} = \frac{1}{r}\frac{\partial(n_\theta I)}{\partial\theta}- \frac{n_\varphi\cos\theta}{r\sin\theta}\frac{\partial I}{\partial \psi}$$

Using the same $\cot\theta$ discretization between the flux divergence and $\psi$ term gives nice convergence to the symmetric profile on the pole test shown above. I have tested it on non-symmetric problems as well and the result is similar.

<img width="662" height="444" alt="image" src="https://github.com/user-attachments/assets/95e2e0dd-6b10-4bd3-ad44-e8fd938f65cd" />



### 2) North/south asymmetry from psi upwinding logic

Logic in the $\psi$-flux upwinding, upwinds incorrectly because some faces expected to have $\sin\psi=0$ are not zero to machine precision. This results in otherwise symmetric problems developing a north-south asymmetry (see plot of luminosity for the symmetric problem below, note also the pole artifact issue 1) in full effect) and instability of the successive over-relaxation with many angles.

<img width="298" height="514" alt="image" src="https://github.com/user-attachments/assets/b13d520f-fb14-4ea0-8a96-1f5baadc7ac7" />


The $\psi$ term (used when `angle_flag=1`) 

 $$\frac{\partial I}{\partial t} + \dots + \frac{\partial}{\partial\psi}\left(g_\psi I\right) = \dots$$

with $g_\psi = -c\sin\zeta\cot\theta/r$ is added in the code via upwinding $I$ across $\psi$-faces. The code in `ImplicitPsiFluxCoef` implicitly assumes in its upwinding that $g_\psi$ will not change signs across a given cell:

```
if ((g_psi_(m) < 0) || (g_psi_(m+1) < 0)) {
  imp_ang_psi_l_(...,ang_num) = coef0;   
  imp_ang_psi_r_(...,ang_num) = 0.0;
  coef_c = coef1;                        
} else if ((g_psi_(m) > 0) || (g_psi_(m+1) > 0)) {
  imp_ang_psi_l_(...,ang_num) = 0.0;
  imp_ang_psi_r_(...,ang_num) = coef1;     
  coef_c = coef0;                         
}
```

this is true in a general sense because $g_\psi\sim \sin\psi$ only changes sign at $\psi=0,\pi,2\pi$ which are guaranteed to be cell faces by construction. This is not guaranteed in floating point arithmetic though as sin(pi) and sin(2*pi) evaluate to +/- 1e-16. This results in the wrong logic being triggered and incorrect upwinding occurring. 

The north-south behavior stems from the incorrect upwinding and the fact that $g_\psi\sim \cot\theta$ flips sign at $\theta=\pi/2$. In the north, ultimately the branch logic+sign results in the correct behavior in the northern hemisphere but incorrect in the southern hemisphere. In the south a large negative term ends up being added to the diagonal of the SOR matrix making it ill-conditioned. This large negative term $\sim 1/\Delta \psi$ causing problems to blow up at high angular resolution. I was seeing catastrophic behavior at $N_\psi=8$. 

The fix in this pull request is to explicitly set sin(psi) to zero at the faces psi=0, pi, 2*pi when the array of sin(psi) is constructed. I am open to other implementations, but this seems to work well.

### 3) Out-of-the-box BCs like reflecting, outflow are stuck at t=0 values if using implicit radiation

When using implicit radiation, some of the pre-defined hydro BCs get applied but do not update as the simulation progresses. This stems from the boundary communication and updating of the prim vs. cons. The fix is straightforward and to make the logic in the ImRad PhysicalBoundary function mirror the standard time_integrator PhysicalBoundary function, namely adding a SwapHydroQuantity(cons, prim) call. 

## Testing and validation

Existing regression tests on my local machine have passed as for benchmarks on each of the individual bugs:

1) I have tested the $\cot\theta$ discretization on a variety of 2D implicit radiation symmetric and non-symmetric problems and found good improvement in all cases. This is an example of the convergence of a symmetric problem to a symmetric solution with increasing angular resolution. Before the fix the problem converged to a 30% error in Er at the pole and a non-zero $\theta$ flux. After the fix, the problem shows nice $(\Delta\psi)^2$ convergence to a symmetric solution as well as lower error to begin with. While the non-symmetric problems I've run don't have benchmarked errors, the improvement in the error is very obvious by eye. 

<img width="1808" height="688" alt="image" src="https://github.com/user-attachments/assets/057fc3be-cd81-4c02-80c1-bce009583511" />

2) tested on various 2D problems symmetric problems with implicit radiation, problems are now symmetric between north and south pole and problems which crashed at $N_\psi=8$ I have run with good convergence including $N_\psi=16$.

3) tested on a minimal working example problem generator with just 1D $\rho=\cos(x)$ and a user BC copied from the existing reflecting BC. Before the fix, this problem run with BC=user in the input file would give the correct reflecting behavior but setting BC=reflecting would leave the BC stuck at its initial condition. After this fix, running the problem generator with BC=user or BC=reflecting gives the same results, with the appropriate reflection. See below where ghost zones are included in the plot of density after system has evolved -- reflecting (fixed) and user give the same behavior and show reflecting behavior density behavior at domain edge, pre-patch reflecting (buggy) does not show appropriate reflecting behavior at t>0.

<img width="880" height="569" alt="image" src="https://github.com/user-attachments/assets/76bb05df-4ea3-4229-84ab-e8686fc588ec" />

