### PR TITLE
Outputting 2D integrals over data fields.

### DIFF
--- a/src/coordinates/coordinates.cpp
+++ b/src/coordinates/coordinates.cpp
@@ -503,31 +503,22 @@ Real __attribute__((weak)) Coordinates::GetFace3Area(const int k, const int j,
 void __attribute__((weak)) Coordinates::VolCenterFace1Area(const int k, const int j,
                            const int il, const int iu, AthenaArray<Real> &area) {
 #pragma omp simd
-  for (int i=il; i<=iu; ++i) {
-    Real& area_i = area(i);
-    area_i = dx2v(j)*dx3v(k);
-  }
-  return;
+  for (int i = il; i <= iu; ++i)
+    area(i) = dx2v(j) * dx3v(k);
 }
 
 void __attribute__((weak)) Coordinates::VolCenterFace2Area(const int k, const int j,
                            const int il, const int iu, AthenaArray<Real> &area) {
 #pragma omp simd
-  for (int i=il; i<=iu; ++i) {
-    Real& area_i = area(i);
-    area_i = dx1v(i)*dx3v(k);
-  }
-  return;
+  for (int i = il; i <= iu; ++i)
+    area(i) = dx1v(i) * dx3v(k);
 }
 
 void __attribute__((weak)) Coordinates::VolCenterFace3Area(const int k, const int j,
                            const int il, const int iu, AthenaArray<Real> &area) {
 #pragma omp simd
-  for (int i=il; i<=iu; ++i) {
-    Real& area_i = area(i);
-    area_i = dx1v(i)*dx2v(j);
-  }
-  return;
+  for (int i = il; i <= iu; ++i)
+    area(i) = dx1v(i) * dx2v(j);
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -206,6 +206,7 @@ class MeshBlock {
 class Mesh {
   friend class RestartOutput;
   friend class HistoryOutput;
+  friend class IntX1X2Output;
   friend class MeshBlock;
   friend class MeshBlockTree;
   friend class BoundaryBase;

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -207,6 +207,8 @@ class Mesh {
   friend class RestartOutput;
   friend class HistoryOutput;
   friend class IntX1X2Output;
+  friend class IntX1X3Output;
+  friend class IntX2X3Output;
   friend class MeshBlock;
   friend class MeshBlockTree;
   friend class BoundaryBase;

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -24,6 +24,7 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             << "\n\tt = " << pm->time
             << "\n\tnext_time = " << output_params.next_time
             << "\n\tdt = " << output_params.dt << std::endl;
+  std::cout << "IntX1X2Output: fname = '" << fname << "'" << std::endl;
 
   // Update output parameters.
   output_params.next_time += output_params.dt;
@@ -35,6 +36,7 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 //      array in x2.
 
 void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
+  std::cout << "IntX1X3Output: fname = '" << fname << "'" << std::endl;
   std::stringstream msg;
   msg << "IntX1X3Output: not implemented " << std::endl;
   ATHENA_ERROR(msg);
@@ -46,6 +48,7 @@ void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 //      array in x1.
 
 void IntX2X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
+  std::cout << "IntX2X3Output: fname = '" << fname << "'" << std::endl;
   std::stringstream msg;
   msg << "IntX2X3Output: not implemented " << std::endl;
   ATHENA_ERROR(msg);

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -8,20 +8,47 @@
 
 // C/C++ headers
 #include <iostream>  // cout, endl, <<
-#include <sstream>  // stringstream
+#include <sstream>   // stringstream
+#include <string>    // string, to_string
+#include <vector>
 
 // Athena++ headers
-#include "../mesh/mesh.hpp"  // time
+#include "../mesh/mesh.hpp"  // time, my_blocks
 #include "outputs.hpp"
 
 //----------------------------------------------------------------------------------------
-//! \fn void Int2DOutput::ProcessHeader(const string& ext)
+//! \fn void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm)
 //! \brief writes a new or check the existing header of the output file.
 
-void Int2DOutput::ProcessHeader(const std::string& ext) {
+void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
   // Compose the name of the output file.
   fname = output_params.file_basename + '.' + ext;
-  std::cout << "Int2DOutput::ProcessHeader(): fname = '" << fname << "'" << std::endl;
+
+  // Collect the output variables.
+  LoadOutputData(pm->my_blocks(0));
+  std::vector<std::string> varnames;
+  OutputData *pdata = pfirst_data_;
+  while (pdata != nullptr) {
+    switch (pdata->type[0]) {
+      case 'S':  // SCALARS
+        varnames.push_back(pdata->name);
+        break;
+      case 'V':  // VECTORS
+        for (int i = 1; i <= 3; ++i)
+          varnames.push_back(pdata->name + std::to_string(i));
+        break;
+      default:
+        std::stringstream msg;
+        msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
+            << "Unknown output variable type: " << pdata->type << std::endl;
+        ATHENA_ERROR(msg);
+    }
+    pdata = pdata->pnext;
+  }
+  ClearOutputData();
+  for (int i = 0; i < varnames.size(); ++i)
+    std::cout << "::[Int2DOutput::ProcessHeader]:: varname = "
+              << varnames[i] << std::endl;
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -7,6 +7,7 @@
 //! \brief implements non-trivial functions of IntX[123]X[123]Output classes.
 
 // C/C++ headers
+#include <fstream>   // ifstream, ios, ofstream
 #include <iostream>  // cout, endl, <<
 #include <sstream>   // stringstream
 #include <string>    // string, to_string
@@ -26,6 +27,7 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
 
   // Collect the output variables.
   LoadOutputData(pm->my_blocks(0));
+  std::stringstream msg;
   std::vector<std::string> varnames;
   OutputData *pdata = pfirst_data_;
   while (pdata != nullptr) {
@@ -38,17 +40,44 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
           varnames.push_back(pdata->name + std::to_string(i));
         break;
       default:
-        std::stringstream msg;
         msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
             << "Unknown output variable type: " << pdata->type << std::endl;
         ATHENA_ERROR(msg);
+        return;
     }
     pdata = pdata->pnext;
   }
   ClearOutputData();
-  for (int i = 0; i < varnames.size(); ++i)
-    std::cout << "::[Int2DOutput::ProcessHeader]:: varname = "
-              << varnames[i] << std::endl;
+
+  // Process the header of the output file.
+  const int nvar = varnames.size();
+  std::ifstream fin(fname, std::ios::in | std::ios::binary);
+  if (fin.is_open()) {
+    // Read and check the number of output variables.
+    int n;
+    fin.read(reinterpret_cast<char*>(&n), sizeof(n));
+    if (n != nvar) {
+      msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
+          << "Inconsistent number of output variables: "
+          << nvar << " requested vs. " << n << " in existing header" << std::endl;
+      ATHENA_ERROR(msg);
+      return;
+    }
+    fin.close();
+  } else { // if (fin.is_open())
+    // Open a new output file for write.
+    std::ofstream fout(fname, std::ios::out | std::ios::binary);
+    if (!fout.is_open()) {
+      msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
+          << "Unable to create output file '" << fname << "'" << std::endl;
+      ATHENA_ERROR(msg);
+      return;
+    }
+
+    // Write the number of output variables.
+    fout.write(reinterpret_cast<const char*>(&nvar), sizeof(nvar));
+    fout.close();
+  } // if (fin.is_open())
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -7,6 +7,7 @@
 //! \brief implements non-trivial functions of IntX[123]X[123]Output classes.
 
 // C/C++ headers
+#include <sstream>  // endl, stringstream, <<
 
 // Athena++ headers
 #include "outputs.hpp"
@@ -17,6 +18,9 @@
 //      array in x3.
 
 void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
+  std::stringstream msg;
+  msg << "IntX1X2Output: not implemented " << std::endl;
+  ATHENA_ERROR(msg);
 }
 
 //----------------------------------------------------------------------------------------
@@ -25,6 +29,9 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 //      array in x2.
 
 void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
+  std::stringstream msg;
+  msg << "IntX1X3Output: not implemented " << std::endl;
+  ATHENA_ERROR(msg);
 }
 
 //----------------------------------------------------------------------------------------
@@ -33,4 +40,7 @@ void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 //      array in x1.
 
 void IntX2X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
+  std::stringstream msg;
+  msg << "IntX2X3Output: not implemented " << std::endl;
+  ATHENA_ERROR(msg);
 }

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -15,6 +15,16 @@
 #include "outputs.hpp"
 
 //----------------------------------------------------------------------------------------
+//! \fn void Int2DOutput::ProcessHeader(const string& ext)
+//! \brief writes a new or check the existing header of the output file.
+
+void Int2DOutput::ProcessHeader(const std::string& ext) {
+  // Compose the name of the output file.
+  fname = output_params.file_basename + '.' + ext;
+  std::cout << "Int2DOutput::ProcessHeader(): fname = '" << fname << "'" << std::endl;
+}
+
+//----------------------------------------------------------------------------------------
 //! \fn void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
 //! \brief integrates the data over x1 and x2 directions and writes the resulting 1D
 //      array in x3.
@@ -24,7 +34,6 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             << "\n\tt = " << pm->time
             << "\n\tnext_time = " << output_params.next_time
             << "\n\tdt = " << output_params.dt << std::endl;
-  std::cout << "IntX1X2Output: fname = '" << fname << "'" << std::endl;
 
   // Update output parameters.
   output_params.next_time += output_params.dt;
@@ -36,7 +45,6 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 //      array in x2.
 
 void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
-  std::cout << "IntX1X3Output: fname = '" << fname << "'" << std::endl;
   std::stringstream msg;
   msg << "IntX1X3Output: not implemented " << std::endl;
   ATHENA_ERROR(msg);
@@ -48,7 +56,6 @@ void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 //      array in x1.
 
 void IntX2X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
-  std::cout << "IntX2X3Output: fname = '" << fname << "'" << std::endl;
   std::stringstream msg;
   msg << "IntX2X3Output: not implemented " << std::endl;
   ATHENA_ERROR(msg);

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -1,0 +1,36 @@
+//========================================================================================
+// Athena++ astrophysical MHD code
+// Copyright(C) 2026 James M. Stone <jmstone@princeton.edu> and other code contributors
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//! \file int2d.cpp
+//! \brief implements non-trivial functions of IntX[123]X[123]Output classes.
+
+// C/C++ headers
+
+// Athena++ headers
+#include "outputs.hpp"
+
+//----------------------------------------------------------------------------------------
+//! \fn void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
+//! \brief integrates the data over x1 and x2 directions and writes the resulting 1D
+//      array in x3.
+
+void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
+//! \brief integrates the data over x1 and x3 directions and writes the resulting 1D
+//      array in x2.
+
+void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void IntX2X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
+//! \brief integrates the data over x2 and x3 directions and writes the resulting 1D
+//      array in x1.
+
+void IntX2X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
+}

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -7,9 +7,11 @@
 //! \brief implements non-trivial functions of IntX[123]X[123]Output classes.
 
 // C/C++ headers
-#include <sstream>  // endl, stringstream, <<
+#include <iostream>  // cout, endl, <<
+#include <sstream>  // stringstream
 
 // Athena++ headers
+#include "../mesh/mesh.hpp"  // time
 #include "outputs.hpp"
 
 //----------------------------------------------------------------------------------------
@@ -18,9 +20,13 @@
 //      array in x3.
 
 void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
-  std::stringstream msg;
-  msg << "IntX1X2Output: not implemented " << std::endl;
-  ATHENA_ERROR(msg);
+  std::cout << "IntX1X2Output: under construction; "
+            << "\n\tt = " << pm->time
+            << "\n\tnext_time = " << output_params.next_time
+            << "\n\tdt = " << output_params.dt << std::endl;
+
+  // Update output parameters.
+  output_params.next_time += output_params.dt;
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -180,11 +180,6 @@ void IntX1X2Output::SetThirdDim(const Mesh *pm) {
 // TODO(ccyang): consider the case of mesh refinement.
 
 void IntX1X3Output::SetThirdDim(const Mesh *pm) {
-  std::stringstream msg;
-  msg << "IntX1X3Output: not implemented " << std::endl;
-  ATHENA_ERROR(msg);
-  return;
-
   const bool uniform = pm->use_uniform_meshgen_fn_[X2DIR];
   xf.clear();
   nx = pm->mesh_size.nx2;
@@ -200,11 +195,6 @@ void IntX1X3Output::SetThirdDim(const Mesh *pm) {
 // TODO(ccyang): consider the case of mesh refinement.
 
 void IntX2X3Output::SetThirdDim(const Mesh *pm) {
-  std::stringstream msg;
-  msg << "IntX2X3Output: not implemented " << std::endl;
-  ATHENA_ERROR(msg);
-  return;
-
   const bool uniform = pm->use_uniform_meshgen_fn_[X1DIR];
   xf.clear();
   nx = pm->mesh_size.nx1;
@@ -242,6 +232,7 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   for (int b = 0; b < pm->nblocal; ++b) {
     MeshBlock *pmb = pm->my_blocks(b);
     LoadOutputData(pmb);
+    AddToIntegrals(pmb, integral);
 
     // Determine where the meshblock fits.
     const int offset = pmb->loc.lx3 * pmb->block_size.nx3 - pmb->ks;
@@ -279,4 +270,37 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 
   // Update output parameters.
   output_params.next_time += output_params.dt;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void IntX1X2Output::AddToIntegrals(
+//!     const MeshBlock *pmb, AthenaArray<Real> &integrals)
+//! \brief processes loaded output data in one meshblock and adds the sums to the
+//!     integrals.
+
+void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) {
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void IntX1X3Output::AddToIntegrals(
+//!     const MeshBlock *pmb, AthenaArray<Real> &integrals)
+//! \brief processes loaded output data in one meshblock and adds the sums to the
+//!     integrals.
+
+void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) {
+  std::stringstream msg;
+  msg << "IntX1X3Output: not implemented " << std::endl;
+  ATHENA_ERROR(msg);
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void IntX2X3Output::AddToIntegrals(
+//!     const MeshBlock *pmb, AthenaArray<Real> &integrals)
+//! \brief processes loaded output data in one meshblock and adds the sums to the
+//!     integrals.
+
+void IntX2X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) {
+  std::stringstream msg;
+  msg << "IntX2X3Output: not implemented " << std::endl;
+  ATHENA_ERROR(msg);
 }

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -279,7 +279,8 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals,
     AthenaArray<Real> &area) {
   // Determine where the meshblock fits.
-  const int offset = pmb->loc.lx3 * pmb->block_size.nx3 - pmb->ks;
+  const int nfine = 1 << (pmb->pmy_mesh->max_level - pmb->loc.level);
+  const int offset = pmb->loc.lx3 * pmb->block_size.nx3 * nfine;
 
   // Integrate each data field.
   int ii = 0;
@@ -294,7 +295,9 @@ void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
           for (int i = pmb->is; i <= pmb->ie; ++i)
             sum += pdata->data(c,k,j,i) * area(i);
         }
-        integrals(ii, k + offset) += sum;
+        const int ns = offset + (k - pmb->ks) * nfine;
+        for (int n = ns; n < ns + nfine; ++n)
+          integrals(ii, n) += sum;
       }
       ++ii;
     }
@@ -311,7 +314,8 @@ void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
 void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals,
     AthenaArray<Real> &area) {
   // Determine where the meshblock fits.
-  const int offset = pmb->loc.lx2 * pmb->block_size.nx2 - pmb->js;
+  const int nfine = 1 << (pmb->pmy_mesh->max_level - pmb->loc.level);
+  const int offset = pmb->loc.lx2 * pmb->block_size.nx2 * nfine;
 
   // Integrate each data field.
   int ii = 0;
@@ -326,7 +330,9 @@ void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
           for (int i = pmb->is; i <= pmb->ie; ++i)
             sum += pdata->data(c,k,j,i) * area(i);
         }
-        integrals(ii, j + offset) += sum;
+        const int ns = offset + (j - pmb->js) * nfine;
+        for (int n = ns; n < ns + nfine; ++n)
+          integrals(ii, n) += sum;
       }
       ++ii;
     }
@@ -343,7 +349,8 @@ void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
 void IntX2X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals,
     AthenaArray<Real> &area) {
   // Determine where the meshblock fits.
-  const int offset = pmb->loc.lx1 * pmb->block_size.nx1 - pmb->is;
+  const int nfine = 1 << (pmb->pmy_mesh->max_level - pmb->loc.level);
+  const int offset = pmb->loc.lx1 * pmb->block_size.nx1 * nfine;
 
   // Integrate each data field.
   int ii = 0;
@@ -359,7 +366,9 @@ void IntX2X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
             sum += pdata->data(c,k,j,i) * area(i);
           }
         }
-        integrals(ii, i + offset) += sum;
+        const int ns = offset + (i - pmb->is) * nfine;
+        for (int n = ns; n < ns + nfine; ++n)
+          integrals(ii, n) += sum;
       }
       ++ii;
     }

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -109,6 +109,13 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
 }
 
 //----------------------------------------------------------------------------------------
+//! \fn void IntX1X2Output::SetThirdDim(const Mesh *pm)
+//! \brief constructs the coordinates in the X3 dimension.
+
+void IntX1X2Output::SetThirdDim(const Mesh *pm) {
+}
+
+//----------------------------------------------------------------------------------------
 //! \fn void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
 //! \brief integrates the data over x1 and x2 directions and writes the resulting 1D
 //      array in x3.

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -320,7 +320,27 @@ void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
 
 void IntX2X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals,
     AthenaArray<Real> &area) {
-  std::stringstream msg;
-  msg << "IntX2X3Output: not implemented " << std::endl;
-  ATHENA_ERROR(msg);
+  // Determine where the meshblock fits.
+  const int offset = pmb->loc.lx1 * pmb->block_size.nx1 - pmb->is;
+
+  // Integrate each data field.
+  int ii = 0;
+  OutputData *pdata = pfirst_data_;
+  while (pdata != nullptr) {
+    const int nc = (pdata->type == "VECTORS") ? 3 : 1;
+    for (int c = 0; c < nc; ++c) {
+      for (int i = pmb->is; i <= pmb->ie; ++i) {
+        Real sum = 0;
+        for (int k = pmb->ks; k <= pmb->ke; ++k) {
+          for (int j = pmb->js; j <= pmb->je; ++j) {
+            pmb->pcoord->VolCenterFace1Area(k, j, i, i, area);
+            sum += pdata->data(c,k,j,i) * area(i);
+          }
+        }
+        integrals(ii, i + offset) += sum;
+      }
+      ++ii;
+    }
+    pdata = pdata->pnext;
+  }
 }

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -56,8 +56,11 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
   const int nvar = varnames.size();
   std::ifstream fin(fname, std::ios::in | std::ios::binary);
   if (fin.is_open()) {
-    // Read and check the number of output variables.
+    // Skip the first int (size of Real).
     int n;
+    fin.read(reinterpret_cast<char*>(&n), sizeof(n));
+
+    // Read and check the number of output variables.
     fin.read(reinterpret_cast<char*>(&n), sizeof(n));
     if (n != nvar) {
       msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
@@ -102,6 +105,10 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
       ATHENA_ERROR(msg);
       return;
     }
+
+    // Write the size of the Athena++ Real.
+    const int size = sizeof(Real);
+    fout.write(reinterpret_cast<const char*>(&size), sizeof(size));
 
     // Write the number of output variables.
     fout.write(reinterpret_cast<const char*>(&nvar), sizeof(nvar));

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -18,6 +18,11 @@
 #include "../mesh/mesh.hpp"  // time, my_blocks
 #include "outputs.hpp"
 
+// MPI headers
+#ifdef MPI_PARALLEL
+#include <mpi.h>
+#endif
+
 //----------------------------------------------------------------------------------------
 //! \fn void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm)
 //! \brief writes a new or check the existing header of the output file.
@@ -241,6 +246,14 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
     AddToIntegrals(pmb, integrals, area);
     ClearOutputData();
   }
+#ifdef MPI_PARALLEL
+  const int count = integrals.GetSize();
+  void *buf = reinterpret_cast<void*>(&integrals(0,0));
+  if (is_root)
+    MPI_Reduce(MPI_IN_PLACE, buf, count, MPI_ATHENA_REAL, MPI_SUM, ROOT, MPI_COMM_WORLD);
+  else
+    MPI_Reduce(buf, buf, count, MPI_ATHENA_REAL, MPI_SUM, ROOT, MPI_COMM_WORLD);
+#endif
 
   if (is_root) {
     // Write the integrals and close the output file.

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -23,6 +23,9 @@
 //! \brief writes a new or check the existing header of the output file.
 
 void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
+  // Construct the coordinates of the third dimension.
+  SetThirdDim(pm);
+
   // Compose the name of the output file.
   fname = output_params.file_basename + '.' + ext;
 
@@ -59,9 +62,7 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
     ATHENA_ERROR(msg);
     return;
   }
-
-  // Construct the coordinates of the third dimension.
-  SetThirdDim(pm);
+  if (Globals::my_rank != 0) return;
 
   // Process the header of the output file.
   const int rsize = sizeof(Real);
@@ -210,18 +211,23 @@ void IntX2X3Output::SetThirdDim(const Mesh *pm) {
 //!     the third.
 
 void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
-  // Open the output file for write.
-  std::ofstream fout(fname, std::ios::out | std::ios::app | std::ios::binary);
-  if (!fout.is_open()) {
-    std::stringstream msg;
-    msg << "### FATAL ERROR in IntX1X2Output::ProcessHeader" << std::endl
-        << "Unable to open output file '" << fname << "'" << std::endl;
-    ATHENA_ERROR(msg);
-    return;
-  }
+  const int ROOT = 0;
+  const bool is_root = (Globals::my_rank == ROOT);
+  std::ofstream fout;
+  if (is_root) {
+    // Open the output file for write.
+    fout.open(fname, std::ios::out | std::ios::app | std::ios::binary);
+    if (!fout.is_open()) {
+      std::stringstream msg;
+      msg << "### FATAL ERROR in IntX1X2Output::ProcessHeader" << std::endl
+          << "Unable to open output file '" << fname << "'" << std::endl;
+      ATHENA_ERROR(msg);
+      return;
+    }
 
-  // Write the current time.
-  fout.write(reinterpret_cast<const char*>(&pm->time), sizeof(pm->time));
+    // Write the current time.
+    fout.write(reinterpret_cast<const char*>(&pm->time), sizeof(pm->time));
+  } // if (is_root)
 
   // Allocate arrays for 2D integrals.
   AthenaArray<Real> area(pm->my_blocks(0)->ncells1);
@@ -236,11 +242,14 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
     ClearOutputData();
   }
 
-  // Write the integrals.
-  fout.write(reinterpret_cast<const char*>(integrals.data()), integrals.GetSizeInBytes());
+  if (is_root) {
+    // Write the integrals and close the output file.
+    fout.write(reinterpret_cast<const char*>(integrals.data()),
+               integrals.GetSizeInBytes());
+    fout.close();
+  }
 
-  // Close and clean up.
-  fout.close();
+  // Clean up.
   integrals.DeleteAthenaArray();
   area.DeleteAthenaArray();
 

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -111,6 +111,7 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
 //----------------------------------------------------------------------------------------
 //! \fn void IntX1X2Output::SetThirdDim(const Mesh *pm)
 //! \brief constructs the coordinates in the X3 dimension.
+// TODO(ccyang): consider the case of mesh refinement.
 
 void IntX1X2Output::SetThirdDim(const Mesh *pm) {
   const bool uniform = pm->use_uniform_meshgen_fn_[X3DIR];
@@ -119,6 +120,36 @@ void IntX1X2Output::SetThirdDim(const Mesh *pm) {
   for (int i = 0; i <= nx; ++i) {
     const Real rx = ComputeMeshGeneratorX(i, nx, uniform);
     xf.push_back(pm->MeshGenerator_[X3DIR](rx, pm->mesh_size));
+  }
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void IntX1X3Output::SetThirdDim(const Mesh *pm)
+//! \brief constructs the coordinates in the X2 dimension.
+// TODO(ccyang): consider the case of mesh refinement.
+
+void IntX1X3Output::SetThirdDim(const Mesh *pm) {
+  const bool uniform = pm->use_uniform_meshgen_fn_[X2DIR];
+  xf.clear();
+  nx = pm->mesh_size.nx2;
+  for (int i = 0; i <= nx; ++i) {
+    const Real rx = ComputeMeshGeneratorX(i, nx, uniform);
+    xf.push_back(pm->MeshGenerator_[X2DIR](rx, pm->mesh_size));
+  }
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void IntX2X3Output::SetThirdDim(const Mesh *pm)
+//! \brief constructs the coordinates in the X1 dimension.
+// TODO(ccyang): consider the case of mesh refinement.
+
+void IntX2X3Output::SetThirdDim(const Mesh *pm) {
+  const bool uniform = pm->use_uniform_meshgen_fn_[X1DIR];
+  xf.clear();
+  nx = pm->mesh_size.nx1;
+  for (int i = 0; i <= nx; ++i) {
+    const Real rx = ComputeMeshGeneratorX(i, nx, uniform);
+    xf.push_back(pm->MeshGenerator_[X1DIR](rx, pm->mesh_size));
   }
 }
 

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -49,6 +49,9 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
   }
   ClearOutputData();
 
+  // Construct the coordinates of the third dimension.
+  SetThirdDim();
+
   // Process the header of the output file.
   const int nvar = varnames.size();
   std::ifstream fin(fname, std::ios::in | std::ios::binary);

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -54,11 +54,20 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
 
   // Process the header of the output file.
   const int nvar = varnames.size();
+  const int rsize = sizeof(Real);
   std::ifstream fin(fname, std::ios::in | std::ios::binary);
   if (fin.is_open()) {
-    // Skip the first int (size of Real).
+    // Check the Real size.
     int n;
     fin.read(reinterpret_cast<char*>(&n), sizeof(n));
+    if (n != rsize) {
+      msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
+          << "Inconsistent Athena++ Real size: "
+          << rsize << " bytes compied vs. " << n << " bytes in existing header"
+          << std::endl;
+      ATHENA_ERROR(msg);
+      return;
+    }
 
     // Read and check the number of output variables.
     fin.read(reinterpret_cast<char*>(&n), sizeof(n));
@@ -107,8 +116,7 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
     }
 
     // Write the size of the Athena++ Real.
-    const int size = sizeof(Real);
-    fout.write(reinterpret_cast<const char*>(&size), sizeof(size));
+    fout.write(reinterpret_cast<const char*>(&rsize), sizeof(rsize));
 
     // Write the number of output variables.
     fout.write(reinterpret_cast<const char*>(&nvar), sizeof(nvar));

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -49,11 +49,20 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
   }
   ClearOutputData();
 
+  // Confirm the count of output variables with the parent class.
+  const int nvar = varnames.size();
+  if (nvar != num_vars_) {
+    msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
+        << "Inconsistent num_vars_ = " << num_vars_ << " vs. nvar = " << nvar
+        << std::endl;
+    ATHENA_ERROR(msg);
+    return;
+  }
+
   // Construct the coordinates of the third dimension.
   SetThirdDim(pm);
 
   // Process the header of the output file.
-  const int nvar = varnames.size();
   const int rsize = sizeof(Real);
   std::ifstream fin(fname, std::ios::in | std::ios::binary);
   if (fin.is_open()) {

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -188,6 +188,21 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
             << "\n\tnext_time = " << output_params.next_time
             << "\n\tdt = " << output_params.dt << std::endl;
 
+  // Open the output file for write.
+  std::ofstream fout(fname, std::ios::out | std::ios::app | std::ios::binary);
+  if (!fout.is_open()) {
+    std::stringstream msg;
+    msg << "### FATAL ERROR in IntX1X2Output::ProcessHeader" << std::endl
+        << "Unable to open output file '" << fname << "'" << std::endl;
+    ATHENA_ERROR(msg);
+    return;
+  }
+
+  // Write the current time.
+  fout.write(reinterpret_cast<const char*>(&pm->time), sizeof(pm->time));
+
+  fout.close();
+
   // Update output parameters.
   output_params.next_time += output_params.dt;
 }

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -173,7 +173,7 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
 void IntX1X2Output::SetThirdDim(const Mesh *pm) {
   const bool uniform = pm->use_uniform_meshgen_fn_[X3DIR];
   xf.clear();
-  nx = pm->mesh_size.nx3;
+  nx = pm->mesh_size.nx3 << (pm->max_level - pm->root_level);
   for (int i = 0; i <= nx; ++i) {
     const Real rx = ComputeMeshGeneratorX(i, nx, uniform);
     xf.push_back(pm->MeshGenerator_[X3DIR](rx, pm->mesh_size));
@@ -188,7 +188,7 @@ void IntX1X2Output::SetThirdDim(const Mesh *pm) {
 void IntX1X3Output::SetThirdDim(const Mesh *pm) {
   const bool uniform = pm->use_uniform_meshgen_fn_[X2DIR];
   xf.clear();
-  nx = pm->mesh_size.nx2;
+  nx = pm->mesh_size.nx2 << (pm->max_level - pm->root_level);
   for (int i = 0; i <= nx; ++i) {
     const Real rx = ComputeMeshGeneratorX(i, nx, uniform);
     xf.push_back(pm->MeshGenerator_[X2DIR](rx, pm->mesh_size));
@@ -203,7 +203,7 @@ void IntX1X3Output::SetThirdDim(const Mesh *pm) {
 void IntX2X3Output::SetThirdDim(const Mesh *pm) {
   const bool uniform = pm->use_uniform_meshgen_fn_[X1DIR];
   xf.clear();
-  nx = pm->mesh_size.nx1;
+  nx = pm->mesh_size.nx1 << (pm->max_level - pm->root_level);
   for (int i = 0; i <= nx; ++i) {
     const Real rx = ComputeMeshGeneratorX(i, nx, uniform);
     xf.push_back(pm->MeshGenerator_[X1DIR](rx, pm->mesh_size));

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -57,6 +57,15 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
   const int rsize = sizeof(Real);
   std::ifstream fin(fname, std::ios::in | std::ios::binary);
   if (fin.is_open()) {
+    // Stop if the run is a fresh start.
+    // TODO(ccyang): implement truncation of the output file for restart.
+    if (pm->time == pm->start_time) {
+      msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
+          << "The output file '" << fname << "' already exists. " << std::endl;
+      ATHENA_ERROR(msg);
+      return;
+    }
+
     // Check the Real size.
     int n;
     fin.read(reinterpret_cast<char*>(&n), sizeof(n));

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -113,6 +113,13 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
 //! \brief constructs the coordinates in the X3 dimension.
 
 void IntX1X2Output::SetThirdDim(const Mesh *pm) {
+  const bool uniform = pm->use_uniform_meshgen_fn_[X3DIR];
+  xf.clear();
+  nx = pm->mesh_size.nx3;
+  for (int i = 0; i <= nx; ++i) {
+    const Real rx = ComputeMeshGeneratorX(i, nx, uniform);
+    xf.push_back(pm->MeshGenerator_[X3DIR](rx, pm->mesh_size));
+  }
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -288,9 +288,28 @@ void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
 
 void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals,
     AthenaArray<Real> &area) {
-  std::stringstream msg;
-  msg << "IntX1X3Output: not implemented " << std::endl;
-  ATHENA_ERROR(msg);
+  // Determine where the meshblock fits.
+  const int offset = pmb->loc.lx2 * pmb->block_size.nx2 - pmb->js;
+
+  // Integrate each data field.
+  int ii = 0;
+  OutputData *pdata = pfirst_data_;
+  while (pdata != nullptr) {
+    const int nc = (pdata->type == "VECTORS") ? 3 : 1;
+    for (int c = 0; c < nc; ++c) {
+      for (int j = pmb->js; j <= pmb->je; ++j) {
+        Real sum = 0;
+        for (int k = pmb->ks; k <= pmb->ke; ++k) {
+          pmb->pcoord->VolCenterFace2Area(k, j, pmb->is, pmb->ie, area);
+          for (int i = pmb->is; i <= pmb->ie; ++i)
+            sum += pdata->data(c,k,j,i) * area(i);
+        }
+        integrals(ii, j + offset) += sum;
+      }
+      ++ii;
+    }
+    pdata = pdata->pnext;
+  }
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -224,49 +224,23 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   fout.write(reinterpret_cast<const char*>(&pm->time), sizeof(pm->time));
 
   // Allocate arrays for 2D integrals.
-  AthenaArray<Real> area(pm->my_blocks(0)->ncells3);
-  AthenaArray<Real> integral(num_vars_, nx);
-  integral.ZeroClear();
+  AthenaArray<Real> integrals(num_vars_, nx);
+  integrals.ZeroClear();
 
-  // Loop over meshblocks.
+  // Conduct the integrals.
   for (int b = 0; b < pm->nblocal; ++b) {
     MeshBlock *pmb = pm->my_blocks(b);
     LoadOutputData(pmb);
-    AddToIntegrals(pmb, integral);
-
-    // Determine where the meshblock fits.
-    const int offset = pmb->loc.lx3 * pmb->block_size.nx3 - pmb->ks;
-
-    // Integrate each data field.
-    int ii = 0;
-    OutputData *pdata = pfirst_data_;
-    while (pdata != nullptr) {
-      const int nc = (pdata->type == "VECTORS") ? 3 : 1;
-      for (int c = 0; c < nc; ++c) {
-        for (int k = pmb->ks; k <= pmb->ke; ++k) {
-          Real sum = 0;
-          for (int j = pmb->js; j <= pmb->je; ++j) {
-            pmb->pcoord->VolCenterFace3Area(k, j, pmb->is, pmb->ie, area);
-            for (int i = pmb->is; i <= pmb->ie; ++i)
-              sum += pdata->data(c,k,j,i) * area(i);
-          }
-          integral(ii, k + offset) += sum;
-        }
-        ++ii;
-      }
-      pdata = pdata->pnext;
-    }
-
+    AddToIntegrals(pmb, integrals);
     ClearOutputData();
   }
 
   // Write the integrals.
-  fout.write(reinterpret_cast<const char*>(integral.data()), integral.GetSizeInBytes());
+  fout.write(reinterpret_cast<const char*>(integrals.data()), integrals.GetSizeInBytes());
 
   // Close and clean up.
   fout.close();
-  integral.DeleteAthenaArray();
-  area.DeleteAthenaArray();
+  integrals.DeleteAthenaArray();
 
   // Update output parameters.
   output_params.next_time += output_params.dt;
@@ -279,6 +253,32 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 //!     integrals.
 
 void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) {
+  // Determine where the meshblock fits.
+  const int offset = pmb->loc.lx3 * pmb->block_size.nx3 - pmb->ks;
+
+  // Integrate each data field.
+  int ii = 0;
+  AthenaArray<Real> area(pmb->ncells1);
+  OutputData *pdata = pfirst_data_;
+  while (pdata != nullptr) {
+    const int nc = (pdata->type == "VECTORS") ? 3 : 1;
+    for (int c = 0; c < nc; ++c) {
+      for (int k = pmb->ks; k <= pmb->ke; ++k) {
+        Real sum = 0;
+        for (int j = pmb->js; j <= pmb->je; ++j) {
+          pmb->pcoord->VolCenterFace3Area(k, j, pmb->is, pmb->ie, area);
+          for (int i = pmb->is; i <= pmb->ie; ++i)
+            sum += pdata->data(c,k,j,i) * area(i);
+        }
+        integrals(ii, k + offset) += sum;
+      }
+      ++ii;
+    }
+    pdata = pdata->pnext;
+  }
+
+  // Clean up.
+  area.DeleteAthenaArray();
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -209,10 +209,7 @@ void IntX2X3Output::SetThirdDim(const Mesh *pm) {
 //      array in x3.
 
 void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
-  std::cout << "IntX1X2Output: under construction; "
-            << "\n\tt = " << pm->time
-            << "\n\tnext_time = " << output_params.next_time
-            << "\n\tdt = " << output_params.dt << std::endl;
+  std::cout << "IntX1X2Output: under construction" << std::endl;
 
   // Open the output file for write.
   std::ofstream fout(fname, std::ios::out | std::ios::app | std::ios::binary);
@@ -244,6 +241,9 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 
     ClearOutputData();
   }
+
+  // Write the integrals.
+  fout.write(reinterpret_cast<const char*>(integral.data()), integral.GetSizeInBytes());
 
   // Close and clean up.
   fout.close();

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -59,7 +59,7 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
   ClearOutputData();
 
   // Confirm the count of output variables with the parent class.
-  const int nvar = varnames.size();
+  const int nvar = static_cast<int>(varnames.size());
   if (nvar != num_vars_) {
     msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
         << "Inconsistent num_vars_ = " << num_vars_ << " vs. nvar = " << nvar
@@ -149,7 +149,7 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
     // Write the names of the variables.
     for (std::vector<std::string>::iterator it = varnames.begin();
         it != varnames.end(); ++it) {
-      const int size = it->size();
+      const int size = static_cast<int>(it->size());
       fout.write(reinterpret_cast<const char*>(&size), sizeof(size));
       if (size > 0) fout.write(it->data(), size);
     }
@@ -280,7 +280,7 @@ void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
     AthenaArray<Real> &area) {
   // Determine where the meshblock fits.
   const int nfine = 1 << (pmb->pmy_mesh->max_level - pmb->loc.level);
-  const int offset = pmb->loc.lx3 * pmb->block_size.nx3 * nfine;
+  const int offset = static_cast<int>(pmb->loc.lx3) * pmb->block_size.nx3 * nfine;
 
   // Integrate each data field.
   int ii = 0;
@@ -315,7 +315,7 @@ void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
     AthenaArray<Real> &area) {
   // Determine where the meshblock fits.
   const int nfine = 1 << (pmb->pmy_mesh->max_level - pmb->loc.level);
-  const int offset = pmb->loc.lx2 * pmb->block_size.nx2 * nfine;
+  const int offset = static_cast<int>(pmb->loc.lx2) * pmb->block_size.nx2 * nfine;
 
   // Integrate each data field.
   int ii = 0;
@@ -350,7 +350,7 @@ void IntX2X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
     AthenaArray<Real> &area) {
   // Determine where the meshblock fits.
   const int nfine = 1 << (pmb->pmy_mesh->max_level - pmb->loc.level);
-  const int offset = pmb->loc.lx1 * pmb->block_size.nx1 * nfine;
+  const int offset = static_cast<int>(pmb->loc.lx1) * pmb->block_size.nx1 * nfine;
 
   // Integrate each data field.
   int ii = 0;

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -50,7 +50,7 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
   ClearOutputData();
 
   // Construct the coordinates of the third dimension.
-  SetThirdDim();
+  SetThirdDim(pm);
 
   // Process the header of the output file.
   const int nvar = varnames.size();

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -82,6 +82,16 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
       }
     }
 
+    // Read and check the number of cells in the third dimension.
+    fin.read(reinterpret_cast<char*>(&n), sizeof(n));
+    if (n != nx) {
+      msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
+          << "Inconsistent number of cells in the third dimension: "
+          << nx << " requested vs. " << n << " in existing header" << std::endl;
+      ATHENA_ERROR(msg);
+      return;
+    }
+
     fin.close();
   } else { // if (fin.is_open())
     // Open a new output file for write.
@@ -102,6 +112,13 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
       const int size = it->size();
       fout.write(reinterpret_cast<const char*>(&size), sizeof(size));
       if (size > 0) fout.write(it->data(), size);
+    }
+
+    // Write the coordinates in the third dimension.
+    fout.write(reinterpret_cast<const char*>(&nx), sizeof(nx));
+    for (std::vector<Real>::iterator it = xf.begin(); it != xf.end(); ++it) {
+      const Real x = *it;
+      fout.write(reinterpret_cast<const char*>(&x), sizeof(x));
     }
 
     fout.close();

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -63,6 +63,22 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
       ATHENA_ERROR(msg);
       return;
     }
+
+    // Read and check the names of the variables.
+    for (int i = 0; i < nvar; ++i) {
+      fin.read(reinterpret_cast<char*>(&n), sizeof(n));
+      std::string name(n, '*');
+      fin.read(&name[0], n);
+      if (name != varnames[i]) {
+        msg << "### FATAL ERROR in Int2DOutput::ProcessHeader" << std::endl
+            << "Inconsistent name of output variable " << (i + 1) << std::endl
+            << "'" << varnames[i] << "' requested vs. '" << name << "' in existing header"
+            << std::endl;
+        ATHENA_ERROR(msg);
+        return;
+      }
+    }
+
     fin.close();
   } else { // if (fin.is_open())
     // Open a new output file for write.
@@ -76,6 +92,15 @@ void Int2DOutput::ProcessHeader(const std::string& ext, const Mesh *pm) {
 
     // Write the number of output variables.
     fout.write(reinterpret_cast<const char*>(&nvar), sizeof(nvar));
+
+    // Write the names of the variables.
+    for (std::vector<std::string>::iterator it = varnames.begin();
+        it != varnames.end(); ++it) {
+      const int size = it->size();
+      fout.write(reinterpret_cast<const char*>(&size), sizeof(size));
+      if (size > 0) fout.write(it->data(), size);
+    }
+
     fout.close();
   } // if (fin.is_open())
 }

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -227,7 +227,27 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   // Write the current time.
   fout.write(reinterpret_cast<const char*>(&pm->time), sizeof(pm->time));
 
+  // Allocate arrays for 2D integrals.
+  AthenaArray<Real> integral(num_vars_, nx);
+  integral.ZeroClear();
+
+  // Loop over meshblocks.
+  for (int i = 0; i < pm->nblocal; ++i) {
+    MeshBlock *pmb = pm->my_blocks(i);
+    LoadOutputData(pmb);
+
+    // Loop over data in each meshblock.
+    OutputData *pdata = pfirst_data_;
+    while (pdata != nullptr) {
+      pdata = pdata->pnext;
+    }
+
+    ClearOutputData();
+  }
+
+  // Close and clean up.
   fout.close();
+  integral.DeleteAthenaArray();
 
   // Update output parameters.
   output_params.next_time += output_params.dt;

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 // Athena++ headers
+#include "../coordinates/coordinates.hpp"  // VolCenterFace3Area
 #include "../mesh/mesh.hpp"  // time, my_blocks
 #include "outputs.hpp"
 
@@ -225,17 +226,35 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   fout.write(reinterpret_cast<const char*>(&pm->time), sizeof(pm->time));
 
   // Allocate arrays for 2D integrals.
+  AthenaArray<Real> area(pm->my_blocks(0)->ncells3);
   AthenaArray<Real> integral(num_vars_, nx);
   integral.ZeroClear();
 
   // Loop over meshblocks.
-  for (int i = 0; i < pm->nblocal; ++i) {
-    MeshBlock *pmb = pm->my_blocks(i);
+  for (int b = 0; b < pm->nblocal; ++b) {
+    MeshBlock *pmb = pm->my_blocks(b);
     LoadOutputData(pmb);
 
-    // Loop over data in each meshblock.
+    // Determine where the meshblock fits.
+    const int offset = pmb->loc.lx3 * pmb->block_size.nx3 - pmb->ks;
+
+    // Integrate each data field.
+    int ii = 0;
     OutputData *pdata = pfirst_data_;
     while (pdata != nullptr) {
+      const int nc = (pdata->type == "VECTORS") ? 3 : 1;
+      for (int c = 0; c < nc; ++c) {
+        for (int k = pmb->ks; k <= pmb->ke; ++k) {
+          Real sum = 0;
+          for (int j = pmb->js; j <= pmb->je; ++j) {
+            pmb->pcoord->VolCenterFace3Area(k, j, pmb->is, pmb->ie, area);
+            for (int i = pmb->is; i <= pmb->ie; ++i)
+              sum += pdata->data(c,k,j,i) * area(i);
+          }
+          integral(ii, k + offset) += sum;
+        }
+        ++ii;
+      }
       pdata = pdata->pnext;
     }
 
@@ -248,6 +267,7 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   // Close and clean up.
   fout.close();
   integral.DeleteAthenaArray();
+  area.DeleteAthenaArray();
 
   // Update output parameters.
   output_params.next_time += output_params.dt;

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -180,6 +180,11 @@ void IntX1X2Output::SetThirdDim(const Mesh *pm) {
 // TODO(ccyang): consider the case of mesh refinement.
 
 void IntX1X3Output::SetThirdDim(const Mesh *pm) {
+  std::stringstream msg;
+  msg << "IntX1X3Output: not implemented " << std::endl;
+  ATHENA_ERROR(msg);
+  return;
+
   const bool uniform = pm->use_uniform_meshgen_fn_[X2DIR];
   xf.clear();
   nx = pm->mesh_size.nx2;
@@ -195,6 +200,11 @@ void IntX1X3Output::SetThirdDim(const Mesh *pm) {
 // TODO(ccyang): consider the case of mesh refinement.
 
 void IntX2X3Output::SetThirdDim(const Mesh *pm) {
+  std::stringstream msg;
+  msg << "IntX2X3Output: not implemented " << std::endl;
+  ATHENA_ERROR(msg);
+  return;
+
   const bool uniform = pm->use_uniform_meshgen_fn_[X1DIR];
   xf.clear();
   nx = pm->mesh_size.nx1;
@@ -205,13 +215,11 @@ void IntX2X3Output::SetThirdDim(const Mesh *pm) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
-//! \brief integrates the data over x1 and x2 directions and writes the resulting 1D
-//      array in x3.
+//! \fn void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
+//! \brief integrates the data over two dimensions and writes the resulting 1D array in
+//!     the third.
 
-void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
-  std::cout << "IntX1X2Output: under construction" << std::endl;
-
+void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   // Open the output file for write.
   std::ofstream fout(fname, std::ios::out | std::ios::app | std::ios::binary);
   if (!fout.is_open()) {
@@ -271,26 +279,4 @@ void IntX1X2Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 
   // Update output parameters.
   output_params.next_time += output_params.dt;
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
-//! \brief integrates the data over x1 and x3 directions and writes the resulting 1D
-//      array in x2.
-
-void IntX1X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
-  std::stringstream msg;
-  msg << "IntX1X3Output: not implemented " << std::endl;
-  ATHENA_ERROR(msg);
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn void IntX2X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag)
-//! \brief integrates the data over x2 and x3 directions and writes the resulting 1D
-//      array in x1.
-
-void IntX2X3Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
-  std::stringstream msg;
-  msg << "IntX2X3Output: not implemented " << std::endl;
-  ATHENA_ERROR(msg);
 }

--- a/src/outputs/int2d.cpp
+++ b/src/outputs/int2d.cpp
@@ -224,6 +224,7 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   fout.write(reinterpret_cast<const char*>(&pm->time), sizeof(pm->time));
 
   // Allocate arrays for 2D integrals.
+  AthenaArray<Real> area(pm->my_blocks(0)->ncells1);
   AthenaArray<Real> integrals(num_vars_, nx);
   integrals.ZeroClear();
 
@@ -231,7 +232,7 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   for (int b = 0; b < pm->nblocal; ++b) {
     MeshBlock *pmb = pm->my_blocks(b);
     LoadOutputData(pmb);
-    AddToIntegrals(pmb, integrals);
+    AddToIntegrals(pmb, integrals, area);
     ClearOutputData();
   }
 
@@ -241,24 +242,25 @@ void Int2DOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   // Close and clean up.
   fout.close();
   integrals.DeleteAthenaArray();
+  area.DeleteAthenaArray();
 
   // Update output parameters.
   output_params.next_time += output_params.dt;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn void IntX1X2Output::AddToIntegrals(
-//!     const MeshBlock *pmb, AthenaArray<Real> &integrals)
+//! \fn void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb,
+//!         AthenaArray<Real> &integrals, AthenaArray<Real> &area)
 //! \brief processes loaded output data in one meshblock and adds the sums to the
 //!     integrals.
 
-void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) {
+void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals,
+    AthenaArray<Real> &area) {
   // Determine where the meshblock fits.
   const int offset = pmb->loc.lx3 * pmb->block_size.nx3 - pmb->ks;
 
   // Integrate each data field.
   int ii = 0;
-  AthenaArray<Real> area(pmb->ncells1);
   OutputData *pdata = pfirst_data_;
   while (pdata != nullptr) {
     const int nc = (pdata->type == "VECTORS") ? 3 : 1;
@@ -276,30 +278,29 @@ void IntX1X2Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &inte
     }
     pdata = pdata->pnext;
   }
-
-  // Clean up.
-  area.DeleteAthenaArray();
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn void IntX1X3Output::AddToIntegrals(
-//!     const MeshBlock *pmb, AthenaArray<Real> &integrals)
+//! \fn void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb,
+//!         AthenaArray<Real> &integrals, AthenaArray<Real> &area)
 //! \brief processes loaded output data in one meshblock and adds the sums to the
 //!     integrals.
 
-void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) {
+void IntX1X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals,
+    AthenaArray<Real> &area) {
   std::stringstream msg;
   msg << "IntX1X3Output: not implemented " << std::endl;
   ATHENA_ERROR(msg);
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn void IntX2X3Output::AddToIntegrals(
-//!     const MeshBlock *pmb, AthenaArray<Real> &integrals)
+//! \fn void IntX2X3Output::AddToIntegrals(const MeshBlock *pmb,
+//!         AthenaArray<Real> &integrals, AthenaArray<Real> &area)
 //! \brief processes loaded output data in one meshblock and adds the sums to the
 //!     integrals.
 
-void IntX2X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) {
+void IntX2X3Output::AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals,
+    AthenaArray<Real> &area) {
   std::stringstream msg;
   msg << "IntX2X3Output: not implemented " << std::endl;
   ATHENA_ERROR(msg);

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -327,6 +327,12 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin) {
           pnew_type = new FormattedTableOutput(op);
         } else if (op.file_type.compare("vtk") == 0) {
           pnew_type = new VTKOutput(op);
+        } else if (op.file_type.compare("int12") == 0) {
+          pnew_type = new IntX1X2Output(op);
+        } else if (op.file_type.compare("int13") == 0) {
+          pnew_type = new IntX1X3Output(op);
+        } else if (op.file_type.compare("int23") == 0) {
+          pnew_type = new IntX2X3Output(op);
         } else if (op.file_type.compare("rst") == 0) {
           pnew_type = new RestartOutput(op);
           num_rst_outputs++;

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -328,11 +328,11 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin) {
         } else if (op.file_type.compare("vtk") == 0) {
           pnew_type = new VTKOutput(op);
         } else if (op.file_type.compare("int12") == 0) {
-          pnew_type = new IntX1X2Output(op);
+          pnew_type = new IntX1X2Output(pm, op);
         } else if (op.file_type.compare("int13") == 0) {
-          pnew_type = new IntX1X3Output(op);
+          pnew_type = new IntX1X3Output(pm, op);
         } else if (op.file_type.compare("int23") == 0) {
-          pnew_type = new IntX2X3Output(op);
+          pnew_type = new IntX2X3Output(pm, op);
         } else if (op.file_type.compare("rst") == 0) {
           pnew_type = new RestartOutput(op);
           num_rst_outputs++;

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -145,6 +145,36 @@ class HistoryOutput : public OutputType {
 };
 
 //----------------------------------------------------------------------------------------
+//! \class IntX1X2Output
+//! \brief derived OutputType class for integrals over x1 and x2 directions
+
+class IntX1X2Output : public OutputType {
+ public:
+  explicit IntX1X2Output(OutputParameters oparams) : OutputType(oparams) {}
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override {}
+};
+
+//----------------------------------------------------------------------------------------
+//! \class IntX1X3Output
+//! \brief derived OutputType class for integrals over x1 and x3 directions
+
+class IntX1X3Output : public OutputType {
+ public:
+  explicit IntX1X3Output(OutputParameters oparams) : OutputType(oparams) {}
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override {}
+};
+
+//----------------------------------------------------------------------------------------
+//! \class IntX2X3Output
+//! \brief derived OutputType class for integrals over x2 and x3 directions
+
+class IntX2X3Output : public OutputType {
+ public:
+  explicit IntX2X3Output(OutputParameters oparams) : OutputType(oparams) {}
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override {}
+};
+
+//----------------------------------------------------------------------------------------
 //! \class FormattedTableOutput
 //! \brief derived OutputType class for formatted table (tabular) data
 

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -154,6 +154,7 @@ class Int2DOutput : public OutputType {
   virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) = 0;
 
  protected:
+  void ProcessHeader(const std::string& ext);
   std::string fname;  // name of the output file
 };
 
@@ -164,7 +165,7 @@ class Int2DOutput : public OutputType {
 class IntX1X2Output : public Int2DOutput {
  public:
   explicit IntX1X2Output(OutputParameters op) : Int2DOutput(op) {
-    fname = op.file_basename + ".int12";
+    ProcessHeader("int12");
   }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
@@ -176,7 +177,7 @@ class IntX1X2Output : public Int2DOutput {
 class IntX1X3Output : public Int2DOutput {
  public:
   explicit IntX1X3Output(OutputParameters op) : Int2DOutput(op) {
-    fname = op.file_basename + ".int13";
+    ProcessHeader("int13");
   }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
@@ -188,7 +189,7 @@ class IntX1X3Output : public Int2DOutput {
 class IntX2X3Output : public Int2DOutput {
  public:
   explicit IntX2X3Output(OutputParameters op) : Int2DOutput(op) {
-    fname = op.file_basename + ".int23";
+    ProcessHeader("int23");
   }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -151,7 +151,7 @@ class HistoryOutput : public OutputType {
 class IntX1X2Output : public OutputType {
  public:
   explicit IntX1X2Output(OutputParameters oparams) : OutputType(oparams) {}
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override {}
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 
 //----------------------------------------------------------------------------------------
@@ -161,7 +161,7 @@ class IntX1X2Output : public OutputType {
 class IntX1X3Output : public OutputType {
  public:
   explicit IntX1X3Output(OutputParameters oparams) : OutputType(oparams) {}
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override {}
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 
 //----------------------------------------------------------------------------------------
@@ -171,7 +171,7 @@ class IntX1X3Output : public OutputType {
 class IntX2X3Output : public OutputType {
  public:
   explicit IntX2X3Output(OutputParameters oparams) : OutputType(oparams) {}
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override {}
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -152,6 +152,9 @@ class Int2DOutput : public OutputType {
  public:
   explicit Int2DOutput(OutputParameters oparams) : OutputType(oparams) {}
   virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) = 0;
+
+ protected:
+  std::string fname;  // name of the output file
 };
 
 //----------------------------------------------------------------------------------------
@@ -160,7 +163,9 @@ class Int2DOutput : public OutputType {
 
 class IntX1X2Output : public Int2DOutput {
  public:
-  explicit IntX1X2Output(OutputParameters oparams) : Int2DOutput(oparams) {}
+  explicit IntX1X2Output(OutputParameters op) : Int2DOutput(op) {
+    fname = op.file_basename + ".int12";
+  }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 
@@ -170,7 +175,9 @@ class IntX1X2Output : public Int2DOutput {
 
 class IntX1X3Output : public Int2DOutput {
  public:
-  explicit IntX1X3Output(OutputParameters oparams) : Int2DOutput(oparams) {}
+  explicit IntX1X3Output(OutputParameters op) : Int2DOutput(op) {
+    fname = op.file_basename + ".int13";
+  }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 
@@ -180,7 +187,9 @@ class IntX1X3Output : public Int2DOutput {
 
 class IntX2X3Output : public Int2DOutput {
  public:
-  explicit IntX2X3Output(OutputParameters oparams) : Int2DOutput(oparams) {}
+  explicit IntX2X3Output(OutputParameters op) : Int2DOutput(op) {
+    fname = op.file_basename + ".int23";
+  }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -145,12 +145,22 @@ class HistoryOutput : public OutputType {
 };
 
 //----------------------------------------------------------------------------------------
+//! \class Int2DOutput
+//! \brief derived OutputType class for integrals over two dimensions
+
+class Int2DOutput : public OutputType {
+ public:
+  explicit Int2DOutput(OutputParameters oparams) : OutputType(oparams) {}
+  virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) = 0;
+};
+
+//----------------------------------------------------------------------------------------
 //! \class IntX1X2Output
 //! \brief derived OutputType class for integrals over x1 and x2 directions
 
-class IntX1X2Output : public OutputType {
+class IntX1X2Output : public Int2DOutput {
  public:
-  explicit IntX1X2Output(OutputParameters oparams) : OutputType(oparams) {}
+  explicit IntX1X2Output(OutputParameters oparams) : Int2DOutput(oparams) {}
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 
@@ -158,9 +168,9 @@ class IntX1X2Output : public OutputType {
 //! \class IntX1X3Output
 //! \brief derived OutputType class for integrals over x1 and x3 directions
 
-class IntX1X3Output : public OutputType {
+class IntX1X3Output : public Int2DOutput {
  public:
-  explicit IntX1X3Output(OutputParameters oparams) : OutputType(oparams) {}
+  explicit IntX1X3Output(OutputParameters oparams) : Int2DOutput(oparams) {}
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 
@@ -168,9 +178,9 @@ class IntX1X3Output : public OutputType {
 //! \class IntX2X3Output
 //! \brief derived OutputType class for integrals over x2 and x3 directions
 
-class IntX2X3Output : public OutputType {
+class IntX2X3Output : public Int2DOutput {
  public:
-  explicit IntX2X3Output(OutputParameters oparams) : OutputType(oparams) {}
+  explicit IntX2X3Output(OutputParameters oparams) : Int2DOutput(oparams) {}
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -150,11 +150,11 @@ class HistoryOutput : public OutputType {
 
 class Int2DOutput : public OutputType {
  public:
-  explicit Int2DOutput(OutputParameters oparams) : OutputType(oparams) {}
+  explicit Int2DOutput(const Mesh *pm, const OutputParameters &op) : OutputType(op) {}
   virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) = 0;
 
  protected:
-  void ProcessHeader(const std::string& ext);
+  void ProcessHeader(const std::string& ext, const Mesh *pm);
   std::string fname;  // name of the output file
 };
 
@@ -164,9 +164,8 @@ class Int2DOutput : public OutputType {
 
 class IntX1X2Output : public Int2DOutput {
  public:
-  explicit IntX1X2Output(OutputParameters op) : Int2DOutput(op) {
-    ProcessHeader("int12");
-  }
+  explicit IntX1X2Output(const Mesh *pm, const OutputParameters &op)
+  : Int2DOutput(pm, op) { ProcessHeader("int12", pm); }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 
@@ -176,9 +175,8 @@ class IntX1X2Output : public Int2DOutput {
 
 class IntX1X3Output : public Int2DOutput {
  public:
-  explicit IntX1X3Output(OutputParameters op) : Int2DOutput(op) {
-    ProcessHeader("int13");
-  }
+  explicit IntX1X3Output(const Mesh *pm, const OutputParameters &op)
+  : Int2DOutput(pm, op) { ProcessHeader("int13", pm); }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 
@@ -188,9 +186,8 @@ class IntX1X3Output : public Int2DOutput {
 
 class IntX2X3Output : public Int2DOutput {
  public:
-  explicit IntX2X3Output(OutputParameters op) : Int2DOutput(op) {
-    ProcessHeader("int23");
-  }
+  explicit IntX2X3Output(const Mesh *pm, const OutputParameters &op)
+  : Int2DOutput(pm, op) { ProcessHeader("int23", pm); }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 };
 

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -16,6 +16,7 @@
 #include <limits>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 // Athena++ headers
 #include "../athena.hpp"

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -154,13 +154,16 @@ class Int2DOutput : public OutputType {
   virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) = 0;
 
  protected:
-  void ProcessHeader(const std::string& ext, const Mesh *pm);
-
+  // Instance variables
   std::string fname;     // name of the output file
   std::vector<Real> xf;  // coordinates of cell edges in the third dimension
   int nx;  // number of cells in the third dimension
 
+  // Constructor helper
+  void ProcessHeader(const std::string& ext, const Mesh *pm);
+
  private:
+  // Constructor helper
   virtual void SetThirdDim(const Mesh *pm) = 0;
 };
 
@@ -175,6 +178,7 @@ class IntX1X2Output : public Int2DOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
+  // Constructor helper
   void SetThirdDim(const Mesh *pm) override;
 };
 
@@ -189,6 +193,7 @@ class IntX1X3Output : public Int2DOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
+  // Constructor helper
   void SetThirdDim(const Mesh *pm) override;
 };
 
@@ -203,6 +208,7 @@ class IntX2X3Output : public Int2DOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
+  // Constructor helper
   void SetThirdDim(const Mesh *pm) override;
 };
 

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -189,7 +189,7 @@ class IntX1X3Output : public Int2DOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
-  void SetThirdDim(const Mesh *pm) override {}
+  void SetThirdDim(const Mesh *pm) override;
 };
 
 //----------------------------------------------------------------------------------------
@@ -203,7 +203,7 @@ class IntX2X3Output : public Int2DOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
-  void SetThirdDim(const Mesh *pm) override {}
+  void SetThirdDim(const Mesh *pm) override;
 };
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -155,7 +155,13 @@ class Int2DOutput : public OutputType {
 
  protected:
   void ProcessHeader(const std::string& ext, const Mesh *pm);
-  std::string fname;  // name of the output file
+
+  std::string fname;     // name of the output file
+  std::vector<Real> xf;  // coordinates of cell edges in the third dimension
+  int nx;  // number of cells in the third dimension
+
+ private:
+  virtual void SetThirdDim() = 0;
 };
 
 //----------------------------------------------------------------------------------------
@@ -167,6 +173,9 @@ class IntX1X2Output : public Int2DOutput {
   explicit IntX1X2Output(const Mesh *pm, const OutputParameters &op)
   : Int2DOutput(pm, op) { ProcessHeader("int12", pm); }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
+
+ private:
+  void SetThirdDim() override {}
 };
 
 //----------------------------------------------------------------------------------------
@@ -178,6 +187,9 @@ class IntX1X3Output : public Int2DOutput {
   explicit IntX1X3Output(const Mesh *pm, const OutputParameters &op)
   : Int2DOutput(pm, op) { ProcessHeader("int13", pm); }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
+
+ private:
+  void SetThirdDim() override {}
 };
 
 //----------------------------------------------------------------------------------------
@@ -189,6 +201,9 @@ class IntX2X3Output : public Int2DOutput {
   explicit IntX2X3Output(const Mesh *pm, const OutputParameters &op)
   : Int2DOutput(pm, op) { ProcessHeader("int23", pm); }
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
+
+ private:
+  void SetThirdDim() override {}
 };
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -165,7 +165,8 @@ class Int2DOutput : public OutputType {
 
  private:
   // Helpers
-  virtual void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) = 0;
+  virtual void AddToIntegrals(const MeshBlock *pmb,
+      AthenaArray<Real> &integrals, AthenaArray<Real> &area) = 0;
   virtual void SetThirdDim(const Mesh *pm) = 0;
 };
 
@@ -180,7 +181,8 @@ class IntX1X2Output : public Int2DOutput {
 
  private:
   // Helpers
-  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override;
+  void AddToIntegrals(const MeshBlock *pmb,
+      AthenaArray<Real> &integrals, AthenaArray<Real> &area) override;
   void SetThirdDim(const Mesh *pm) override;
 };
 
@@ -195,7 +197,8 @@ class IntX1X3Output : public Int2DOutput {
 
  private:
   // Helpers
-  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override;
+  void AddToIntegrals(const MeshBlock *pmb,
+      AthenaArray<Real> &integrals, AthenaArray<Real> &area) override;
   void SetThirdDim(const Mesh *pm) override;
 };
 
@@ -210,7 +213,8 @@ class IntX2X3Output : public Int2DOutput {
 
  private:
   // Helpers
-  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override;
+  void AddToIntegrals(const MeshBlock *pmb,
+      AthenaArray<Real> &integrals, AthenaArray<Real> &area) override;
   void SetThirdDim(const Mesh *pm) override;
 };
 

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -151,7 +151,7 @@ class HistoryOutput : public OutputType {
 class Int2DOutput : public OutputType {
  public:
   explicit Int2DOutput(const Mesh *pm, const OutputParameters &op) : OutputType(op) {}
-  virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) = 0;
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag);
 
  protected:
   // Instance variables
@@ -175,7 +175,6 @@ class IntX1X2Output : public Int2DOutput {
  public:
   explicit IntX1X2Output(const Mesh *pm, const OutputParameters &op)
   : Int2DOutput(pm, op) { ProcessHeader("int12", pm); }
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
   // Constructor helper
@@ -190,7 +189,6 @@ class IntX1X3Output : public Int2DOutput {
  public:
   explicit IntX1X3Output(const Mesh *pm, const OutputParameters &op)
   : Int2DOutput(pm, op) { ProcessHeader("int13", pm); }
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
   // Constructor helper
@@ -205,7 +203,6 @@ class IntX2X3Output : public Int2DOutput {
  public:
   explicit IntX2X3Output(const Mesh *pm, const OutputParameters &op)
   : Int2DOutput(pm, op) { ProcessHeader("int23", pm); }
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
   // Constructor helper

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -175,7 +175,7 @@ class IntX1X2Output : public Int2DOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
-  void SetThirdDim(const Mesh *pm) override {}
+  void SetThirdDim(const Mesh *pm) override;
 };
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -161,7 +161,7 @@ class Int2DOutput : public OutputType {
   int nx;  // number of cells in the third dimension
 
  private:
-  virtual void SetThirdDim() = 0;
+  virtual void SetThirdDim(const Mesh *pm) = 0;
 };
 
 //----------------------------------------------------------------------------------------
@@ -175,7 +175,7 @@ class IntX1X2Output : public Int2DOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
-  void SetThirdDim() override {}
+  void SetThirdDim(const Mesh *pm) override {}
 };
 
 //----------------------------------------------------------------------------------------
@@ -189,7 +189,7 @@ class IntX1X3Output : public Int2DOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
-  void SetThirdDim() override {}
+  void SetThirdDim(const Mesh *pm) override {}
 };
 
 //----------------------------------------------------------------------------------------
@@ -203,7 +203,7 @@ class IntX2X3Output : public Int2DOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
 
  private:
-  void SetThirdDim() override {}
+  void SetThirdDim(const Mesh *pm) override {}
 };
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -179,7 +179,7 @@ class IntX1X2Output : public Int2DOutput {
 
  private:
   // Helpers
-  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override {}
+  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override;
   void SetThirdDim(const Mesh *pm) override;
 };
 
@@ -194,7 +194,7 @@ class IntX1X3Output : public Int2DOutput {
 
  private:
   // Helpers
-  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override {}
+  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override;
   void SetThirdDim(const Mesh *pm) override;
 };
 
@@ -209,7 +209,7 @@ class IntX2X3Output : public Int2DOutput {
 
  private:
   // Helpers
-  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override {}
+  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override;
   void SetThirdDim(const Mesh *pm) override;
 };
 

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -163,7 +163,8 @@ class Int2DOutput : public OutputType {
   void ProcessHeader(const std::string& ext, const Mesh *pm);
 
  private:
-  // Constructor helper
+  // Helpers
+  virtual void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) = 0;
   virtual void SetThirdDim(const Mesh *pm) = 0;
 };
 
@@ -177,7 +178,8 @@ class IntX1X2Output : public Int2DOutput {
   : Int2DOutput(pm, op) { ProcessHeader("int12", pm); }
 
  private:
-  // Constructor helper
+  // Helpers
+  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override {}
   void SetThirdDim(const Mesh *pm) override;
 };
 
@@ -191,7 +193,8 @@ class IntX1X3Output : public Int2DOutput {
   : Int2DOutput(pm, op) { ProcessHeader("int13", pm); }
 
  private:
-  // Constructor helper
+  // Helpers
+  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override {}
   void SetThirdDim(const Mesh *pm) override;
 };
 
@@ -205,7 +208,8 @@ class IntX2X3Output : public Int2DOutput {
   : Int2DOutput(pm, op) { ProcessHeader("int23", pm); }
 
  private:
-  // Constructor helper
+  // Helpers
+  void AddToIntegrals(const MeshBlock *pmb, AthenaArray<Real> &integrals) override {}
   void SetThirdDim(const Mesh *pm) override;
 };
 

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -963,6 +963,11 @@ def int2d(filename):
         A namedtuple containing the following fields:
             xf
                 Coordinates of the cell edges in the third dimension.
+            time
+                Times in the series.
+            *
+                2D integrals of the data fields specified by output*/variable in the
+                input file as a function of time and the third dimension.
     """
     from collections import namedtuple
     from struct import unpack

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -1010,7 +1010,6 @@ def int2d(filename):
                     a = np.frombuffer(f.read(arraysize), dtype=dtype)
                     integrals[i] = np.vstack((v, a))
             else:
-                integrals = []
                 for i in range(nvar):
                     integrals.append(np.frombuffer(f.read(arraysize), dtype=dtype))
 

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -990,11 +990,13 @@ def int2d(filename):
 
         # Loop over the time series.
         arraysize = nx * realsize
+        integrals = []
         time = np.array([])
         while True:
             # Read the time.
             b = f.read(realsize)
-            if len(b) <= 0: break
+            if len(b) <= 0:
+                break
             time = np.concatenate((time, np.frombuffer(b, dtype=dtype)))
 
             # Read the 2D integrals.
@@ -1011,6 +1013,7 @@ def int2d(filename):
         names = ["xf", "time"] + varnames
         pairs = dict(zip(names, [xf, time] + integrals))
         return namedtuple("Int2D", names)(**pairs)
+
 
 # ========================================================================================
 

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -995,8 +995,18 @@ def int2d(filename):
         for i in range(nx + 1):
             xf[i] = unpack(fmt, f.read(realsize))[0]
 
-        Int2D = namedtuple("Int2D", ["xf"])
-        return Int2D(xf)
+        # Loop over the time series.
+        time = []
+        while True:
+            # Read the time.
+            b = f.read(realsize)
+            if len(b) <= 0: break
+            time.append(unpack(fmt, b)[0])
+        time = np.array(time)
+
+        # Construct and return a namedtuple.
+        Int2D = namedtuple("Int2D", ["xf", "time"])
+        return Int2D(xf, time)
 
 # ========================================================================================
 

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -960,7 +960,9 @@ def int2d(filename):
             Name of or path to the output file (with extension int12, int13, or int23).
 
     Returned Values
-        None.
+        A numpy record array containing the following data:
+            xf
+                Coordinates of the cell edges in the third dimension.
     """
     from struct import unpack
 
@@ -985,6 +987,14 @@ def int2d(filename):
         for i in range(nvar):
             size = unpack("=i", f.read(intsize))[0]
             varnames.append(f.read(size).decode())
+
+        # Read the coordinates of cell edges in the third dimension.
+        nx = unpack("=i", f.read(intsize))[0]
+        xf = np.empty(nx + 1,)
+        for i in range(nx + 1):
+            xf[i] = unpack(fmt, f.read(realsize))[0]
+
+        return np.rec.array((xf,), names=("xf",))
 
 # ========================================================================================
 

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -970,7 +970,13 @@ def int2d(filename):
     with open(filename, "rb") as f:
         # Read number of output variables.
         nvar = unpack("=i", f.read(intsize))[0]
-        print(f"int2d: nvar = {nvar}")
+
+        # Read the names of the variables.
+        varnames = []
+        for i in range(nvar):
+            size = unpack("=i", f.read(intsize))[0]
+            varnames.append(f.read(size).decode())
+        print("varnames = ", varnames)
 
 # ========================================================================================
 

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -989,6 +989,7 @@ def int2d(filename):
         xf = np.frombuffer(f.read((nx+1) * realsize), dtype=dtype)
 
         # Loop over the time series.
+        arraysize = nx * realsize
         time = np.array([])
         while True:
             # Read the time.
@@ -996,9 +997,20 @@ def int2d(filename):
             if len(b) <= 0: break
             time = np.concatenate((time, np.frombuffer(b, dtype=dtype)))
 
+            # Read the 2D integrals.
+            if len(time) > 1:
+                for i, v in enumerate(integrals):
+                    a = np.frombuffer(f.read(arraysize), dtype=dtype)
+                    integrals[i] = np.vstack((v, a))
+            else:
+                integrals = []
+                for i in range(nvar):
+                    integrals.append(np.frombuffer(f.read(arraysize), dtype=dtype))
+
         # Construct and return a namedtuple.
-        Int2D = namedtuple("Int2D", ["xf", "time"])
-        return Int2D(xf, time)
+        names = ["xf", "time"] + varnames
+        pairs = dict(zip(names, [xf, time] + integrals))
+        return namedtuple("Int2D", names)(**pairs)
 
 # ========================================================================================
 

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -952,6 +952,28 @@ def athdf(filename, raw=False, data=None, quantities=None, dtype=None, level=Non
 
 # ========================================================================================
 
+def int2d(filename):
+    """Reads an output file for integrals of data fields over two dimensions.
+
+    Positional Argument
+        filename
+            Name of or path to the output file (with extension int12, int13, or int23).
+
+    Returned Values
+        None.
+    """
+    from struct import unpack
+
+    # Hard code the size of an int from C/C++.
+    intsize = 4  # bytes
+
+    with open(filename, "rb") as f:
+        # Read number of output variables.
+        nvar = unpack("=i", f.read(intsize))[0]
+        print(f"int2d: nvar = {nvar}")
+
+# ========================================================================================
+
 def restrict_like(vals, levels, vols=None):
     """Average cell values according to given mesh refinement scheme."""
 

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -973,12 +973,7 @@ def int2d(filename):
     with open(filename, "rb") as f:
         # Read and check the size of the Athena++ Real.
         realsize = unpack("=i", f.read(intsize))[0]
-        if realsize == 4:
-          fmt = "=f"
-        elif realsize == 8:
-          fmt = "=d"
-        else:
-          raise RuntimeError(f"Unsupported Real size of {realsize} bytes. ")
+        dtype = np.dtype(f"f{realsize}")
 
         # Read the number of output variables.
         nvar = unpack("=i", f.read(intsize))[0]
@@ -991,18 +986,15 @@ def int2d(filename):
 
         # Read the coordinates of cell edges in the third dimension.
         nx = unpack("=i", f.read(intsize))[0]
-        xf = np.empty(nx + 1,)
-        for i in range(nx + 1):
-            xf[i] = unpack(fmt, f.read(realsize))[0]
+        xf = np.frombuffer(f.read((nx+1) * realsize), dtype=dtype)
 
         # Loop over the time series.
-        time = []
+        time = np.array([])
         while True:
             # Read the time.
             b = f.read(realsize)
             if len(b) <= 0: break
-            time.append(unpack(fmt, b)[0])
-        time = np.array(time)
+            time = np.concatenate((time, np.frombuffer(b, dtype=dtype)))
 
         # Construct and return a namedtuple.
         Int2D = namedtuple("Int2D", ["xf", "time"])

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -968,7 +968,16 @@ def int2d(filename):
     intsize = 4  # bytes
 
     with open(filename, "rb") as f:
-        # Read number of output variables.
+        # Read and check the size of the Athena++ Real.
+        realsize = unpack("=i", f.read(intsize))[0]
+        if realsize == 4:
+          fmt = "=f"
+        elif realsize == 8:
+          fmt = "=d"
+        else:
+          raise RuntimeError(f"Unsupported Real size of {realsize} bytes. ")
+
+        # Read the number of output variables.
         nvar = unpack("=i", f.read(intsize))[0]
 
         # Read the names of the variables.
@@ -976,7 +985,6 @@ def int2d(filename):
         for i in range(nvar):
             size = unpack("=i", f.read(intsize))[0]
             varnames.append(f.read(size).decode())
-        print("varnames = ", varnames)
 
 # ========================================================================================
 

--- a/vis/python/athena_read.py
+++ b/vis/python/athena_read.py
@@ -960,10 +960,11 @@ def int2d(filename):
             Name of or path to the output file (with extension int12, int13, or int23).
 
     Returned Values
-        A numpy record array containing the following data:
+        A namedtuple containing the following fields:
             xf
                 Coordinates of the cell edges in the third dimension.
     """
+    from collections import namedtuple
     from struct import unpack
 
     # Hard code the size of an int from C/C++.
@@ -994,7 +995,8 @@ def int2d(filename):
         for i in range(nx + 1):
             xf[i] = unpack(fmt, f.read(realsize))[0]
 
-        return np.rec.array((xf,), names=("xf",))
+        Int2D = namedtuple("Int2D", ["xf"])
+        return Int2D(xf)
 
 # ========================================================================================
 


### PR DESCRIPTION
This implementation adds the flexibility to integrate the data fields in two dimensions and output the resulting 1D array in the third dimension.

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation in the [Wiki](https://github.com/PrincetonUniversity/athena/wiki) accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Description

1. Major change: implemented three new choices for `file_type` to an `<output*>` section in the input file: `int12`, `int13`, and `int23`.  The file type `int12` integrates the data field over the X1 and the X2 dimensions (with proper area elements) and writes the resulting 1D array in the third (X3) dimension in binary format.  Similarly for the other two choices.
2. Major change: implemented the Python reader `athena_read.int2d(filename)` to read these output files.

These output types eliminate the need of full data dump and post-processing and allow for high-cadence analysis on the fly (powered by user-defined fields `uov`).

## Testing and validation

It has been tested using a bare-bone hydro run with uniform density, pressure, and velocity field.  It passed with varying dimensions, resolutions, and mesh refinements.

## To-do

- [ ] Update the documentation once no issue is found by the reviewer.