### PR TITLE
fix(amr): correct sffc3 buffer size for non-cubic meshblocks (#719)

### DIFF
--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -1228,7 +1228,7 @@ void Mesh::PrepareAndSendFaceFieldCorrection(LogicalLocation *newloc,
   const int bnx2 = my_blocks(0)->block_size.nx2;
   const int bnx3 = my_blocks(0)->block_size.nx3;
   const int nf = static_cast<int>(my_blocks(0)->pmr->pvars_fc_.size());
-  const int sffc1 = nf*bnx2*bnx3, sffc2 = nf*bnx1*bnx3, sffc3 = nf*bnx2*bnx3;
+  const int sffc1 = nf*bnx2*bnx3, sffc2 = nf*bnx1*bnx3, sffc3 = nf*bnx1*bnx2;
 
   // Step FFC1. Construct a hash map of MeshBlocks before refinement
   for (int i = 0; i < nbtold; ++i) {


### PR DESCRIPTION
## Description

Fixes #719.

In `Mesh::PrepareAndSendFaceFieldCorrection` (`src/mesh/amr_loadbalance.cpp:1231`), the per-face buffer sizes `sffc1`, `sffc2`, `sffc3` are set to `nf*bnx2*bnx3`, `nf*bnx1*bnx3`, and `nf*bnx2*bnx3` respectively. The third one is wrong: x3-face buffers carry the XY-plane (`bnx1*bnx2`), not the YZ-plane (`bnx2*bnx3`).

The downstream pack call confirms it:

```cpp
case BoundaryFace::inner_x3:
  BufferUtility::PackData(var_fc.x3f, f.buf, pmb->is, pmb->ie,
                          pmb->js, pmb->je, pmb->ks, pmb->ks, p);
```

It writes `(ie-is+1) * (je-js+1) * 1 = bnx1 * bnx2` doubles per field, so the buffer must be `nf*bnx1*bnx2`. With the current expression, whenever `bnx1 != bnx3` the x3-face buffer is wrong-sized: either too small (out-of-bounds write/MPI send) or too large (silently sends garbage). As reported, this produces a segfault for meshes with unequal block dimensions.

## Changes

```diff
-  const int sffc1 = nf*bnx2*bnx3, sffc2 = nf*bnx1*bnx3, sffc3 = nf*bnx2*bnx3;
+  const int sffc1 = nf*bnx2*bnx3, sffc2 = nf*bnx1*bnx3, sffc3 = nf*bnx1*bnx2;
```

## Testing and validation

- `tst/regression/run_tests.py amr/amr_linwave` passes both before and after the change.
- Verified the diff manually against the matching pack/unpack call shapes in the same function for inner_x3 and outer_x3.

## To-do

- A dedicated regression test that exercises `PrepareAndSendFaceFieldCorrection` with `bnx1 != bnx3` (3D MHD AMR with non-cubic meshblocks) would catch this class of bug; happy to follow up if useful.
